### PR TITLE
docs(changelog): add 2.0.4 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to `pgserve` are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 2.0.4
+
+### Fixed
+
+- `_startPostgres()` now removes a stale `postmaster.pid` from the data
+  directory before spawning postgres. Previously, an unclean shutdown
+  (SIGKILL, machine reboot, OOM) left a `postmaster.pid` whose recorded
+  PID was no longer alive, and postgres refused to start with
+  `FATAL: lock file "postmaster.pid" already exists` on the next boot.
+  Operators had to `rm postmaster.pid` manually to recover. A live PID
+  is never touched, so a real concurrent postmaster still surfaces the
+  normal lock conflict. ([#46](https://github.com/namastexlabs/pgserve/pull/46),
+  fixes [#45](https://github.com/namastexlabs/pgserve/issues/45))
+
 ## 2.0.0 — Unreleased
 
 > The release date will replace "Unreleased" when the v2.0.0 release workflow


### PR DESCRIPTION
## Summary
Adds a CHANGELOG entry for v2.0.4, documenting the postmaster.pid cleanup fix from #46.

## Why this PR also retriggers the release workflow

The previous version-bump merge (#47, commit 2986e5f) did not fire any GitHub Actions runs — both Release and CI were silently skipped. Root cause: the merge commit message body contained the literal substring beginning with bracket-skip-ci as part of the prose, which GitHub auto-skip picks up despite mid-line context.

Net effect: package.json on main says 2.0.4 but no v2.0.4 tag exists and no npm publish ran. This PR's clean commit message will retrigger the workflow on merge — prepare reads package.json, sees 2.0.4 with no v2.0.4 tag, and proceeds to build + publish + release.

## What's in 2.0.4
- #46 — clear stale postmaster.pid before starting backend (resolves #45)

## Test plan
- [x] CHANGELOG entry follows the repo's Keep-a-Changelog format
- [x] Commit message is clean (no auto-skip markers anywhere)
- [ ] After merge: confirm Release workflow runs with version=2.0.4 / skip=false and publishes to npm