### PR TITLE
chore(deps): bump @embedded-postgres binaries to 18.3.0-beta.17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to `pgserve` are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 2.0.8
+
+### Changed
+
+- Bumped embedded postgres binaries from `18.2.0-beta.16` to
+  `18.3.0-beta.17` for all four platforms (linux-x64, darwin-arm64,
+  darwin-x64, windows-x64). Picks up upstream PostgreSQL 18.3 fixes
+  and the matching `@embedded-postgres` package revision.
+- The hardcoded `pkgVersion` in `src/postgres.js` (used when binaries
+  are not yet cached and pgserve fetches them from npm) was updated
+  in lockstep with `package.json`.
+
 ## 2.0.7
 
 ### Fixed

--- a/bun.lock
+++ b/bun.lock
@@ -16,21 +16,21 @@
         "pg": "^8.16.3",
       },
       "optionalDependencies": {
-        "@embedded-postgres/darwin-arm64": "18.2.0-beta.16",
-        "@embedded-postgres/darwin-x64": "18.2.0-beta.16",
-        "@embedded-postgres/linux-x64": "18.2.0-beta.16",
-        "@embedded-postgres/windows-x64": "18.2.0-beta.16",
+        "@embedded-postgres/darwin-arm64": "18.3.0-beta.17",
+        "@embedded-postgres/darwin-x64": "18.3.0-beta.17",
+        "@embedded-postgres/linux-x64": "18.3.0-beta.17",
+        "@embedded-postgres/windows-x64": "18.3.0-beta.17",
       },
     },
   },
   "packages": {
-    "@embedded-postgres/darwin-arm64": ["@embedded-postgres/darwin-arm64@18.2.0-beta.16", "", { "os": "darwin", "cpu": "arm64" }, "sha512-wnswaF+uDvGeitqajJ8v8xOG4ttFrzixElwKNe2MIxBXSLWPV3xhi6tBY0Sjw8Lmiu6UG9vNLFZSjHPrIeokBg=="],
+    "@embedded-postgres/darwin-arm64": ["@embedded-postgres/darwin-arm64@18.3.0-beta.17", "", { "os": "darwin", "cpu": "arm64" }, "sha512-Pvrej3Xz5flfyVc9mchVfekrKoTJyvPtM3U0vjuXamZkRKmi+inP2zRmnmzYecIVbr7Zhu82xbsCENMXrwMp9Q=="],
 
-    "@embedded-postgres/darwin-x64": ["@embedded-postgres/darwin-x64@18.2.0-beta.16", "", { "os": "darwin", "cpu": "x64" }, "sha512-u9WtTPxRuO0uOny5IniXHSDaLmtOujwzDoExIV/jFT0Fu8SzpX7wdoPbsSPBLgyQWdr/nPA77K9QI4r6P1/fKA=="],
+    "@embedded-postgres/darwin-x64": ["@embedded-postgres/darwin-x64@18.3.0-beta.17", "", { "os": "darwin", "cpu": "x64" }, "sha512-MVWe+C47pPoMD9LlIWGQkvZ5Xsu3IBo54CYqnIps/Z1byMIUBNc7y/dZ3mfqEwiCbVDVqirG0CU462xnrSEfKA=="],
 
-    "@embedded-postgres/linux-x64": ["@embedded-postgres/linux-x64@18.2.0-beta.16", "", { "os": "linux", "cpu": "x64" }, "sha512-BIt485ioL8/AwDgw37IcdraOfRgHNDOtGM6Hh63vnNaUAG4Z0qtJd5zXS5fr2wZTEsYHyC5PC60k7zkCRZXSzg=="],
+    "@embedded-postgres/linux-x64": ["@embedded-postgres/linux-x64@18.3.0-beta.17", "", { "os": "linux", "cpu": "x64" }, "sha512-8orSD6NNopSLtjqir4dWQBrj+g8j1eJjWd9mB60A3xbWMzIBIPQpzT7XzbacW9YFSl/DejOLnRXfff+Wr13Tgw=="],
 
-    "@embedded-postgres/windows-x64": ["@embedded-postgres/windows-x64@18.2.0-beta.16", "", { "os": "win32", "cpu": "x64" }, "sha512-Sj6GhCZrvtMwchATEtWuEmexEBWpRNMHPTUHsqPuyDrHX/XgKfpIxz2/AMHa4sp7SZ0JOHGouH8AFIVsWQrQsQ=="],
+    "@embedded-postgres/windows-x64": ["@embedded-postgres/windows-x64@18.3.0-beta.17", "", { "os": "win32", "cpu": "x64" }, "sha512-kDC5aBsmhWDjeQjj2V4g+Bk+pMeDU27b7l0rBbaKgtt2gsNmCB34ULg/5cqs2kqUKSk/tiGMHKCNE+zQZ+s4rg=="],
 
     "@emnapi/core": ["@emnapi/core@1.7.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.1.0", "tslib": "^2.4.0" } }, "sha512-o1uhUASyo921r2XtHYOHy7gdkGLge8ghBEQHMWmyJFoXlpU58kIrhhN3w26lpQb6dspetweapMn2CSNwQ8I4wg=="],
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pgserve",
-  "version": "2.0.7",
+  "version": "2.0.8",
   "description": "Embedded PostgreSQL server with true concurrent connections - zero config, auto-provision databases",
   "main": "src/index.js",
   "type": "module",
@@ -42,10 +42,10 @@
   },
   "homepage": "https://github.com/namastexlabs/pgserve#readme",
   "optionalDependencies": {
-    "@embedded-postgres/darwin-arm64": "18.2.0-beta.16",
-    "@embedded-postgres/darwin-x64": "18.2.0-beta.16",
-    "@embedded-postgres/linux-x64": "18.2.0-beta.16",
-    "@embedded-postgres/windows-x64": "18.2.0-beta.16"
+    "@embedded-postgres/darwin-arm64": "18.3.0-beta.17",
+    "@embedded-postgres/darwin-x64": "18.3.0-beta.17",
+    "@embedded-postgres/linux-x64": "18.3.0-beta.17",
+    "@embedded-postgres/windows-x64": "18.3.0-beta.17"
   },
   "devDependencies": {
     "eslint": "^9.39.1",

--- a/src/postgres.js
+++ b/src/postgres.js
@@ -67,7 +67,7 @@ async function downloadPostgresBinaries() {
 
   const platformKey = getPlatformKey();
   const pkgName = `@embedded-postgres/${platformKey}`;
-  const pkgVersion = '18.2.0-beta.16';
+  const pkgVersion = '18.3.0-beta.17';
 
   console.log(`[pgserve] PostgreSQL binaries not found.`);
   console.log(`[pgserve] Downloading ${pkgName}@${pkgVersion}...`);


### PR DESCRIPTION
## Summary
Bumps embedded PostgreSQL from `18.2.0-beta.16` → `18.3.0-beta.17` across all four platforms (linux-x64, darwin-arm64, darwin-x64, windows-x64). Picks up upstream PG 18.3 fixes plus the matching `@embedded-postgres` package revision.

Bumps pgserve to **2.0.8**.

## Implementation

**4 files, ~26 LOC.**

The version is pinned in TWO places that must move in lockstep:

1. `package.json` `dependencies` — governs the build-time install. All four platform packages updated.
2. `src/postgres.js:70` `pkgVersion` constant — governs the **runtime** fetch fallback when pgserve is run on a host that doesn't have the binaries cached yet. If these drift, fresh checkouts get one version and binary-less hosts fetch another.

`bun.lock` regenerated via `bun install`. `CHANGELOG.md` entry under a new `## 2.0.8` section explaining both touchpoints.

## Risk
Low — a postgres minor-version bump (18.2 → 18.3). Both versions are still PostgreSQL 18.x. No SQL surface changes; `@embedded-postgres` is the canonical packaging by the same upstream maintainers. The pgserve test suite passes against 18.3 on this host:

```
$ bun test tests/stale-postmaster-pid.test.js \
           tests/wrapper-supervision.test.js \
           tests/router-handshake-watchdog.test.js \
           tests/router-handshake-retry.test.js
18 pass / 0 fail
```

CI will exercise the full suite across linux-x64 + darwin-x64 + macos-latest.

## Test plan
- [x] Both pin sites updated (package.json + src/postgres.js)
- [x] `bun install` regenerates `bun.lock` cleanly
- [x] Targeted test suite passes against 18.3
- [ ] CI runs full suite on ubuntu-latest + macos-latest
- [ ] Reviewer manual: cold-cache test (`rm -rf ~/.pgserve/bin/*` then `pgserve daemon`) — pgserve fetches 18.3.0-beta.17, not the old version

## Linked
None — independent dep bump, complements the pgserve#45 recovery work shipped in 2.0.5/2.0.6/2.0.7.