### PR TITLE
fix(daemon): watchdog closes peers stuck in pre-handshake state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to `pgserve` are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 2.0.6
+
+### Fixed
+
+- `PgserveDaemon` now runs a watchdog that forcibly closes peers stuck in
+  pre-handshake state past `PGSERVE_HANDSHAKE_DEADLINE_MS` (default
+  30000ms). Without this, a peer that connected to `control.sock` and
+  never sent the postgres StartupMessage occupied a connection slot
+  indefinitely — pgserve#45 documented the file-descriptor leak under
+  load. The watchdog runs every `handshakeSweepIntervalMs` (default
+  5000ms, bounded at 1s minimum). Stalls are logged with `acceptedAt`,
+  `ageMs`, and the peer's fingerprint.
+
 ## 2.0.5
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pgserve",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "description": "Embedded PostgreSQL server with true concurrent connections - zero config, auto-provision databases",
   "main": "src/index.js",
   "type": "module",

--- a/src/daemon-control.js
+++ b/src/daemon-control.js
@@ -72,6 +72,13 @@ function handleSocketOpen(socket) {
     pendingToPg: null,
     pendingToClient: null,
     fingerprint,
+    // Wall-clock timestamp when this socket was accepted. The watchdog
+    // installed by PgserveDaemon.start() forcibly closes any socket that
+    // hasn't completed its postgres handshake within
+    // PGSERVE_HANDSHAKE_DEADLINE_MS. Without this, a peer that connects
+    // and never sends the StartupMessage occupies the connection slot
+    // forever — the file-descriptor leak documented in pgserve#45.
+    acceptedAt: Date.now(),
   });
   this.connections.add(socket);
   if (fingerprint) {

--- a/src/daemon.js
+++ b/src/daemon.js
@@ -290,6 +290,52 @@ export class PgserveDaemon extends EventEmitter {
     this.gcOptions = options.gcOptions || {};
 
     this.setMaxListeners(this.maxConnections + 10);
+
+    // Watchdog: forcibly close any control-socket peer that has been accepted
+    // but hasn't completed the postgres handshake within this deadline. The
+    // env override is for tests (or for operators who want a tighter bound).
+    // See pgserve#45: peers that connected and never sent a StartupMessage
+    // would pile up indefinitely in `state.handshakeComplete=false`,
+    // exhausting connection slots.
+    const envDeadline = Number.parseInt(process.env.PGSERVE_HANDSHAKE_DEADLINE_MS ?? '', 10);
+    this.handshakeDeadlineMs =
+      Number.isFinite(envDeadline) && envDeadline > 0
+        ? envDeadline
+        : (options.handshakeDeadlineMs ?? 30_000);
+    // Sweep cadence: small enough to bound the worst-case slop on top of the
+    // deadline (5s default → 30s deadline becomes "killed within 30-35s").
+    this.handshakeSweepIntervalMs = Math.max(
+      1000,
+      Math.min(this.handshakeDeadlineMs, options.handshakeSweepIntervalMs ?? 5_000),
+    );
+    this._handshakeWatchdogTimer = null;
+  }
+
+  /**
+   * Iterate accepted sockets and force-close any that have been waiting on
+   * the postgres handshake for longer than `handshakeDeadlineMs`. Exposed on
+   * the prototype so tests can drive it deterministically without waiting for
+   * the timer.
+   */
+  _sweepStuckHandshakes() {
+    const now = Date.now();
+    let closed = 0;
+    for (const socket of this.connections) {
+      const state = this.socketState.get(socket);
+      if (!state) continue;
+      if (state.handshakeComplete) continue;
+      const acceptedAt = state.acceptedAt ?? now;
+      if (now - acceptedAt < this.handshakeDeadlineMs) continue;
+      this.logger.warn?.(
+        { acceptedAt, ageMs: now - acceptedAt, deadlineMs: this.handshakeDeadlineMs, fingerprint: state.fingerprint },
+        'Closing peer stuck in pre-handshake state past deadline',
+      );
+      try { socket.end(); } catch { /* swallow */ }
+      this.connections.delete(socket);
+      this.socketState.delete(socket);
+      closed++;
+    }
+    return closed;
   }
 
   /**
@@ -473,7 +519,19 @@ export class PgserveDaemon extends EventEmitter {
       pidLockPath: this.pidLockPath,
       pgPort: this.pgManager.port,
       tcpListens: this.tcpListens,
+      handshakeDeadlineMs: this.handshakeDeadlineMs,
     }, 'pgserve daemon listening');
+
+    // Arm the handshake watchdog. unref() so the timer doesn't keep the
+    // process alive on its own — the daemon already awaits the wrapper's
+    // forever-promise.
+    this._handshakeWatchdogTimer = setInterval(
+      () => this._sweepStuckHandshakes(),
+      this.handshakeSweepIntervalMs,
+    );
+    if (typeof this._handshakeWatchdogTimer.unref === 'function') {
+      this._handshakeWatchdogTimer.unref();
+    }
 
     this.emit('listening');
     return this;
@@ -487,6 +545,11 @@ export class PgserveDaemon extends EventEmitter {
     this._stopping = true;
 
     this.logger.info?.('Stopping pgserve daemon');
+
+    if (this._handshakeWatchdogTimer) {
+      clearInterval(this._handshakeWatchdogTimer);
+      this._handshakeWatchdogTimer = null;
+    }
 
     for (const socket of this.connections) {
       try { socket.end(); } catch { /* swallow */ }

--- a/tests/router-handshake-watchdog.test.js
+++ b/tests/router-handshake-watchdog.test.js
@@ -1,0 +1,110 @@
+/**
+ * Handshake watchdog: peers that connect and never complete the postgres
+ * StartupMessage are forcibly closed past `PGSERVE_HANDSHAKE_DEADLINE_MS`.
+ *
+ * Regression coverage: pgserve#45 documented file-descriptor leak where
+ * peers piled up indefinitely in `state.handshakeComplete=false`.
+ *
+ * The tests drive `_sweepStuckHandshakes()` directly via a synthetic
+ * connection record. This avoids spawning a real postgres backend, which
+ * is unnecessary when we only want to assert the sweep policy and timer
+ * lifecycle.
+ */
+
+import { PgserveDaemon } from '../src/daemon.js';
+import { test, expect } from 'bun:test';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+
+function quietLogger() {
+  return {
+    info: () => {}, warn: () => {}, error: () => {}, debug: () => {},
+    child: () => quietLogger(),
+  };
+}
+
+function makeDaemon(opts = {}) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'pgserve-watchdog-'));
+  const daemon = new PgserveDaemon({
+    baseDir: dir,
+    logger: quietLogger(),
+    enforcementDisabled: true,
+    ...opts,
+  });
+  return { daemon, dir };
+}
+
+function fakeSocket() {
+  const calls = [];
+  return {
+    end: () => { calls.push('end'); },
+    pause: () => {}, resume: () => {}, write: () => 0,
+    _calls: calls,
+  };
+}
+
+test('handshakeDeadlineMs falls back to 30000 when env unset', () => {
+  delete process.env.PGSERVE_HANDSHAKE_DEADLINE_MS;
+  const { daemon, dir } = makeDaemon();
+  expect(daemon.handshakeDeadlineMs).toBe(30000);
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+test('handshakeDeadlineMs honours PGSERVE_HANDSHAKE_DEADLINE_MS env', () => {
+  process.env.PGSERVE_HANDSHAKE_DEADLINE_MS = '2000';
+  try {
+    const { daemon, dir } = makeDaemon();
+    expect(daemon.handshakeDeadlineMs).toBe(2000);
+    fs.rmSync(dir, { recursive: true, force: true });
+  } finally {
+    delete process.env.PGSERVE_HANDSHAKE_DEADLINE_MS;
+  }
+});
+
+test('_sweepStuckHandshakes closes pre-handshake sockets past deadline', () => {
+  const { daemon, dir } = makeDaemon({ handshakeDeadlineMs: 100 });
+  const sock = fakeSocket();
+  const stuckAt = Date.now() - 500; // older than 100ms deadline
+  daemon.connections.add(sock);
+  daemon.socketState.set(sock, { handshakeComplete: false, acceptedAt: stuckAt });
+  const closed = daemon._sweepStuckHandshakes();
+  expect(closed).toBe(1);
+  expect(sock._calls).toContain('end');
+  expect(daemon.connections.has(sock)).toBe(false);
+  expect(daemon.socketState.has(sock)).toBe(false);
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+test('_sweepStuckHandshakes leaves fresh pre-handshake sockets alone', () => {
+  const { daemon, dir } = makeDaemon({ handshakeDeadlineMs: 30000 });
+  const sock = fakeSocket();
+  daemon.connections.add(sock);
+  daemon.socketState.set(sock, { handshakeComplete: false, acceptedAt: Date.now() });
+  const closed = daemon._sweepStuckHandshakes();
+  expect(closed).toBe(0);
+  expect(sock._calls).not.toContain('end');
+  expect(daemon.connections.has(sock)).toBe(true);
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+test('_sweepStuckHandshakes leaves completed-handshake sockets alone even past deadline', () => {
+  const { daemon, dir } = makeDaemon({ handshakeDeadlineMs: 100 });
+  const sock = fakeSocket();
+  daemon.connections.add(sock);
+  daemon.socketState.set(sock, { handshakeComplete: true, acceptedAt: Date.now() - 5000 });
+  const closed = daemon._sweepStuckHandshakes();
+  expect(closed).toBe(0);
+  expect(sock._calls).not.toContain('end');
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+test('handshakeSweepIntervalMs is bounded sensibly relative to deadline', () => {
+  const { daemon, dir } = makeDaemon({
+    handshakeDeadlineMs: 200,
+    handshakeSweepIntervalMs: 50,
+  });
+  // Sweep interval cannot drop below 1s safety floor.
+  expect(daemon.handshakeSweepIntervalMs).toBe(1000);
+  fs.rmSync(dir, { recursive: true, force: true });
+});


### PR DESCRIPTION
## Summary
Adds a periodic sweep that forcibly closes any control-socket peer that hasn't completed its postgres StartupMessage handshake within `PGSERVE_HANDSHAKE_DEADLINE_MS` (default 30000ms).

Stage 2 — Group 2 of pgserve#45 follow-up. Bumps to 2.0.6.

> Independent of #49 — different files, no merge conflict. Order-of-merge does not matter.

## Why
A peer that connects to `control.sock` and never sends a StartupMessage occupies a connection slot indefinitely. Under load — or under buggy clients that connect, give up, and never close — slots accumulate until the daemon runs out of file descriptors. This was the file-descriptor leak documented in pgserve#45 (we observed 15+ ESTAB sockets on `control.sock` with empty queues, the daemon read them and never wrote back).

## Implementation

**3 source files + 1 new test, ~75 LOC + 110 LOC tests.**

- `src/daemon-control.js` — `handleSocketOpen` records `acceptedAt: Date.now()` in per-socket state.
- `src/daemon.js` — adds `_sweepStuckHandshakes()` instance method that walks `this.connections`, force-closes any socket where `state.handshakeComplete=false && now - acceptedAt > handshakeDeadlineMs`. Constructor reads `PGSERVE_HANDSHAKE_DEADLINE_MS` env (default 30000); `start()` arms a `setInterval(...).unref()` at `handshakeSweepIntervalMs` (default 5000, min 1000); `stop()` clears it.
- Stalls are logged with `acceptedAt`, `ageMs`, `deadlineMs`, and the peer's fingerprint for forensics.

## Risk
Low.
- **Default deadline 30s** is well above any legitimate handshake (Postgres SSL/SASL negotiation completes in milliseconds locally).
- **`unref()` on the timer** prevents the watchdog from keeping the event loop alive on its own.
- **Sweep interval bounded ≥1s** prevents pathological CPU usage from misconfiguration.
- **Real production peers** complete the handshake during `processStartupMessage`, which sets `state.handshakeComplete=true` — they're untouched by the sweep.

## Test plan
- [x] `tests/router-handshake-watchdog.test.js` (6/6 pass — env override default, env override custom value, stuck peer closed past deadline, fresh peer left alone, completed-handshake peer left alone, sweep interval bounded)
- [x] No regressions in unrelated test files
- [ ] Reviewer manual: connect to `control.sock` with `nc -U` and don't write anything; verify the connection is closed within 30s ± 5s by default
- [ ] Reviewer manual: `PGSERVE_HANDSHAKE_DEADLINE_MS=2000 pgserve daemon` + same nc test → closed within 2-7s

## Linked
- Issue #45 — root-cause report; this addresses gap #2 in the v2.0.3 follow-up
- Wish (genie repo): `pgserve-proxy-resilience` Group 2
- Sibling PR #49 (Group 1 — wrapper supervision)