### PR TITLE
fix(release): build/release gates robust to empty needs.outputs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -168,17 +168,33 @@ jobs:
             echo "EOF"
           } >> "$GITHUB_OUTPUT"
 
+      # Echo the resolved outputs so downstream skip/no-skip decisions are
+      # debuggable from the run log without re-running with step debug.
+      - name: Debug resolved outputs
+        run: |
+          echo "version=${{ steps.ver.outputs.version }}"
+          echo "tag=${{ steps.ver.outputs.tag }}"
+          echo "skip=${{ steps.ver.outputs.skip }}"
+          echo "prev=${{ steps.prev.outputs.tag }}"
+
   # ---------------------------------------------------------------------------
   # Build & Publish: matrix build of platform binaries + npm publish via OIDC.
   #
   # The reusable workflow filename is `version.yml` because npm Trusted
   # Publisher is configured against that exact path. Renaming requires
   # updating the npmjs.com Trusted Publisher entry first.
+  #
+  # `if:` uses `!= 'true'` rather than `== 'false'` to also match the empty-
+  # string case. When a job's `needs:` chain includes a skipped job (here,
+  # `bump` skipped on push events), GH Actions can propagate `outputs.<name>`
+  # as empty rather than the resolved value to downstream `if:` evaluation.
+  # `!= 'true'` is robust to that — only an explicit "release exists, skip"
+  # signal blocks the build.
   # ---------------------------------------------------------------------------
   build:
     name: Build & Publish
     needs: prepare
-    if: needs.prepare.outputs.skip == 'false'
+    if: needs.prepare.outputs.skip != 'true'
     uses: ./.github/workflows/version.yml
     with:
       version: ${{ needs.prepare.outputs.version }}
@@ -192,7 +208,7 @@ jobs:
   release:
     name: Create GitHub Release
     needs: [prepare, build]
-    if: needs.prepare.outputs.skip == 'false'
+    if: needs.prepare.outputs.skip != 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:


### PR DESCRIPTION
## Summary

After PR #30 + #31 merged, the first push-to-main run of \`release.yml\` ([run 24939599427](https://github.com/namastexlabs/pgserve/actions/runs/24939599427)) saw \`prepare\` succeed with \`skip=false\` (proven by the inner steps gated on that value running) — but \`build\` and \`release\` were silently skipped anyway. Their \`if: needs.prepare.outputs.skip == 'false'\` evaluated to false despite the output being set.

Root cause: GH Actions has a known quirk where, when a job's \`needs:\` chain contains a skipped job (here, \`bump\` skipped on \`push\` events), GH can propagate the upstream job's outputs as empty strings to downstream \`if:\` evaluators — even though the upstream job ran successfully and set the outputs. \`'' == 'false'\` is false → silent skip.

## Fix

1. Change \`build\` and \`release\` \`if:\` from \`== 'false'\` to \`!= 'true'\`. Only an explicit \"release exists, skip\" signal blocks the build. If outputs are empty for any reason, the build attempts to run; if \`version\` ends up empty the called \`version.yml\` fails at runtime with a clear \"required input not provided\" error, which is far more diagnostic than the silent skip.
2. Add a \`Debug resolved outputs\` step at the end of \`prepare\` that echoes the resolved values into the run log. Future runs are auditable without enabling \`ACTIONS_STEP_DEBUG\`.

## Test plan

- [ ] Merge this PR — the merge commit on main triggers \`release.yml\`
- [ ] In the resulting run, the new debug step in \`prepare\` should print \`skip=false\`
- [ ] \`build\` and \`release\` should now execute
- [ ] Expected: \`pgserve@1.2.0\` published to npm \`latest\`, \`v1.2.0\` GitHub Release with binaries created
- [ ] If it still skips: the debug log will tell us exactly what \`prepare\` thought \`skip\` was, narrowing the diagnosis

🤖 Generated with [Claude Code](https://claude.com/claude-code)