### PR TITLE
fix: release script handles promote from clean version

### DIFF
--- a/scripts/release.cjs
+++ b/scripts/release.cjs
@@ -89,12 +89,20 @@ function bumpRcVersion(currentVersion) {
 }
 
 function promoteToStable(currentVersion) {
-  // 1.0.9-rc.2 -> 1.0.9
-  const match = currentVersion.match(/^(\d+\.\d+\.\d+)-rc\.\d+$/);
-  if (!match) {
-    throw new Error(`Cannot promote: ${currentVersion} is not an RC version`);
+  // If RC version: 1.0.9-rc.2 -> 1.0.9
+  const rcMatch = currentVersion.match(/^(\d+\.\d+\.\d+)-rc\.\d+$/);
+  if (rcMatch) {
+    return rcMatch[1];
   }
-  return match[1];
+
+  // If already stable: 1.1.1 -> 1.1.2 (bump patch for new stable release)
+  const stableMatch = currentVersion.match(/^(\d+)\.(\d+)\.(\d+)$/);
+  if (stableMatch) {
+    const [, major, minor, patch] = stableMatch;
+    return `${major}.${minor}.${parseInt(patch) + 1}`;
+  }
+
+  throw new Error(`Invalid version format: ${currentVersion}`);
 }
 
 function createTag(version) {


### PR DESCRIPTION
## Summary
Fix the release script to handle promote when version is already stable.

## Problem
When current version has no `-rc` suffix (e.g., `1.1.1`), the promote action failed with:
```
Cannot promote: 1.1.1 is not an RC version
```

## Solution
The `promoteToStable` function now handles both cases:
- RC version: `1.0.9-rc.2` → `1.0.9` (strip RC suffix)
- Stable version: `1.1.1` → `1.1.2` (bump patch)

## Test
```bash
$ node scripts/release.cjs --action promote --dry-run
[release] Current version: 1.1.1
[release] New version: 1.1.2
```

## Test plan
- [ ] Merge with `stable` label
- [ ] Verify version bumps to 1.1.2
- [ ] Verify npm publish succeeds with @latest tag