### PR TITLE
fix(install): launch foreground multi-tenant mode, not daemon mode

### DIFF
--- a/src/cli-install.cjs
+++ b/src/cli-install.cjs
@@ -179,7 +179,24 @@ function buildPm2StartArgs({ scriptPath, port, dataDir }) {
     '--error',
     logs.error,
     '--',
-    'daemon',
+    // Foreground multi-tenant mode (`pgserve [options]`), NOT daemon mode.
+    //
+    // Daemon mode binds a unix control socket and requires libpq peers to
+    // authenticate via a fingerprint+token handshake (`pgserve daemon
+    // issue-token`). Downstream services that connect with a plain
+    // `postgres://` URL (omni, genie, anything that doesn't speak the
+    // fingerprint protocol) cannot reach a daemon-mode listener. We also
+    // observed live: `pgserve install` was passing `--port` to the daemon
+    // parser, which only accepts `--data | --ram | --log | --no-provision
+    // | --listen | --pgvector` — every install attempt crashed with
+    // `Unknown daemon option: --port` and pm2 burned its restart budget.
+    //
+    // Foreground mode (the default `pgserve [options]` invocation in
+    // postgres-server.js) accepts `--port`, auto-provisions databases on
+    // first connect, runs the cluster on multi-core hosts, and binds TCP
+    // on `127.0.0.1:<port>` with no auth dance — exactly what canonical
+    // pgserve consumers expect. Pass the same flags pgserve already
+    // documents in its own `pgserve --help` output.
     '--port',
     String(port),
     '--data',

--- a/tests/cli-install.test.js
+++ b/tests/cli-install.test.js
@@ -137,6 +137,22 @@ describe('pgserve install', () => {
     expect(startCall).toContain('60000');
     expect(startCall).toContain('--interpreter');
     expect(startCall).toContain('none');
+
+    // pgserve install must launch the foreground multi-tenant server, NOT
+    // the daemon. Daemon mode rejects `--port` (it only accepts --data,
+    // --ram, --log, --no-provision, --listen, --pgvector) and its TCP
+    // listeners require fingerprint+token auth which downstream services
+    // (omni, genie) don't speak. Foreground mode binds plain TCP on
+    // 127.0.0.1:<port> with auto-provisioning. Lock that out:
+    expect(startCall).not.toContain('daemon');
+    // The script-arg handover (after `--`) must include `--port` so the
+    // foreground parser binds the right TCP port.
+    const dashDashIdx = startCall.indexOf('--');
+    const scriptArgs = startCall.slice(dashDashIdx + 1);
+    expect(scriptArgs).toContain('--port');
+    expect(scriptArgs).toContain('--data');
+    expect(scriptArgs).toContain('--log');
+    expect(scriptArgs).not.toContain('daemon');
   });
 
   test('second install is idempotent (no second pm2 start)', () => {


### PR DESCRIPTION
## Summary

\`pgserve install\` was passing \`daemon\` as the subcommand and \`--port <N>\` as a flag, but \`bin/postgres-server.js\` \`parseDaemonArgs()\` doesn't accept \`--port\`. Every install attempt crashed in a tight pm2 restart loop:

\`\`\`
$ pgserve install
$ tail ~/.pgserve/logs/pgserve-error.log
Unknown daemon option: --port
Unknown daemon option: --port
...
\`\`\`

Reproduced live during a canonical-pgserve migration on a server with \`@automagik/omni@2.260430.15\`. After fixing the \`--min-uptime\` bug from #59, this second bug surfaced immediately — pm2 burned through restarts in ~16s and the migration aborted.

## Why daemon mode is the wrong target

Beyond the parser mismatch, daemon mode requires fingerprint+token auth on its TCP listeners (\`pgserve daemon issue-token\`). Downstream services like omni and genie connect with plain \`postgres://...\` URLs and have no way to mint or pass a daemon token, so even a "fixed" daemon mode wouldn't accept their connections.

Foreground multi-tenant mode (\`pgserve [options]\` — the default fall-through in postgres-server.js) is what canonical install actually wants:
- Accepts \`--port\` directly (plus \`--data\`, \`--host\`, \`--log\`, etc.)
- Auto-provisions databases on first connect
- Cluster mode on multi-core hosts via SO_REUSEPORT
- Plain TCP bind on \`127.0.0.1:<port>\` — no auth dance

## Fix

Drop the literal \`daemon\` arg from \`buildPm2StartArgs\`. Args after \`--\` flow into the foreground parser which handles \`--port\` correctly.

## Test plan

- [x] \`bun test tests/cli-install.test.js\` — 15/15 pass (60 → 65 expect calls; 5 new assertions lock out daemon-mode regression and verify the foreground arg shape)
- [x] **Live verification on pm2 6.0.14:**
  \`\`\`
  $ pgserve install
  pgserve: installed: pm2 process \"pgserve\" on port 8432 (data: /home/genie/.pgserve/data)
  pgserve: url: postgres://localhost:8432/postgres

  $ pgserve status
  status      online (pid 2303471)
  port        8432
  restarts    0
  \`\`\`
  32 cluster workers all bound to 127.0.0.1:8432.

## Companion PR

Pairs with **#59** (\`drop --min-uptime CLI flag\`). Either can land first, but **both must land** for \`pgserve install\` to actually work end-to-end on pm2 6.x.

## What's still missing for full canonical adoption

This PR makes \`pgserve install\` work. It does **not** cover **data migration** for consumers that already have data in their embedded pgserve. Specifically: omni's \`omni doctor --fix\` only flips the \`databaseUrl\` config when migrating to canonical — it doesn't \`pg_dump\` from the embedded data dir into the canonical one. Operators with existing data hit an empty database after migration. Will be filed as a separate omni-side issue.