### PR TITLE
fix(release): annotate tag so --follow-tags pushes it

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,7 +86,7 @@ jobs:
           TAG="${{ steps.bump.outputs.tag }}"
           git add package.json
           git commit -m "[skip ci] release ${TAG}"
-          git tag "${TAG}"
+          git tag -a "${TAG}" -m "release ${TAG}"
           git push origin HEAD --follow-tags
 
   # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`git push origin HEAD --follow-tags` only pushes **annotated** tags. The existing `git tag "${TAG}"` creates a **lightweight** tag, which was created locally but never pushed to origin. The subsequent `Prepare Release` job then crashed because origin had no tag for the just-bumped version.

This bug surfaced during the v2.0.0 release attempt on 2026-04-29 — manual intervention was required to push an annotated tag and complete the publish flow (genie team-lead pushed the `v2.0.0` annotated tag by hand to unblock).

## Fix

```diff
-          git tag "${TAG}"
+          git tag -a "${TAG}" -m "release ${TAG}"
```

`-a` makes the tag annotated → `--follow-tags` actually pushes it on the same `git push` call → `Prepare Release` finds the tag at origin.

## Test plan

- [x] One-line YAML diff verified locally
- [ ] Next minor/patch release will exercise the path (validates without manual intervention)

## Refs

- Manual annotated-tag intervention during pgserve v2.0.0 release (commit 882d7be, tag pushed by hand)

🤖 Generated with [Claude Code](https://claude.com/claude-code)