### PR TITLE
fix: add reusePort for cluster mode multi-worker port sharing

### DIFF
--- a/src/cluster.js
+++ b/src/cluster.js
@@ -72,6 +72,7 @@ class ClusterRouter extends EventEmitter {
     this.server = Bun.listen({
       hostname: this.host,
       port: this.port,
+      reusePort: true,  // Enable SO_REUSEPORT for multi-worker port sharing (Linux)
       socket: {
         data(socket, data) {
           router.handleSocketData(socket, data);


### PR DESCRIPTION
## Summary
- Fixes EADDRINUSE error where all 32 workers tried to bind to the same port
- Adds `reusePort: true` to `Bun.listen()` enabling SO_REUSEPORT kernel load balancing

## Root Cause
`src/cluster.js:72` - `Bun.listen()` was missing `reusePort: true`, so only the first worker could bind to port 8432.

## Platform Notes
- **Linux**: `reusePort: true` enables `SO_REUSEPORT` - kernel load-balances connections across workers
- **macOS/Windows**: Option is ignored (OS limitation) - cluster mode only works on Linux

## Test plan
- [x] Local test: `bun bin/pglite-server.js` → All 32 workers ready
- [ ] CI passes
- [ ] `bunx pgserve@next` works after release