### PR TITLE
fix(daemon): accept --max-connections (was rejected as Unknown option)

### DIFF
--- a/bin/postgres-server.js
+++ b/bin/postgres-server.js
@@ -132,6 +132,7 @@ function parseDaemonArgs(daemonArgs) {
     autoProvision: true,
     tcpListens: [],
     enablePgvector: false,
+    maxConnections: null,
   };
   for (let i = 0; i < daemonArgs.length; i++) {
     const arg = daemonArgs[i];
@@ -156,6 +157,21 @@ function parseDaemonArgs(daemonArgs) {
       case '--pgvector':
         opts.enablePgvector = true;
         break;
+      case '--max-connections': {
+        // Accept the same flag the foreground/router mode takes so callers
+        // (genie's `getOrStartDaemon`, anything that spawns `pgserve daemon`
+        // with a tuned cap) can override the postmaster's `max_connections`.
+        // The `PgserveDaemon` constructor already honors `options.maxConnections`
+        // (see src/daemon.js — defaults to 1000); we just plumb it through.
+        const raw = daemonArgs[++i];
+        const parsed = Number.parseInt(raw, 10);
+        if (!Number.isFinite(parsed) || parsed <= 0) {
+          console.error(`--max-connections: expected a positive integer, got "${raw}"`);
+          process.exit(1);
+        }
+        opts.maxConnections = parsed;
+        break;
+      }
       case '--help':
         console.log(`
 pgserve daemon — singleton control-socket mode
@@ -167,13 +183,14 @@ USAGE:
   pgserve daemon revoke-token <id>
 
 OPTIONS:
-  --data <path>   Persistent data directory (default: in-memory)
-  --ram           Use /dev/shm storage (Linux only)
-  --log <level>   Log level: error|warn|info|debug (default: info)
-  --no-provision  Disable auto-provisioning of databases
-  --listen [host:]port  Bind opt-in TCP listener (repeatable)
-  --pgvector      Auto-enable pgvector extension on new databases
-  --help          Show this help
+  --data <path>          Persistent data directory (default: in-memory)
+  --ram                  Use /dev/shm storage (Linux only)
+  --log <level>          Log level: error|warn|info|debug (default: info)
+  --no-provision         Disable auto-provisioning of databases
+  --listen [host:]port   Bind opt-in TCP listener (repeatable)
+  --pgvector             Auto-enable pgvector extension on new databases
+  --max-connections <n>  Override the postmaster's max_connections (default: 1000)
+  --help                 Show this help
 
 The daemon binds $XDG_RUNTIME_DIR/pgserve/control.sock (fallback /tmp/pgserve/control.sock).
 A second invocation while the first is running exits with "already running".

--- a/tests/daemon-args.test.js
+++ b/tests/daemon-args.test.js
@@ -1,0 +1,86 @@
+/**
+ * Integration tests for `pgserve daemon` argv parsing.
+ *
+ * `parseDaemonArgs` lives inside `bin/postgres-server.js` (the script
+ * entry point) and isn't exported, so we exercise it via subprocess
+ * invocations of the wrapper. Each test runs in <100ms — they only ask
+ * the daemon to print help or reject an invalid argument; no real
+ * postgres backend is started.
+ *
+ * Background: every recent CLI-flag mismatch between callers and
+ * `pgserve daemon` exited the daemon child with code 1 immediately,
+ * surfacing upstream as the unhelpful "pgserve v2 daemon exited before
+ * binding …" error. These tests pin the daemon's accepted flag set
+ * explicitly so the next mismatch fails CI here, not at runtime.
+ */
+
+import { spawnSync } from 'node:child_process';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, test } from 'bun:test';
+
+const REPO_ROOT = join(fileURLToPath(import.meta.url), '..', '..');
+const PGSERVE_BIN = join(REPO_ROOT, 'bin', 'pgserve-wrapper.cjs');
+
+function runDaemon(args, timeoutMs = 3000) {
+  return spawnSync('node', [PGSERVE_BIN, 'daemon', ...args], {
+    encoding: 'utf-8',
+    timeout: timeoutMs,
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+}
+
+describe('pgserve daemon — argv parser', () => {
+  test('--help lists every flag the daemon accepts', () => {
+    const result = runDaemon(['--help']);
+    expect(result.status).toBe(0);
+    const help = result.stdout;
+    // Every flag the parser accepts must appear in --help so callers
+    // (and the next operator running `pgserve daemon --help`) discover them.
+    expect(help).toContain('--data');
+    expect(help).toContain('--ram');
+    expect(help).toContain('--log');
+    expect(help).toContain('--no-provision');
+    expect(help).toContain('--listen');
+    expect(help).toContain('--pgvector');
+    expect(help).toContain('--max-connections');
+    expect(help).toContain('--help');
+  });
+
+  test('--max-connections accepts a positive integer (no "Unknown option" error)', () => {
+    // Use a bogus --data path so the daemon never actually starts postgres
+    // — the parser runs, accepts --max-connections, then PgserveDaemon
+    // tries to start and fails on the missing/invalid data dir. We only
+    // care that the parser doesn't reject the flag.
+    const result = runDaemon(['--data', '/nonexistent/pgserve-test-dir', '--max-connections', '5000', '--log', 'error']);
+    // The daemon may exit non-zero because the data dir is invalid, but
+    // it MUST NOT exit with "Unknown daemon option" — that's the
+    // pre-fix behavior we're guarding against.
+    const stderr = result.stderr ?? '';
+    expect(stderr).not.toContain('Unknown daemon option: --max-connections');
+  });
+
+  test('--max-connections rejects non-numeric values with a clear error', () => {
+    const result = runDaemon(['--max-connections', 'abc']);
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('--max-connections: expected a positive integer');
+  });
+
+  test('--max-connections rejects zero / negative values', () => {
+    const zero = runDaemon(['--max-connections', '0']);
+    expect(zero.status).toBe(1);
+    expect(zero.stderr).toContain('--max-connections: expected a positive integer');
+
+    const negative = runDaemon(['--max-connections', '-50']);
+    expect(negative.status).toBe(1);
+    expect(negative.stderr).toContain('--max-connections: expected a positive integer');
+  });
+
+  test('unknown flags still exit 1 with the documented "Unknown daemon option" error', () => {
+    // Sanity: the parser hasn't become permissive. Genuinely unknown
+    // flags must still error out so callers learn about the mismatch.
+    const result = runDaemon(['--definitely-not-a-flag']);
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('Unknown daemon option: --definitely-not-a-flag');
+  });
+});


### PR DESCRIPTION
Third in the family of CLI-flag mismatches between callers and `pgserve daemon` (after #59 dropping `--min-uptime` and #62 fixing foreground-vs-daemon mode in `pgserve install`).

## Reproduction

genie's `getOrStartDaemon` ([db.ts in `automagik-dev/genie@4.260501.2`](https://github.com/automagik-dev/genie)) spawns the daemon with `--max-connections 10000` so the postmaster's connection ceiling matches the workload cap. But `bin/postgres-server.js`'s `parseDaemonArgs` only accepted `--data | --ram | --log | --no-provision | --listen | --pgvector | --help` — `--max-connections` fell through the default branch and exited 1.

Live on a server running pgserve@2.1.2 + genie@4.260501.2:

```
$ genie events list
Error: pgserve v2 daemon exited before binding
/run/user/1000/pgserve/.s.PGSQL.5432 (exit code 1).
Try starting it manually: pgserve daemon --data ~/.genie/data/pgserve --log warn

$ pgserve daemon --max-connections 10000
Unknown daemon option: --max-connections
```

Every `genie` invocation (events list, task list, agent ls) hit this. `genie-serve` (the long-lived pm2 process) gave up retrying after the first spawn failure and started logging:

```
[emit] flush failed: pgserve daemon unavailable and PG autostart is disabled (requeued 113/113)
```

## Fix

The `PgserveDaemon` constructor (`src/daemon.js:229`) already honors `options.maxConnections` (defaults to 1000); only the CLI parser was missing. Patch threads the value through via `opts.maxConnections`, validates it as a positive integer, and documents the flag in `--help`.

```diff
+      case '--max-connections': {
+        const raw = daemonArgs[++i];
+        const parsed = Number.parseInt(raw, 10);
+        if (!Number.isFinite(parsed) || parsed <= 0) {
+          console.error(`--max-connections: expected a positive integer, got "${raw}"`);
+          process.exit(1);
+        }
+        opts.maxConnections = parsed;
+        break;
+      }
```

## Test plan

New `tests/daemon-args.test.js` (5 tests, 18 expects):

- `--help` advertises every accepted flag (regression guard against the next mismatch landing silently)
- `--max-connections <n>` accepts a valid integer — does NOT print "Unknown daemon option"
- `--max-connections <non-numeric>` exits 1 with `expected a positive integer`
- `--max-connections 0` and `--max-connections -50` both exit 1 with the same error
- Genuinely unknown flags still emit `Unknown daemon option: <flag>` so the parser hasn't become permissive

```
bun test tests/daemon-args.test.js
 5 pass, 0 fail, 18 expect() calls
```

Full suite:
```
bun test tests/
 135 pass, 0 fail, 411 expect() calls
```

Verified live by patching the global install and re-running:

```
$ genie events list
[pgserve] connected to postgres
Time    | Type | ...
$ genie task list
[pgserve] connected to postgres
  # 5  Group 4: server cutover ...
$ genie agent ls
[pgserve] connected to postgres
NAME ...
```

## Companion fixes

This closes the loop on the three pgserve install/daemon flag mismatches that surfaced during the canonical-pgserve rollout on this server:

- #59 (merged) — `pgserve install` was passing `--min-uptime` to pm2 6.x which dropped it
- #62 (merged) — `pgserve install` was launching `daemon` mode but the parser rejected `--port`; switched to foreground TCP mode
- **this PR** — `pgserve daemon` itself was rejecting `--max-connections` that genie passes

After this lands, every flag the daemon's documented callers (genie spawn, install, manual operators) want to set is wired through the CLI surface.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--max-connections` flag for daemon mode to configure maximum database connections (default: 1000). The flag validates input as a positive integer and provides clear error messages for invalid values.

* **Tests**
  * Added comprehensive integration tests for daemon CLI argument parsing. Tests verify all flags are properly documented, validate expected inputs, and handle errors appropriately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->