### PR TITLE
fix(install): drop `daemon` arg — pm2-supervised pgserve must run TCP mode

### DIFF
--- a/src/cli-install.cjs
+++ b/src/cli-install.cjs
@@ -179,7 +179,13 @@ function buildPm2StartArgs({ scriptPath, port, dataDir }) {
     '--error',
     logs.error,
     '--',
-    'daemon',
+    // NOTE: do NOT pass `daemon` here. `pgserve daemon` is the singleton
+    // Unix-socket mode (different argv parser, only accepts --data/--ram/
+    // --log/--listen/--pgvector — NOT --port). The canonical pm2-supervised
+    // pgserve must listen on TCP so omni/genie can connect via DATABASE_URL,
+    // which is the legacy multi-tenant mode (no subcommand). Caught live
+    // 2026-04-30: passing `daemon --port 8432` triggered "Unknown daemon
+    // option: --port" in a restart loop.
     '--port',
     String(port),
     '--data',

--- a/tests/cli-install.test.js
+++ b/tests/cli-install.test.js
@@ -130,6 +130,14 @@ describe('pgserve install', () => {
     // `pgserve install` must NOT pass `--min-uptime` so it stays compatible
     // across pm2 5.x → 6.x. See cli-install.cjs:HARDENED_DEFAULTS.
     expect(startCall).not.toContain('--min-uptime');
+    // The script args MUST be the legacy multi-tenant TCP mode (no subcommand),
+    // not `daemon` (Unix-socket singleton — no --port support). Asserting
+    // negatively guards against a regression: the previous code was
+    // `pm2 start ... -- daemon --port N --data ...`, which crashed at boot
+    // with "Unknown daemon option: --port". See cli-install.cjs comment.
+    expect(startCall).not.toContain('daemon');
+    expect(startCall).toContain('--port');
+    expect(startCall).toContain('8432');
     expect(startCall).toContain('--exp-backoff-restart-delay');
     expect(startCall).toContain('--max-memory-restart');
     expect(startCall).toContain('4G');


### PR DESCRIPTION
## Summary

**`pgserve install` registers pgserve in the wrong mode.** It builds:

```
pm2 start <script> ... -- daemon --port 8432 --data ~/.pgserve/data --log warn
```

…but `pgserve daemon` is the singleton Unix-socket mode (introduced in 2.1.0). Its argv parser only accepts `--data`, `--ram`, `--log`, `--listen`, `--pgvector` — **not `--port`**. The result: pm2 starts the process, the daemon parser sees `--port`, prints `Unknown daemon option: --port` and exits 1, pm2 restarts, infinite loop, canonical pgserve never serves anything.

Caught live on 2026-04-30 while running `omni doctor --fix` to migrate this server from embedded → canonical pgserve. After #60 fixed the `--min-uptime` regression, the next bug surfaced — pm2 logs:

```
25|pgserve | Unknown daemon option: --port
25|pgserve | Unknown daemon option: --port    (×11 restarts in 8s)
```

## Fix

Drop `daemon` from the trailing args. `pgserve` with no subcommand runs the legacy multi-tenant TCP server, which:
- Listens on `--port <n>` (canonical 8432) ✓
- Auto-provisions databases on first connection ✓
- Is what omni-api / genie-serve actually need (DATABASE_URL → TCP)

The Unix-socket `daemon` mode is for high-density single-host workloads that authenticate via fingerprint+token — different use case, not what the canonical-pgserve-pm2 wish targeted.

## Tests

Added negative assertions to `tests/cli-install.test.js`:
- install args **MUST NOT** contain `daemon` (regression guard)
- install args **MUST** contain `--port 8432`

15/15 tests pass. Linter clean.

## Validated live

After applying this fix locally + `pgserve install`:

```
$ pgserve install
pgserve: installed: pm2 process "pgserve" on port 8432

$ ss -tln | grep 8432
LISTEN 0 ...    127.0.0.1:8432    ...

$ pm2 list
│ pgserve  │ online │ ...
```

Then `omni doctor --fix` completed end-to-end with `pgserve-canonical: ✓`.

## Wave context

This is the second post-#57 patch (after #60 dropped `--min-uptime`) needed to make canonical pm2 supervision actually work in production. Once this lands and 2.1.2 publishes, both omni and genie can rely on `pgserve install` as the canonical bootstrap step.
