### PR TITLE
fix(daemon): support macOS socket tenants

### DIFF
--- a/src/daemon.js
+++ b/src/daemon.js
@@ -251,7 +251,7 @@ export class PgserveDaemon extends EventEmitter {
 
     this.pgManager = options.pgManager || new PostgresManager({
       dataDir: this.baseDir,
-      port: options.pgPort || 5433,
+      port: options.pgPort ?? 0,
       logger: this.logger.child ? this.logger.child({ component: 'postgres' }) : this.logger,
       useRam: this.useRam,
       enablePgvector: options.enablePgvector || false,

--- a/src/fingerprint.js
+++ b/src/fingerprint.js
@@ -6,7 +6,7 @@
  *
  *   1. SO_PEERCRED (Linux) / getpeereid + LOCAL_PEERPID (macOS)
  *      → kernel-attested {pid, uid, gid}
- *   2. /proc/$pid/cwd  → peer's current working directory (Linux only)
+ *   2. peer cwd lookup → /proc/$pid/cwd on Linux, lsof on macOS
  *   3. walk upward to the nearest package.json
  *   4. if found:  fingerprint = sha256(realpath \0 name \0 uid)[:12]   mode='package'
  *      else:      fingerprint = sha256(uid \0 cwd \0 cmdline[1])[:12]  mode='script'
@@ -29,6 +29,7 @@
  */
 
 import crypto from 'crypto';
+import { execFileSync } from 'child_process';
 import fs from 'fs';
 import path from 'path';
 import { audit, AUDIT_EVENTS } from './audit.js';
@@ -175,23 +176,48 @@ function makeDarwinReader(symbols, ptr) {
 }
 
 // ---------------------------------------------------------------------------
-// /proc reads — Linux-only; macOS daemon support is best-effort
+// Peer process metadata reads
 // ---------------------------------------------------------------------------
 
 /**
- * Resolve the cwd of a peer process via /proc/$pid/cwd. Linux-only.
- * Returns null if the symlink cannot be read (process gone, EACCES, etc).
+ * Resolve the cwd of a peer process. Linux uses /proc/$pid/cwd; macOS has no
+ * /proc, so it shells out to the platform lsof binary and parses the cwd row.
+ * Returns null if the process disappeared, permissions deny the lookup, or the
+ * host does not expose a cwd for the peer.
  *
  * @param {number} pid
  * @returns {string | null}
  */
 export function readProcCwd(pid) {
+  if (!Number.isInteger(pid) || pid <= 0) return null;
+  if (process.platform === 'darwin') return readDarwinCwd(pid);
   if (process.platform !== 'linux') return null;
   try {
     return fs.readlinkSync(`/proc/${pid}/cwd`);
   } catch {
     return null;
   }
+}
+
+function readDarwinCwd(pid) {
+  const lsof = process.env.PGSERVE_LSOF_BIN || '/usr/sbin/lsof';
+  try {
+    const output = execFileSync(lsof, ['-a', '-p', String(pid), '-d', 'cwd', '-Fn'], {
+      encoding: 'utf8',
+      timeout: 1000,
+      stdio: ['ignore', 'pipe', 'ignore'],
+    });
+    return parseDarwinLsofCwd(output);
+  } catch {
+    return null;
+  }
+}
+
+export function parseDarwinLsofCwd(output) {
+  for (const line of String(output || '').split(/\r?\n/)) {
+    if (line.startsWith('n') && line.length > 1) return line.slice(1);
+  }
+  return null;
 }
 
 /**

--- a/src/postgres.js
+++ b/src/postgres.js
@@ -406,10 +406,23 @@ export function pgvectorMetaMatches(meta, runtime) {
   return true;
 }
 
+function findAvailableTcpPort() {
+  const server = Bun.listen({
+    hostname: '127.0.0.1',
+    port: 0,
+    socket: {
+      data() {},
+    },
+  });
+  const port = server.port;
+  server.stop(true);
+  return port;
+}
+
 export class PostgresManager {
   constructor(options = {}) {
     this.dataDir = options.dataDir || null; // null = memory mode (temp dir)
-    this.port = options.port || 5433; // Internal PG port (router listens on different port)
+    this.port = options.port ?? 5433; // Internal PG port (router listens on different port)
     this.user = options.user || 'postgres';
     this.password = options.password || 'postgres';
     this.logger = options.logger;
@@ -464,6 +477,10 @@ export class PostgresManager {
     // Make binaries executable
     await fs.promises.chmod(this.binaries.initdb, '755');
     await fs.promises.chmod(this.binaries.postgres, '755');
+
+    if (this.port === 0) {
+      this.port = findAvailableTcpPort();
+    }
 
     // Determine data directory
     if (this.persistent) {
@@ -568,7 +585,8 @@ export class PostgresManager {
       const initdbCmd = [
         this.binaries.initdb,
         `--pgdata=${this.databaseDir}`,
-        '--auth=password',
+        '--auth-local=trust',
+        '--auth-host=password',
         `--username=${this.user}`,
         `--pwfile=${passwordFile}`,
       ];
@@ -744,11 +762,13 @@ export class PostgresManager {
       // Whichever succeeds first wins
 
       const markReady = (method) => {
-        if (!started) {
-          started = true;
-          this.logger.info({ port: this.port, method }, 'PostgreSQL ready');
-          resolve();
-        }
+        if (started || processExited) return true;
+        const socketPath = this.getSocketPath();
+        if (socketPath && !fs.existsSync(socketPath)) return false;
+        started = true;
+        this.logger.info({ port: this.port, method }, 'PostgreSQL ready');
+        resolve();
+        return true;
       };
 
       // Read stderr - detect port binding in logs (locale-independent: just look for port number)
@@ -873,14 +893,19 @@ export class PostgresManager {
           if (processExited) return;
 
           try {
+            const socketPath = this.getSocketPath();
+            if (socketPath && fs.existsSync(socketPath)) {
+              markReady('unix-socket');
+              return;
+            }
             await tryConnect();
             // On Windows, TCP port opens before PostgreSQL is fully ready for protocol handshakes
             // Add delay to let PostgreSQL complete its startup sequence
             if (isWindows) {
               await Bun.sleep(2000); // 2 second delay for Windows
             }
-            markReady('tcp');
-            return;
+            if (processExited) return;
+            if (markReady('tcp')) return;
           } catch {
             await Bun.sleep(200);
           }

--- a/tests/fingerprint.test.js
+++ b/tests/fingerprint.test.js
@@ -20,6 +20,8 @@ import {
   initFingerprintFfi,
   getPeerCred,
   findNearestPackageJson,
+  parseDarwinLsofCwd,
+  readProcCwd,
   readPackageName,
   derivePackageFingerprint,
   deriveScriptFingerprint,
@@ -78,6 +80,18 @@ test('getPeerCred reads kernel-attested pid/uid/gid via Unix socket pair', async
   expect(cred.pid).toBe(expectedPid);
   expect(cred.uid).toBe(expectedUid);
   expect(cred.gid).toBe(expectedGid);
+});
+
+test('macOS lsof parser extracts cwd field output', () => {
+  const cwd = path.join(scratch, 'project');
+  const output = `p12345\nn${cwd}\n`;
+  expect(parseDarwinLsofCwd(output)).toBe(cwd);
+  expect(parseDarwinLsofCwd('p12345\n')).toBeNull();
+});
+
+test('readProcCwd resolves the current process cwd on supported platforms', () => {
+  if (process.platform !== 'linux' && process.platform !== 'darwin') return;
+  expect(readProcCwd(process.pid)).toBe(process.cwd());
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- resolve macOS peer cwd via lsof so Unix-socket tenants can be fingerprinted outside Linux /proc
- use an ephemeral internal PostgreSQL port for daemon mode to avoid stale 5433 collisions
- wait for the PostgreSQL Unix socket and trust local socket auth while keeping host auth password-protected

## Verification
- bun test tests/fingerprint.test.js tests/daemon-fingerprint-integration.test.js tests/daemon-pr24-regression.test.js
- bun run lint
- bun run build
- bun run deadcode
- bun test
- isolated Genie smoke on macOS: patched pgserve daemon + dist/genie.js task list routed to app__automagik_genie_<fingerprint>