### PR TITLE
fix(install): drop --min-uptime — flag removed in pm2 6.x

### DIFF
--- a/src/cli-install.cjs
+++ b/src/cli-install.cjs
@@ -47,8 +47,10 @@ const DEFAULT_PORT = 8432;
  * Revised defaults:
  *   - 4G memory ceiling — covers realistic load while still bounded so
  *     a runaway query can't eat the host.
- *   - 50 max restarts BUT only counted when min_uptime < 10s ("rapid"
- *     failures). Healthy long-uptime crashes don't count against the cap.
+ *   - 50 max restarts. (Original design used `--min-uptime` to filter
+ *     "rapid failures only", but pm2 6.x dropped that CLI flag — so the
+ *     budget now counts every restart. Combined with exp-backoff below,
+ *     the host is still protected from runaway loops.)
  *   - Exponential backoff on repeated failures (100ms → 60s) so we don't
  *     hammer on persistent issues.
  *   - 60s graceful shutdown window — Postgres needs time to flush WAL.
@@ -62,7 +64,6 @@ const DEFAULT_PORT = 8432;
  */
 const HARDENED_DEFAULTS = {
   maxRestarts: 50,
-  minUptimeMs: 10_000,
   restartDelayMs: 4000,
   expBackoffRestartDelayMs: 100,
   // pm2 caps `--exp-backoff-restart-delay` ramp at the current backoff
@@ -149,11 +150,14 @@ function buildPm2StartArgs({ scriptPath, port, dataDir }) {
     'none',
     '--max-restarts',
     String(HARDENED_DEFAULTS.maxRestarts),
-    // `--min-uptime` makes `--max-restarts` count only RAPID failures
-    // (process crashed within N ms of starting). Healthy long-uptime
-    // crashes don't burn the budget.
-    '--min-uptime',
-    String(HARDENED_DEFAULTS.minUptimeMs),
+    // NOTE: `--min-uptime` was dropped from pm2's CLI flag set in pm2 6.x.
+    // Passing it makes `pm2 start` exit with `unknown option '--min-uptime'`,
+    // which broke `pgserve install` against pm2@^6.0 (live failure on
+    // 2026-04-30). min_uptime is still supported via ecosystem.config.js
+    // JSON form, but not as a CLI flag. For our supervision profile
+    // (max-restarts=50 + exp-backoff), losing the rapid-failure-only filter
+    // means the restart budget burns slightly faster on long-uptime
+    // crashes — acceptable.
     '--restart-delay',
     String(HARDENED_DEFAULTS.restartDelayMs),
     // Exponential backoff between successive failures: starts at 100ms,

--- a/tests/cli-install.test.js
+++ b/tests/cli-install.test.js
@@ -124,7 +124,10 @@ describe('pgserve install', () => {
     expect(startCall).toContain('pgserve');
     expect(startCall).toContain('--max-restarts');
     expect(startCall).toContain('50');
-    expect(startCall).toContain('--min-uptime');
+    // `--min-uptime` was removed in pm2 6.x — see cli-install.cjs comment.
+    // Asserting NEGATIVELY ensures we don't reintroduce the flag and break
+    // pgserve install on pm2@^6.0 again.
+    expect(startCall).not.toContain('--min-uptime');
     expect(startCall).toContain('--exp-backoff-restart-delay');
     expect(startCall).toContain('--max-memory-restart');
     expect(startCall).toContain('4G');


### PR DESCRIPTION
## Summary

`pgserve install` is broken on `pm2@^6.0` — it passes `--min-uptime <ms>` to `pm2 start`, but pm2 6.x dropped that CLI flag.

Live failure on 2026-04-30:
```
$ pgserve install
  error: unknown option `--min-uptime'
pgserve: pm2 start failed (exit 1)
```

Caught while running `omni doctor --fix` (which shells `pgserve install` to migrate omni from embedded to canonical pgserve). `pgserve install` exited non-zero, the migration aborted, and the operator was left with `omni doctor` reporting `pgserve-canonical: WARN`.

## Fix

Drop `--min-uptime` from `buildPm2StartArgs` in `src/cli-install.cjs`. Also drop the now-unused `minUptimeMs: 10_000` from `HARDENED_DEFAULTS`. Update the doc comment to explain why.

`min_uptime` is still supported by pm2 via `ecosystem.config.js` JSON form — it's just not a CLI flag anymore. For pgserve's profile (max-restarts=50 + exp-backoff 100ms → 60s), losing the rapid-failure-only filter just means the restart budget burns slightly faster on long-uptime crashes. Combined with exp-backoff, the host is still protected from runaway loops.

## Tests

- `tests/cli-install.test.js` — the assertion flipped from `expect(startCall).toContain('--min-uptime')` to `expect(startCall).not.toContain('--min-uptime')` so we don't accidentally reintroduce it.
- 15/15 pgserve tests pass.
- Linter clean.

## Validated live

Fresh `pgserve install` against pm2 6.0.14 (the broken case) now succeeds; pm2 list shows `pgserve` as a managed process on port 8432.

## Why this matters

This is a cross-repo blocker. The canonical-pgserve-pm2-supervision wish (Wave 1 = this repo, Wave 2 = `automagik-dev/genie`, Wave 3 = `automagik-dev/omni`) all hinged on `pgserve install` actually working. Until this lands, no fresh install or `omni doctor --fix` can complete on hosts with pm2@^6.0.

Genie has the same bug in its own `pm2 start` args (filed separately).
