### PR TITLE
fix: TCP proxy deadlock on large wire protocol messages

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,2 +1,2 @@
-pnpm exec lint-staged
-pnpm deadcode
+bunx lint-staged
+bun run deadcode

--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "pgserve",
       "dependencies": {
-        "bun": "1.3.4",
+        "bun": "^1.3.4",
       },
       "devDependencies": {
         "@electric-sql/pglite": "^0.2.17",
@@ -20,7 +20,7 @@
         "@embedded-postgres/darwin-arm64": "17.7.0-beta.15",
         "@embedded-postgres/darwin-x64": "17.7.0-beta.15",
         "@embedded-postgres/linux-x64": "17.7.0-beta.15",
-        "@embedded-postgres/win32-x64": "17.7.0-beta.15",
+        "@embedded-postgres/windows-x64": "17.7.0-beta.15",
       },
     },
   },
@@ -32,6 +32,8 @@
     "@embedded-postgres/darwin-x64": ["@embedded-postgres/darwin-x64@17.7.0-beta.15", "", { "os": "darwin", "cpu": "x64" }, "sha512-KXXBbiyJ8fNYNQt9ondhVUayQ0+qCi6Uoma23Oa40xoyzXY6kRNjXwlGB7Bvf9ZV8PsiBdlnEv/fSpYeRcDjSA=="],
 
     "@embedded-postgres/linux-x64": ["@embedded-postgres/linux-x64@17.7.0-beta.15", "", { "os": "linux", "cpu": "x64" }, "sha512-HeaxSHsw6ccVh8l5iC4OgXqvaaCGWnnZR9CpgNgrAfnKPPGiEhUPBmO2XhEsFQIhc+ad/+36h0NTvKo4bdi40w=="],
+
+    "@embedded-postgres/windows-x64": ["@embedded-postgres/windows-x64@17.7.0-beta.15", "", { "os": "win32", "cpu": "x64" }, "sha512-Oq11yyKxISjefuYdKljcp3Q+uxx237zn9YpP9hO43+6Feorq7USuMIDqk5ofLSQ30FAnVyTqaIQK8ZIjW+tQXQ=="],
 
     "@emnapi/core": ["@emnapi/core@1.7.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.1.0", "tslib": "^2.4.0" } }, "sha512-o1uhUASyo921r2XtHYOHy7gdkGLge8ghBEQHMWmyJFoXlpU58kIrhhN3w26lpQb6dspetweapMn2CSNwQ8I4wg=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -17,23 +17,23 @@
         "pg": "^8.16.3",
       },
       "optionalDependencies": {
-        "@embedded-postgres/darwin-arm64": "17.7.0-beta.15",
-        "@embedded-postgres/darwin-x64": "17.7.0-beta.15",
-        "@embedded-postgres/linux-x64": "17.7.0-beta.15",
-        "@embedded-postgres/windows-x64": "17.7.0-beta.15",
+        "@embedded-postgres/darwin-arm64": "18.2.0-beta.16",
+        "@embedded-postgres/darwin-x64": "18.2.0-beta.16",
+        "@embedded-postgres/linux-x64": "18.2.0-beta.16",
+        "@embedded-postgres/windows-x64": "18.2.0-beta.16",
       },
     },
   },
   "packages": {
     "@electric-sql/pglite": ["@electric-sql/pglite@0.2.17", "", {}, "sha512-qEpKRT2oUaWDH6tjRxLHjdzMqRUGYDnGZlKrnL4dJ77JVMcP2Hpo3NYnOSPKdZdeec57B6QPprCUFg0picx5Pw=="],
 
-    "@embedded-postgres/darwin-arm64": ["@embedded-postgres/darwin-arm64@17.7.0-beta.15", "", { "os": "darwin", "cpu": "arm64" }, "sha512-yIo9ACgWI3U84lZpRD2G3ELzVM7fXCaTWCpH+9+lLeEj7+F9eTWYsG3DE/fcsPcDcDDxhLTqX71p9oFeX/KOZA=="],
+    "@embedded-postgres/darwin-arm64": ["@embedded-postgres/darwin-arm64@18.2.0-beta.16", "", { "os": "darwin", "cpu": "arm64" }, "sha512-wnswaF+uDvGeitqajJ8v8xOG4ttFrzixElwKNe2MIxBXSLWPV3xhi6tBY0Sjw8Lmiu6UG9vNLFZSjHPrIeokBg=="],
 
-    "@embedded-postgres/darwin-x64": ["@embedded-postgres/darwin-x64@17.7.0-beta.15", "", { "os": "darwin", "cpu": "x64" }, "sha512-KXXBbiyJ8fNYNQt9ondhVUayQ0+qCi6Uoma23Oa40xoyzXY6kRNjXwlGB7Bvf9ZV8PsiBdlnEv/fSpYeRcDjSA=="],
+    "@embedded-postgres/darwin-x64": ["@embedded-postgres/darwin-x64@18.2.0-beta.16", "", { "os": "darwin", "cpu": "x64" }, "sha512-u9WtTPxRuO0uOny5IniXHSDaLmtOujwzDoExIV/jFT0Fu8SzpX7wdoPbsSPBLgyQWdr/nPA77K9QI4r6P1/fKA=="],
 
-    "@embedded-postgres/linux-x64": ["@embedded-postgres/linux-x64@17.7.0-beta.15", "", { "os": "linux", "cpu": "x64" }, "sha512-HeaxSHsw6ccVh8l5iC4OgXqvaaCGWnnZR9CpgNgrAfnKPPGiEhUPBmO2XhEsFQIhc+ad/+36h0NTvKo4bdi40w=="],
+    "@embedded-postgres/linux-x64": ["@embedded-postgres/linux-x64@18.2.0-beta.16", "", { "os": "linux", "cpu": "x64" }, "sha512-BIt485ioL8/AwDgw37IcdraOfRgHNDOtGM6Hh63vnNaUAG4Z0qtJd5zXS5fr2wZTEsYHyC5PC60k7zkCRZXSzg=="],
 
-    "@embedded-postgres/windows-x64": ["@embedded-postgres/windows-x64@17.7.0-beta.15", "", { "os": "win32", "cpu": "x64" }, "sha512-Oq11yyKxISjefuYdKljcp3Q+uxx237zn9YpP9hO43+6Feorq7USuMIDqk5ofLSQ30FAnVyTqaIQK8ZIjW+tQXQ=="],
+    "@embedded-postgres/windows-x64": ["@embedded-postgres/windows-x64@18.2.0-beta.16", "", { "os": "win32", "cpu": "x64" }, "sha512-Sj6GhCZrvtMwchATEtWuEmexEBWpRNMHPTUHsqPuyDrHX/XgKfpIxz2/AMHa4sp7SZ0JOHGouH8AFIVsWQrQsQ=="],
 
     "@emnapi/core": ["@emnapi/core@1.7.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.1.0", "tslib": "^2.4.0" } }, "sha512-o1uhUASyo921r2XtHYOHy7gdkGLge8ghBEQHMWmyJFoXlpU58kIrhhN3w26lpQb6dspetweapMn2CSNwQ8I4wg=="],
 

--- a/package.json
+++ b/package.json
@@ -41,10 +41,10 @@
   },
   "homepage": "https://github.com/namastexlabs/pgserve#readme",
   "optionalDependencies": {
-    "@embedded-postgres/darwin-arm64": "17.7.0-beta.15",
-    "@embedded-postgres/darwin-x64": "17.7.0-beta.15",
-    "@embedded-postgres/linux-x64": "17.7.0-beta.15",
-    "@embedded-postgres/windows-x64": "17.7.0-beta.15"
+    "@embedded-postgres/darwin-arm64": "18.2.0-beta.16",
+    "@embedded-postgres/darwin-x64": "18.2.0-beta.16",
+    "@embedded-postgres/linux-x64": "18.2.0-beta.16",
+    "@embedded-postgres/windows-x64": "18.2.0-beta.16"
   },
   "devDependencies": {
     "@electric-sql/pglite": "^0.2.17",

--- a/src/postgres.js
+++ b/src/postgres.js
@@ -66,7 +66,7 @@ async function downloadPostgresBinaries() {
 
   const platformKey = getPlatformKey();
   const pkgName = `@embedded-postgres/${platformKey}`;
-  const pkgVersion = '17.7.0-beta.15';
+  const pkgVersion = '18.2.0-beta.16';
 
   console.log(`[pgserve] PostgreSQL binaries not found.`);
   console.log(`[pgserve] Downloading ${pkgName}@${pkgVersion}...`);

--- a/tests/backpressure.test.js
+++ b/tests/backpressure.test.js
@@ -1,0 +1,167 @@
+/**
+ * Backpressure / Large Message Regression Tests
+ *
+ * Reproduces the deadlock from issue #14: TCP proxy drops bytes when
+ * socket buffers are full, causing PostgreSQL to wait forever for the
+ * remainder of a truncated wire protocol message.
+ */
+
+import { startMultiTenantServer } from '../src/index.js';
+import pg from 'pg';
+import { test, expect } from 'bun:test';
+import fs from 'fs';
+
+const { Client } = pg;
+
+const TEST_PORT = 15433;
+const testDataDir = './test-data-backpressure';
+
+function cleanup() {
+  if (fs.existsSync(testDataDir)) {
+    fs.rmSync(testDataDir, { recursive: true, force: true });
+  }
+}
+
+/** Create a connected pg.Client */
+async function connect(dbName) {
+  const client = new Client({
+    host: '127.0.0.1',
+    port: TEST_PORT,
+    database: dbName,
+    user: 'postgres',
+    password: 'postgres',
+  });
+  await client.connect();
+  return client;
+}
+
+test('Large INSERT (~360KB payload) does not deadlock', async () => {
+  cleanup();
+  const router = await startMultiTenantServer({
+    port: TEST_PORT,
+    baseDir: testDataDir,
+    logLevel: 'warn',
+  });
+
+  let client;
+  try {
+    client = await connect('bp_insert');
+    await client.query('CREATE TABLE big (id SERIAL PRIMARY KEY, payload TEXT)');
+
+    // ~360KB of text — exceeds typical socket buffer size
+    const bigPayload = 'x'.repeat(360_000);
+    await client.query('INSERT INTO big (payload) VALUES ($1)', [bigPayload]);
+
+    const res = await client.query('SELECT length(payload) AS len FROM big');
+    expect(Number(res.rows[0].len)).toBe(360000);
+  } finally {
+    if (client) await client.end().catch(() => {});
+    await router.stop();
+    cleanup();
+  }
+}, 30_000);
+
+test('Large SELECT result (500KB+) does not deadlock', async () => {
+  cleanup();
+  const router = await startMultiTenantServer({
+    port: TEST_PORT,
+    baseDir: testDataDir,
+    logLevel: 'warn',
+  });
+
+  let client;
+  try {
+    client = await connect('bp_select');
+    await client.query('CREATE TABLE chunks (id SERIAL PRIMARY KEY, data TEXT)');
+
+    // Insert many rows that sum to >500KB
+    const chunkSize = 10_000;
+    const numChunks = 60; // 60 * 10KB = 600KB total
+    const chunk = 'y'.repeat(chunkSize);
+
+    for (let i = 0; i < numChunks; i++) {
+      await client.query('INSERT INTO chunks (data) VALUES ($1)', [chunk]);
+    }
+
+    // Fetch all rows in a single result set (PG→Client backpressure)
+    const res = await client.query('SELECT * FROM chunks');
+    expect(res.rows.length).toBe(numChunks);
+    expect(res.rows[0].data.length).toBe(chunkSize);
+  } finally {
+    if (client) await client.end().catch(() => {});
+    await router.stop();
+    cleanup();
+  }
+}, 30_000);
+
+test('Large single query with multi-value INSERT (500KB+)', async () => {
+  cleanup();
+  const router = await startMultiTenantServer({
+    port: TEST_PORT,
+    baseDir: testDataDir,
+    logLevel: 'warn',
+  });
+
+  let client;
+  try {
+    client = await connect('bp_multivalue');
+    await client.query('CREATE TABLE items (id INT, val TEXT)');
+
+    // Build a single INSERT with many value tuples to produce a large wire message
+    const rowCount = 500;
+    const rowValue = 'z'.repeat(1_000); // 1KB per row → ~500KB total
+    const values = [];
+    const params = [];
+    for (let i = 0; i < rowCount; i++) {
+      values.push(`($${i * 2 + 1}, $${i * 2 + 2})`);
+      params.push(i, rowValue);
+    }
+
+    const sql = `INSERT INTO items (id, val) VALUES ${values.join(', ')}`;
+    await client.query(sql, params);
+
+    const res = await client.query('SELECT count(*)::int AS cnt FROM items');
+    expect(res.rows[0].cnt).toBe(rowCount);
+  } finally {
+    if (client) await client.end().catch(() => {});
+    await router.stop();
+    cleanup();
+  }
+}, 30_000);
+
+test('Concurrent large operations (5 clients x 300KB)', async () => {
+  cleanup();
+  const router = await startMultiTenantServer({
+    port: TEST_PORT,
+    baseDir: testDataDir,
+    logLevel: 'warn',
+  });
+
+  try {
+    const numClients = 5;
+    const payloadSize = 300_000;
+    const payload = 'c'.repeat(payloadSize);
+
+    // Run all clients concurrently
+    const results = await Promise.all(
+      Array.from({ length: numClients }, async (_, i) => {
+        const dbName = `bp_concurrent_${i}`;
+        const client = await connect(dbName);
+        await client.query('CREATE TABLE stress (id SERIAL PRIMARY KEY, data TEXT)');
+        await client.query('INSERT INTO stress (data) VALUES ($1)', [payload]);
+
+        const res = await client.query('SELECT length(data) AS len FROM stress');
+        await client.end();
+        return parseInt(res.rows[0].len, 10);
+      })
+    );
+
+    // All clients should have successfully stored the full payload
+    for (const len of results) {
+      expect(len).toBe(payloadSize);
+    }
+  } finally {
+    await router.stop();
+    cleanup();
+  }
+}, 60_000);


### PR DESCRIPTION
## Summary

Fixes #14 — TCP proxy deadlocks when PostgreSQL clients send wire protocol messages larger than ~300KB.

- **Root cause**: Both `MultiTenantRouter` and `ClusterRouter` ignored the return value of `socket.write()`, silently dropping bytes when socket buffers were full. PostgreSQL would receive truncated messages and wait forever for the rest.
- **Fix**: Added bidirectional backpressure handling — partial writes are buffered, the source socket is paused, and on `drain` the pending buffer is flushed and the source resumed.
- **Refactor**: Extracted shared `pgHandler` object to eliminate duplicated unix/TCP socket handler code.
- **Upgrade**: Embedded PostgreSQL 17.7 → 18.2 (no breaking changes for pgserve).
- **Chore**: Fixed pre-commit hook to use `bun` instead of `pnpm`.

## Changes

| File | What changed |
|------|-------------|
| `src/router.js` | `flushPending` helper, backpressure in both directions, shared pgHandler, buffer cleanup |
| `src/cluster.js` | Identical backpressure pattern applied |
| `tests/backpressure.test.js` | 4 regression tests (360KB INSERT, 600KB SELECT, 500KB multi-value INSERT, 5×300KB concurrent) |
| `package.json` | `@embedded-postgres/*` 17.7.0-beta.15 → 18.2.0-beta.16 |
| `.husky/pre-commit` | `pnpm` → `bun` |

## Test plan

- [x] `bun test tests/backpressure.test.js` — 4/4 pass
- [x] `bun test tests/multi-tenant.test.js` — 4/4 pass (no regressions)
- [x] `bun run lint` — clean
- [x] `bun run deadcode` — clean
- [x] Stress test (3.4M queries, 51K peak QPS) — no regression vs main