### PR TITLE
fix(release): checkout by SHA on push path; surface ref via prepare output

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -115,11 +115,18 @@ jobs:
       tag: ${{ steps.ver.outputs.tag }}
       skip: ${{ steps.ver.outputs.skip }}
       changelog: ${{ steps.changelog.outputs.notes }}
+      # Surface the resolved checkout-ref so downstream jobs (build, release)
+      # can use it. They cannot reference `needs.bump.outputs.*` directly
+      # because they only have `needs: prepare` (or [prepare, build]) — not
+      # `bump` — in their needs context.
+      ref: ${{ needs.bump.outputs.tag || github.sha }}
     steps:
       - uses: actions/checkout@v4
         with:
           # On dispatch, check out the freshly-pushed tag; on push, the
           # triggering SHA already has the bumped package.json.
+          # (Prepare cannot reference its own `outputs.ref` here — that's
+          # only available to downstream jobs.)
           ref: ${{ needs.bump.outputs.tag || github.sha }}
           fetch-depth: 0
 
@@ -210,7 +217,14 @@ jobs:
     with:
       version: ${{ needs.prepare.outputs.version }}
       npm_tag: latest
-      ref: ${{ needs.prepare.outputs.tag }}
+      # Use prepare.outputs.ref (which resolves to the bump-job tag on
+      # dispatch, or `github.sha` on push). Build cannot reference
+      # `needs.bump.*` directly — only `prepare` is in its `needs:` chain.
+      # On the push path nobody creates the tag before this runs; the
+      # SHA-based checkout works because the merge commit already has the
+      # bumped package.json. The release job creates the tag at the end
+      # via `gh release create`.
+      ref: ${{ needs.prepare.outputs.ref }}
     secrets: inherit
 
   # ---------------------------------------------------------------------------
@@ -229,7 +243,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ needs.prepare.outputs.tag }}
+          # Same as the build job: prefer the bump job's tag (dispatch
+          # path) but fall back to the SHA (push path, no tag exists yet).
+          ref: ${{ needs.prepare.outputs.ref }}
 
       - name: Download binaries
         uses: actions/download-artifact@v4


### PR DESCRIPTION
## Summary

After #33 the gate worked and \`build\` actually ran — but immediately failed at the checkout step trying to fetch a tag that doesn't exist yet:

\`\`\`
git fetch ... +refs/tags/v1.2.0*:refs/tags/v1.2.0*
The process '/usr/bin/git' failed with exit code 1
\`\`\`

On the dispatch path, \`bump\` creates the tag before build runs. On the push path, nobody creates the tag — the \`release\` job at the end does it implicitly via \`gh release create\`. So build was checking out a tag that won't exist until later.

## Fix

1. Add \`ref: \${{ needs.bump.outputs.tag || github.sha }}\` as a NEW output of \`prepare\`. Prepare is the only job with \`needs: bump\`, so it's the only place that can resolve this expression.
2. \`build\` and \`release\` reference \`needs.prepare.outputs.ref\` instead of trying to access \`needs.bump.outputs.tag\` directly (which they can't — \`bump\` is not in their needs context).
3. On push, \`prepare.outputs.ref\` resolves to \`github.sha\` (the merge commit, which already has the bumped package.json). On dispatch, it resolves to the freshly-pushed tag.

Run that proved the bug: https://github.com/namastexlabs/pgserve/actions/runs/24940098376

## Test plan

- [ ] Merge — the resulting \`release.yml\` run on main should pass through prepare → build → release end-to-end
- [ ] \`pgserve@1.2.0\` published to npm \`latest\`
- [ ] \`v1.2.0\` GitHub Release with three platform binaries

🤖 Generated with [Claude Code](https://claude.com/claude-code)