### PR TITLE
fix(release): grant id-token: write to unblock release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,6 +37,11 @@ concurrency:
 
 permissions:
   contents: write
+  id-token: write   # required so the reusable `version.yml` workflow can mint
+                    # the OIDC token for npm Trusted Publishing — without this,
+                    # GH rejects the workflow at parse time (startup_failure)
+                    # because the called job's `id-token: write` permission
+                    # exceeds what the caller has granted.
 
 jobs:
   # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Hotfix for #30. The new \`release.yml\` declared only \`permissions: contents: write\` at top level, but its reusable \`version.yml\` callee declares \`id-token: write\` on the publish job for npm OIDC Trusted Publishing. GitHub Actions rejects this at parse time — a called workflow's permissions cannot exceed the caller's grant.

**Symptom:** [run 24938200286](https://github.com/namastexlabs/pgserve/actions/runs/24938200286) failed with \`startup_failure\` in 1s on the merge of #30.

**Fix:** add \`id-token: write\` to \`release.yml\`'s top-level permissions block. Restores parity with the pre-#30 release.yml.

## Test plan

- [ ] Merge this PR (no version bump in package.json — the merge commit on main will trigger \`release.yml\`)
- [ ] Verify the next \`release.yml\` run on main does NOT fail with \`startup_failure\` — the \`prepare\` job should run, find that \`v1.2.0\` already exists as a release, and exit cleanly with \`skip=true\`
- [ ] After this lands, trigger \`gh workflow run release.yml -f bump=patch\` to live-fire Group 4 of the parent wish

🤖 Generated with [Claude Code](https://claude.com/claude-code)