### PR TITLE
fix(postgres): reset socketDir/databaseDir across stop/start cycles (#24)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pgserve",
-  "version": "1.1.10",
+  "version": "1.2.0",
   "description": "Embedded PostgreSQL server with true concurrent connections - zero config, auto-provision databases",
   "main": "src/index.js",
   "type": "module",

--- a/src/postgres.js
+++ b/src/postgres.js
@@ -444,8 +444,20 @@ export class PostgresManager {
 
   /**
    * Start the embedded PostgreSQL instance
+   *
+   * Re-entry guard: if a previous start() left `this.process` or stale state
+   * behind, refuse silently rather than leaking another socketDir/databaseDir.
+   * Callers must call stop() first if they want to restart.
    */
   async start() {
+    if (this.process) {
+      this.logger?.warn(
+        { pid: this.process.pid, socketDir: this.socketDir },
+        'PostgresManager.start() called while already started — returning existing instance'
+      );
+      return this;
+    }
+
     // Get binary paths (may extract bundled binaries on first run)
     this.binaries = await getBinaryPaths();
 
@@ -773,12 +785,33 @@ export class PostgresManager {
       readStream(this.process.stdout);
 
       // Handle process exit
+      //
+      // When the postgres subprocess exits (normal stop OR crash), we must
+      // null `this.process` AND `this.socketDir`/`this.databaseDir` so that
+      // subsequent `getSocketPath()` calls do not return a path to a directory
+      // that no longer exists. This is the issue #24 root cause: the router
+      // was receiving stale socketPaths pointing to cleaned-up tmp dirs.
+      //
+      // NOTE: we do NOT null socketDir here if `stop()` is in flight, because
+      // stop() already handles cleanup+null. We only need to self-heal when
+      // the exit is unexpected (external kill, crash, OOM).
       this.process.exited.then((code) => {
         processExited = true;
         if (!started) {
           reject(new Error(`PostgreSQL exited with code ${code} before starting: ${startupOutput}`));
         }
         this.process = null;
+        // On unexpected exit (not via stop()), reset cached paths so that
+        // getSocketPath() returns null and callers can fall back to TCP
+        // or force a fresh start().
+        if (!this._stopping) {
+          this.socketDir = null;
+          this.databaseDir = null;
+          this.logger?.warn(
+            { code },
+            'PostgreSQL subprocess exited unexpectedly — socketDir/databaseDir reset'
+          );
+        }
       });
 
       // Method 1: TCP connection polling (preferred, works on Linux/macOS)
@@ -1294,8 +1327,19 @@ export class PostgresManager {
 
   /**
    * Stop the PostgreSQL instance
+   *
+   * Cleanup order matters: we null `this.socketDir`/`this.databaseDir` AFTER
+   * the rmSync so any concurrent `getSocketPath()` call either sees the old
+   * path (while it still exists) or null (after cleanup) — never a path
+   * pointing to a deleted directory.
+   *
+   * The `_stopping` flag tells the process.exited handler to NOT redundantly
+   * null the paths (avoids a race where start() called immediately after
+   * stop() sees nulls that stop() was about to set anyway).
    */
   async stop() {
+    this._stopping = true;
+
     // Close admin pool first (Bun.sql)
     if (this.adminPool) {
       await this.adminPool.close();
@@ -1340,6 +1384,16 @@ export class PostgresManager {
         }
       }
     }
+
+    // Reset cached paths UNCONDITIONALLY after cleanup so getSocketPath()
+    // returns null for anyone still holding a reference to this instance.
+    // This is the core fix for issue #24.
+    this.socketDir = null;
+    if (!this.persistent) {
+      this.databaseDir = null;
+    }
+    this.createdDatabases.clear();
+    this._stopping = false;
   }
 
   /**

--- a/src/router.js
+++ b/src/router.js
@@ -14,6 +14,7 @@
  * PERFORMANCE: Uses Bun.listen() and Bun.connect() for 2-3x throughput improvement
  */
 
+import fs from 'fs';
 import { PostgresManager } from './postgres.js';
 import { SyncManager } from './sync.js';
 import { RestoreManager } from './restore.js';
@@ -362,9 +363,18 @@ export class MultiTenantRouter extends EventEmitter {
         }
       };
 
-      if (socketPath) {
+      // Safety net for issue #24: if socketPath points to a directory that was
+      // cleaned up (e.g. pgManager was stopped+started, or the PG subprocess
+      // exited unexpectedly and socketDir was reset to null but a stale cached
+      // path is still hanging around), fall back to TCP instead of Bun.connect
+      // hanging on a missing unix socket.
+      const useUnix = socketPath && fs.existsSync(socketPath);
+      if (useUnix) {
         state.pgSocket = await Bun.connect({ unix: socketPath, socket: pgHandler });
       } else {
+        if (socketPath && !useUnix) {
+          this.logger.warn({ socketPath, dbName }, 'Unix socket path stale — falling back to TCP');
+        }
         state.pgSocket = await Bun.connect({ hostname: '127.0.0.1', port: this.pgPort, socket: pgHandler });
       }
 

--- a/tests/multi-tenant.test.js
+++ b/tests/multi-tenant.test.js
@@ -161,6 +161,91 @@ test('Multi-tenant router - multiple databases isolated', async () => {
   cleanup();
 });
 
+test('PostgresManager - stop() nulls socketDir/databaseDir (issue #24)', async () => {
+  // Regression test for issue #24: router used to cache stale socketPath
+  // pointing to a directory that stop() had already rmSync'd. After fix,
+  // stop() nulls socketDir/databaseDir UNCONDITIONALLY so subsequent
+  // getSocketPath() returns null (forcing TCP fallback in the router).
+  cleanup();
+
+  const { PostgresManager } = await import('../src/postgres.js');
+  const { createLogger } = await import('../src/logger.js');
+  const pg = new PostgresManager({
+    port: 15543,
+    logger: createLogger({ level: 'warn' }),
+  });
+
+  await pg.start();
+  const socketPathBeforeStop = pg.getSocketPath();
+  expect(socketPathBeforeStop).not.toBeNull();
+  expect(fs.existsSync(pg.socketDir)).toBe(true);
+
+  await pg.stop();
+
+  // CORE ASSERTION: socketDir must be nulled after stop
+  expect(pg.socketDir).toBeNull();
+  expect(pg.getSocketPath()).toBeNull();
+  // databaseDir nulled only in memory mode (persistent mode keeps user-owned path)
+  expect(pg.databaseDir).toBeNull();
+  // And the dir on disk must actually be gone
+  // (socketPathBeforeStop points inside the deleted socketDir)
+  const staleSocketDir = path.dirname(socketPathBeforeStop);
+  expect(fs.existsSync(staleSocketDir)).toBe(false);
+});
+
+test('PostgresManager - start()+stop()+start() yields fresh socketDir (issue #24)', async () => {
+  // Regression test for issue #24: pgManager.start() called after stop()
+  // must produce a FRESH socketDir (different path). Without the fix, a
+  // re-entry guard was missing and socketDir could leak across restarts.
+  cleanup();
+
+  const { PostgresManager } = await import('../src/postgres.js');
+  const { createLogger } = await import('../src/logger.js');
+  const pg = new PostgresManager({
+    port: 15544,
+    logger: createLogger({ level: 'warn' }),
+  });
+
+  await pg.start();
+  const socketDir1 = pg.socketDir;
+  expect(socketDir1).not.toBeNull();
+
+  await pg.stop();
+  expect(pg.socketDir).toBeNull();
+
+  await pg.start();
+  const socketDir2 = pg.socketDir;
+  expect(socketDir2).not.toBeNull();
+  expect(socketDir2).not.toBe(socketDir1);
+  expect(fs.existsSync(socketDir2)).toBe(true);
+
+  await pg.stop();
+});
+
+test('PostgresManager - double start() is a no-op (issue #24 re-entry guard)', async () => {
+  // Without the guard, a second start() would overwrite socketDir/databaseDir
+  // and leak the previous tmp dir (the "1,457 stale sock dirs" symptom).
+  cleanup();
+
+  const { PostgresManager } = await import('../src/postgres.js');
+  const { createLogger } = await import('../src/logger.js');
+  const pg = new PostgresManager({
+    port: 15545,
+    logger: createLogger({ level: 'warn' }),
+  });
+
+  await pg.start();
+  const socketDir1 = pg.socketDir;
+
+  // Second start() should silently return the same instance without
+  // reassigning socketDir/databaseDir.
+  const result = await pg.start();
+  expect(result).toBe(pg);
+  expect(pg.socketDir).toBe(socketDir1);
+
+  await pg.stop();
+});
+
 test('Multi-tenant router - instance reuse', async () => {
   cleanup();
 


### PR DESCRIPTION
## Summary
- Fixes #24 — router was receiving stale socketPath pointing to directories `PostgresManager.stop()` had already `rmSync`'d, causing 100% of new connections to fail forever (today's production outage: 2130 errors/sec, 1457 stale `/tmp/pgserve-sock-*` dirs).
- `stop()` now nulls `this.socketDir` unconditionally and `this.databaseDir` in memory mode; `start()` has a re-entry guard; `process.exited` handler self-heals state on unexpected crash.
- Router adds a `fs.existsSync` safety net before `Bun.connect` to unix socket, falling back to TCP if the path is stale.
- Version bumped to **1.2.0** (behaviour fix, API-compatible).

## Root cause
Three compounding bugs in `src/postgres.js`:
1. `stop()` did `fs.rmSync(socketDir)` but never nulled `this.socketDir` → `getSocketPath()` kept returning the ghost path after cleanup.
2. `start()` had no re-entry guard → second call overwrote `socketDir`/`databaseDir` without cleaning the previous tmpdir (source of the 1457 stale dirs).
3. `process.exited` handler didn't reset state on unexpected PG crash → router kept a valid-looking socketPath pointing at a socket file the dead backend never recreates.

Details + diagnosis in commit message.

## Test plan
New regression tests in tests/multi-tenant.test.js — 3/3 passing locally:
- [x] PostgresManager - stop() nulls socketDir/databaseDir (issue #24)
- [x] PostgresManager - start()+stop()+start() yields fresh socketDir (issue #24)
- [x] PostgresManager - double start() is a no-op (issue #24 re-entry guard)

Pre-existing test flakiness in tests/multi-tenant.test.js (EADDRINUSE when multiple tests reuse port 15432) is unchanged by this PR — verified by running the same failing test on main without the fix applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Version bumped to 1.2.0

* **Bug Fixes**
  * Improved connection reliability by enhancing lifecycle management to properly clean up and recover from stale socket references following unexpected PostgreSQL termination
  * Enhanced connection logic with path validation to prevent timeout issues and ensure reliable fallback connections when primary connection paths become unavailable

<!-- end of auto-generated comment: release notes by coderabbit.ai -->