### PR TITLE
chore(release): bump to 2.0.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pgserve",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "Embedded PostgreSQL server with true concurrent connections - zero config, auto-provision databases",
   "main": "src/index.js",
   "type": "module",


### PR DESCRIPTION
## Summary
Bumps `package.json` from 2.0.3 → 2.0.4 to ship the postmaster.pid cleanup fix.

## Why
PR #46 (`fix(postgres): clear stale postmaster.pid before _startPostgres`) merged into main but the Release workflow on that merge logged `skip=true` because the version in `package.json` was unchanged from the existing v2.0.3 tag. Following the documented hand-bump path in `.github/workflows/release.yml`:

> Two trigger paths into the same workflow:
>   1. push to main with a hand-bumped package.json (no [skip ci] marker)
>      -> auto-detect path: prepare reads package.json, checks if v${version}
>         tag exists, builds + publishes + creates GitHub Release if not.

This PR is path #1. Merging it (without `[skip ci]` in the merge commit message) should make `prepare` resolve `version=2.0.4`, see no `v2.0.4` tag exists, and proceed through build → npm publish → GitHub Release.

## What's in 2.0.4
Just the one fix:
- #46 — clear stale `postmaster.pid` before starting backend (resolves manual recovery friction reported in #45)

No breaking changes. No CHANGELOG entry needed (per the existing convention — only 2.0.0 carries an explicit entry).

## Test plan
- [x] `package.json` version bumped to 2.0.4
- [x] No `v2.0.4` git tag exists yet (verified)
- [x] Merge commit will not carry `[skip ci]` (default squash-merge from this PR title is clean)
- [ ] After merge: confirm Release workflow runs `version=2.0.4 / skip=false` and publishes to npm

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package version to 2.0.4

<!-- end of auto-generated comment: release notes by coderabbit.ai -->