### PR TITLE
fix(install): drop --min-uptime CLI flag for pm2 6.x compatibility

### DIFF
--- a/src/cli-install.cjs
+++ b/src/cli-install.cjs
@@ -47,8 +47,13 @@ const DEFAULT_PORT = 8432;
  * Revised defaults:
  *   - 4G memory ceiling — covers realistic load while still bounded so
  *     a runaway query can't eat the host.
- *   - 50 max restarts BUT only counted when min_uptime < 10s ("rapid"
- *     failures). Healthy long-uptime crashes don't count against the cap.
+ *   - 50 max restarts. Earlier drafts paired this with `--min-uptime` to
+ *     only count rapid failures, but pm2 ≥ 6.0 dropped `--min-uptime` from
+ *     the CLI surface (it survives only inside ecosystem files now). We
+ *     keep the budget generous enough that occasional long-uptime crashes
+ *     don't burn through it; if you observe restart-budget exhaustion
+ *     from non-rapid crashes, raise `maxRestarts` rather than reintroducing
+ *     `--min-uptime` (which would break install on pm2 6.x).
  *   - Exponential backoff on repeated failures (100ms → 60s) so we don't
  *     hammer on persistent issues.
  *   - 60s graceful shutdown window — Postgres needs time to flush WAL.
@@ -62,7 +67,6 @@ const DEFAULT_PORT = 8432;
  */
 const HARDENED_DEFAULTS = {
   maxRestarts: 50,
-  minUptimeMs: 10_000,
   restartDelayMs: 4000,
   expBackoffRestartDelayMs: 100,
   // pm2 caps `--exp-backoff-restart-delay` ramp at the current backoff
@@ -149,11 +153,14 @@ function buildPm2StartArgs({ scriptPath, port, dataDir }) {
     'none',
     '--max-restarts',
     String(HARDENED_DEFAULTS.maxRestarts),
-    // `--min-uptime` makes `--max-restarts` count only RAPID failures
-    // (process crashed within N ms of starting). Healthy long-uptime
-    // crashes don't burn the budget.
-    '--min-uptime',
-    String(HARDENED_DEFAULTS.minUptimeMs),
+    // NOTE: pm2 ≥ 6.0 dropped `--min-uptime` from the CLI surface — passing
+    // it produces `error: unknown option --min-uptime` and aborts the
+    // install. The flag still works inside an ecosystem file, but per the
+    // canonical-pm2-supervision wish we keep `pgserve install` as a pure
+    // CLI flow (no extra files for operators to manage). The trade-off is
+    // that `--max-restarts` now counts every restart (rapid or not) rather
+    // than only sub-`min_uptime` ones; the budget of 50 above is sized
+    // accordingly.
     '--restart-delay',
     String(HARDENED_DEFAULTS.restartDelayMs),
     // Exponential backoff between successive failures: starts at 100ms,

--- a/tests/cli-install.test.js
+++ b/tests/cli-install.test.js
@@ -124,7 +124,12 @@ describe('pgserve install', () => {
     expect(startCall).toContain('pgserve');
     expect(startCall).toContain('--max-restarts');
     expect(startCall).toContain('50');
-    expect(startCall).toContain('--min-uptime');
+    // pm2 ≥ 6.0 dropped `--min-uptime` from the CLI surface — it now lives
+    // only inside ecosystem files. Passing it on the command line aborts
+    // `pm2 start` with `error: unknown option --min-uptime`. Lock that out:
+    // `pgserve install` must NOT pass `--min-uptime` so it stays compatible
+    // across pm2 5.x → 6.x. See cli-install.cjs:HARDENED_DEFAULTS.
+    expect(startCall).not.toContain('--min-uptime');
     expect(startCall).toContain('--exp-backoff-restart-delay');
     expect(startCall).toContain('--max-memory-restart');
     expect(startCall).toContain('4G');


### PR DESCRIPTION
## Summary

`pgserve install` was rejected by pm2 ≥ 6.0 because it passes `--min-uptime` on the CLI, which pm2 6.x dropped. Live repro on `pm2@6.0.14`:

\`\`\`
$ pgserve install
  error: unknown option \`--min-uptime'
pgserve: pm2 start failed (exit 1)
\`\`\`

Found while running \`omni doctor --fix\` on a server preparing for the canonical-pgserve migration — every install attempt aborted, blocking adoption of the canonical model.

## Fix

Drop the \`--min-uptime\` flag and its argument from \`buildPm2StartArgs\`. Per the canonical-pm2-supervision wish, \`pgserve install\` is a pure CLI flow (no ecosystem files); the alternative — moving \`min_uptime\` into an ecosystem file — would force operators to manage another file just to get install working.

Trade-off: \`--max-restarts\` now counts every restart, not just rapid (sub-\`min_uptime\`) ones. The pinned budget of \`50\` is generous enough to absorb occasional long-uptime crashes — if you ever observe budget exhaustion from non-rapid crashes, raise \`maxRestarts\` rather than reintroducing \`--min-uptime\`. The HARDENED_DEFAULTS comment block documents this so the next person doesn't put it back.

## Test plan

- [x] \`bun test tests/cli-install.test.js\` — 15/15 pass
- [x] Live repro on pm2 6.0.14: \`pgserve uninstall && pgserve install\` exits 0
- [x] \`pgserve status\` shows the registered process
- [x] Test now asserts \`--min-uptime\` is NOT in the args (locks out the regression)

## Notes

- Compatible with pm2 5.x and 6.x — the dropped flag was only meaningful pre-6.0.
- No data-dir or config changes; existing \`~/.pgserve/config.json\` is untouched.
- Companion fix on the omni side (already on \`fix/canonical-pgserve-migration-bugs\`) handles the rest of the canonical migration: stops omni-api before \`pgserve install\` so port 8432 is free, captures real stderr, prevents cli-key-valid cascade.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated pm2 installation configuration for compatibility with version 6.0 and later.

* **Bug Fixes**
  * Modified restart counting to track all restart attempts rather than rapid restarts only. Adjust `maxRestarts` configuration values as needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->