### PR TITLE
fix: use bun shebang and fix pack test

### DIFF
--- a/bin/pglite-server.js
+++ b/bin/pglite-server.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/env bun
 
 /**
  * pgserve - Embedded PostgreSQL Server

--- a/scripts/test-bunx.sh
+++ b/scripts/test-bunx.sh
@@ -10,15 +10,18 @@ echo "=== Testing bunx compatibility ==="
 TEST_DIR=$(mktemp -d)
 trap "rm -rf $TEST_DIR" EXIT
 
-# Pack the current package
+# Pack the current package (--ignore-scripts to skip prepare/husky in CI)
 echo "Packing package..."
-PACK_FILE=$(bun pm pack --destination "$TEST_DIR" 2>/dev/null | grep -o '[^ ]*\.tgz' | head -1)
+PACK_PATH=$(bun pm pack --destination "$TEST_DIR" --ignore-scripts --quiet 2>&1)
+PACK_FILE=$(basename "$PACK_PATH" 2>/dev/null)
 
 # If bun pm pack fails, exit with an error
 if [ -z "$PACK_FILE" ] || [ ! -f "$TEST_DIR/$PACK_FILE" ]; then
   echo "✗ Failed to pack package with bun"
+  echo "Pack output: $PACK_PATH"
   exit 1
 fi
+echo "Packed: $PACK_FILE"
 
 # Extract and install in isolated environment
 echo "Installing in isolated environment..."


### PR DESCRIPTION
## Summary
- Change shebang from `#!/usr/bin/env node` to `#!/usr/bin/env bun` (Bun-only package)
- Fix `bun pm pack` with `--ignore-scripts --quiet` flags
- Add debug output for pack failures

## Root cause
The bin file had a Node.js shebang, causing `bunx pgserve` to run under Node instead of Bun.

## Test plan
- [x] Local `test:bunx` passes
- [ ] CI tests pass
- [ ] Release workflow succeeds