### PR TITLE
docs(security): add SECURITY.md (disclosure policy + CanisterWorm incident record)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,98 @@
+# Security Policy
+
+`pgserve` is maintained by [Automagik](https://automagik.dev). We take the security of this package seriously and appreciate responsible disclosure from the community.
+
+---
+
+## Reporting a Vulnerability
+
+**Please do not open public issues for security reports.**
+
+Send private reports to one of the following channels:
+
+| Channel | Address | Best for |
+|---------|---------|----------|
+| Security email | `privacidade@namastex.ai` | Anything security-related, including coordinated disclosure |
+| DPO (privacy + security officer) | `dpo@khal.ai` | Privacy, LGPD, data protection concerns |
+| Private GitHub advisory | [Report via GitHub](https://github.com/namastexlabs/pgserve/security/advisories/new) | Preferred for CVE assignment and coordinated release |
+
+**PGP** available on request.
+
+### Response SLA
+
+- Acknowledgement: **within 2 business hours** (UTC-3).
+- Initial triage and severity assessment: **within 24 hours**.
+- Fix or mitigation plan: **within 7 days** for critical/high severity.
+- Public disclosure: coordinated with reporter, typically within 30 days of fix.
+
+We will credit reporters publicly (with their permission) in the released advisory.
+
+---
+
+## Supported Versions
+
+| Version line | Status |
+|--------------|--------|
+| `1.1.10` and later clean releases | ✅ Supported — current |
+| `1.1.11` – `1.1.14` | ❌ **COMPROMISED — do not use** |
+| `1.1.0` – `1.1.10` | ⚠️ Legacy — security patches only |
+| Earlier versions | ❌ End of life |
+
+Always install from the current stable line. Pin explicit versions in your `package.json` and avoid `latest` for supply-chain sensitive packages.
+
+---
+
+## Past Incidents
+
+### 2026-04 — CanisterWorm supply-chain compromise
+
+Between 2026-04-21 (~22:14 UTC) and 2026-04-22 (~14:00 UTC), versions `1.1.11`, `1.1.12`, `1.1.13`, and `1.1.14` were published to npm by a threat actor after a developer GitHub OAuth token was exfiltrated. The malicious versions contained a `TeamPCP` payload in `scripts/check-env.js` that executed via `postinstall` to harvest local credentials.
+
+- **Exposure window:** ~16 hours
+- **Detection-to-containment:** under 20 hours
+- **Current status:** malicious versions `npm unpublish`-ed and no longer installable
+
+**If you installed versions `1.1.11` – `1.1.14` between April 21–22, 2026, assume your machine is compromised.** Follow the remediation guide linked below.
+
+**Resources:**
+- 📖 [Full incident response manual](https://github.com/namastexlabs/genie-dpo/blob/main/knowledge/canisterworm-incident-response.md)
+- 🌐 [Public advisory (English)](https://automagik.dev/security)
+- 🌐 [Aviso público (Português)](https://automagik.dev/seguranca)
+- 🛡️ [GitHub Security Advisory](https://github.com/namastexlabs/pgserve/security/advisories) *(GHSA link — update after publishing)*
+
+A full public post-mortem will be published within 30 days of containment.
+
+---
+
+## Our Commitments
+
+Effective 2026-04-23, all `pgserve` releases are governed by:
+
+- **Provenance attestation** — every publication is signed with `npm --provenance` and verifiable via Sigstore.
+- **OIDC trusted publishing** — migrating to GitHub Actions OIDC publish, eliminating long-lived npm tokens. (in progress)
+- **Mandatory 2FA** on every maintainer account with publish rights.
+- **Environment protection** — production publishes require manual approval from a second maintainer.
+- **Quarterly token audit** — scope and permission review.
+- **External pentest** — scheduled ahead of the original roadmap.
+
+---
+
+## Hardening Recommendations for Consumers
+
+- Pin explicit versions, not `latest`: `"pgserve": "1.1.10"`.
+- Use `npm ci --frozen-lockfile` in CI.
+- Enable `ignore-scripts` where `postinstall` is not required: `npm config set ignore-scripts true`.
+- Verify package provenance: `npm view pgserve --json | jq '.dist.attestations'`.
+- Monitor advisories: subscribe to GitHub security alerts for this repository.
+
+---
+
+## Contact
+
+- **Security & incidents:** `privacidade@namastex.ai`
+- **Data Protection Officer (DPO):** Cezar Vasconcelos — `dpo@khal.ai`
+- **Security disclosure page:** [automagik.dev/security](https://automagik.dev/security)
+
+Namastex Labs Serviços em Tecnologia Ltda · CNPJ 46.156.854/0001-62
+
+*Last updated: 2026-04-23 · v1.0*

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -35,8 +35,8 @@ We will credit reporters publicly (with their permission) in the released adviso
 |--------------|--------|
 | `1.1.10` and later clean releases | ✅ Supported — current |
 | `1.1.11` – `1.1.14` | ❌ **COMPROMISED — do not use** |
-| `1.1.0` – `1.1.10` | ⚠️ Legacy — security patches only |
-| Earlier versions | ❌ End of life |
+| `1.1.0` – `1.1.9` | ⚠️ Legacy — security patches only |
+| `1.0.x` and earlier | ❌ End of life |
 
 Always install from the current stable line. Pin explicit versions in your `package.json` and avoid `latest` for supply-chain sensitive packages.
 
@@ -58,7 +58,7 @@ Between 2026-04-21 (~22:14 UTC) and 2026-04-22 (~14:00 UTC), versions `1.1.11`, 
 - 📖 [Full incident response manual](https://github.com/namastexlabs/genie-dpo/blob/main/knowledge/canisterworm-incident-response.md)
 - 🌐 [Public advisory (English)](https://automagik.dev/security)
 - 🌐 [Aviso público (Português)](https://automagik.dev/seguranca)
-- 🛡️ [GitHub Security Advisory](https://github.com/namastexlabs/pgserve/security/advisories) *(GHSA link — update after publishing)*
+- 🛡️ [GitHub Security Advisories](https://github.com/namastexlabs/pgserve/security/advisories) for this repository
 
 A full public post-mortem will be published within 30 days of containment.
 
@@ -80,8 +80,8 @@ Effective 2026-04-23, all `pgserve` releases are governed by:
 ## Hardening Recommendations for Consumers
 
 - Pin explicit versions, not `latest`: `"pgserve": "1.1.10"`.
-- Use `npm ci --frozen-lockfile` in CI.
-- Enable `ignore-scripts` where `postinstall` is not required: `npm config set ignore-scripts true`.
+- Use `npm ci` in CI. It enforces lockfile-based installs by default.
+- Evaluate `--ignore-scripts` per-package for untrusted dependencies. The current `pgserve` release does not require any lifecycle script to function.
 - Verify package provenance: `npm view pgserve --json | jq '.dist.attestations'`.
 - Monitor advisories: subscribe to GitHub security alerts for this repository.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -64,6 +64,17 @@ A full public post-mortem will be published within 30 days of containment.
 
 ---
 
+## Acknowledgments
+
+We thank the researchers and organizations that identified and tracked this incident:
+
+- [**Socket Research Team**](https://socket.dev/blog/namastex-npm-packages-compromised-canisterworm) — primary discovery and continued tracking at [socket.dev/supply-chain-attacks/canistersprawl](https://socket.dev/supply-chain-attacks/canistersprawl).
+- **Endor Labs**, **Kodem Security**, **BleepingComputer**, **The Register**, **CSO Online**, **GBHackers**, **Cybersecurity News** — for coverage, analysis, and technical breakdowns that helped defenders respond quickly.
+
+We also thank the Automagik team that ran the end-to-end response during the incident window, and the broader open-source community whose scrutiny, tools, and unfiltered feedback keep this ecosystem healthy. We will keep earning it.
+
+---
+
 ## Our Commitments
 
 Effective 2026-04-23, all `pgserve` releases are governed by:


### PR DESCRIPTION
## Summary

Adds a `SECURITY.md` at the repo root with:

- **Private reporting channels** and response SLA (2h ack, 24h triage, 7d mitigation plan)
- **Supported versions** table, flagging `1.1.11` through `1.1.14` as compromised and unsafe to use
- **Past incident record** for the April 2026 CanisterWorm supply-chain compromise, with metrics (~16h window, <20h containment) and links to the response manual and the public advisory pages
- **Our commitments** going forward: mandatory `npm --provenance`, migration to OIDC trusted publishing, mandatory 2FA on publish accounts, environment protection, quarterly token audits
- **Hardening recommendations** for consumers (pin explicit versions, frozen lockfile, `ignore-scripts`, verify provenance)

## Why

GitHub surfaces `SECURITY.md` at the repo root from the "Security" tab. This closes the gap where users landing on the repo had no standard place to find our disclosure policy or the record of the recent CanisterWorm incident.

## Test plan

- [ ] Links resolve (advisory at automagik.dev/security, response manual, GHSA)
- [ ] Supported Versions table matches reality at merge time
- [ ] Contact emails confirmed (`privacidade@namastex.ai`, `dpo@khal.ai`)

Related: public advisory at https://automagik.dev/security · response manual at https://github.com/namastexlabs/genie-dpo/blob/main/knowledge/canisterworm-incident-response.md

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Published comprehensive security policy detailing vulnerability reporting procedures, response timelines, and supported version guidance.
  * Added security governance commitments including release integrity measures and supply-chain protections.
  * Included consumer-side security recommendations and security contact information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->