### PR TITLE
fix(release): bulletproof if-gates for reusable-workflow caller

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -184,17 +184,28 @@ jobs:
   # Publisher is configured against that exact path. Renaming requires
   # updating the npmjs.com Trusted Publisher entry first.
   #
-  # `if:` uses `!= 'true'` rather than `== 'false'` to also match the empty-
-  # string case. When a job's `needs:` chain includes a skipped job (here,
-  # `bump` skipped on push events), GH Actions can propagate `outputs.<name>`
-  # as empty rather than the resolved value to downstream `if:` evaluation.
-  # `!= 'true'` is robust to that — only an explicit "release exists, skip"
-  # signal blocks the build.
+  # The `if:` uses `always() && needs.prepare.result == 'success' &&
+  # needs.prepare.outputs.skip != 'true'`. This is the bulletproof pattern
+  # for reusable-workflow callers when any upstream job in the `needs:`
+  # chain was SKIPPED. With the simpler `needs.prepare.outputs.skip != 'true'`
+  # alone, GH Actions silently evaluated the gate as false even though the
+  # debug step in `prepare` proved the output was actually `'false'` — a
+  # known GH Actions quirk: when a job's transitive `needs:` chain includes
+  # a skipped job (here, `bump` is skipped on push events), the reusable-
+  # workflow caller's expression evaluator treats `needs.<job>.outputs.<x>`
+  # as null/missing regardless of the actual value.
+  #
+  # `always()` opts out of the implicit success() filter; the explicit
+  # `result == 'success'` reinstates it correctly; the outputs check then
+  # works as intended.
   # ---------------------------------------------------------------------------
   build:
     name: Build & Publish
     needs: prepare
-    if: needs.prepare.outputs.skip != 'true'
+    if: |
+      always() &&
+      needs.prepare.result == 'success' &&
+      needs.prepare.outputs.skip != 'true'
     uses: ./.github/workflows/version.yml
     with:
       version: ${{ needs.prepare.outputs.version }}
@@ -208,7 +219,11 @@ jobs:
   release:
     name: Create GitHub Release
     needs: [prepare, build]
-    if: needs.prepare.outputs.skip != 'true'
+    if: |
+      always() &&
+      needs.prepare.result == 'success' &&
+      needs.build.result == 'success' &&
+      needs.prepare.outputs.skip != 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:


### PR DESCRIPTION
## Summary

PR #32's debug step proved \`prepare\`'s outputs are correctly set (\`skip=false\`, \`version=1.2.0\`) — yet \`build\` and \`release\` are STILL silently skipped on push events. This means the issue isn't the comparison operator (\`== 'false'\` vs \`!= 'true'\`); it's a deeper GH Actions quirk where, in a reusable-workflow caller's \`if:\` evaluator, \`needs.<job>.outputs.<x>\` resolves to null/missing whenever any job in the transitive \`needs:\` chain was skipped (here, \`bump\` is skipped on push events).

## Fix

Apply the bulletproof pattern to both \`build\` and \`release\`:

\`\`\`yaml
if: |
  always() &&
  needs.<upstream>.result == 'success' &&
  needs.<upstream>.outputs.<x> != 'true'
\`\`\`

- \`always()\` opts out of GH's implicit \`success()\` filter that's silently blocking the job.
- \`result == 'success'\` reinstates the upstream-must-succeed check explicitly.
- With \`always()\` in front, the outputs check then works as intended.

## Evidence

Run that proved outputs are correct but gate fails: https://github.com/namastexlabs/pgserve/actions/runs/24939835951

\`Prepare release\` → \`Debug resolved outputs\` printed:
\`\`\`
version=1.2.0
tag=v1.2.0
skip=false
prev=v1.1.10
\`\`\`

Yet \`build\` (with \`if: needs.prepare.outputs.skip != 'true'\`) was still skipped.

## Test plan

- [ ] Merge — the resulting \`release.yml\` run on main should now execute \`build\` and \`release\`
- [ ] \`pgserve@1.2.0\` published to npm \`latest\`
- [ ] \`v1.2.0\` GitHub Release with three platform binaries

🤖 Generated with [Claude Code](https://claude.com/claude-code)