### PR TITLE
feat(upgrade): autopg upgrade command + postinstall auto-wire

### DIFF
--- a/.genie/wishes/autopg-upgrade-command/WISH.md
+++ b/.genie/wishes/autopg-upgrade-command/WISH.md
@@ -1,0 +1,177 @@
+# Wish: autopg upgrade — transparent flush + auto-postinstall
+
+| Field | Value |
+|-------|-------|
+| **Status** | DRAFT |
+| **Slug** | `autopg-upgrade-command` |
+| **Date** | 2026-05-03 |
+| **Author** | Felipe Rosa (via felipe agent, dogfooding live break) |
+| **Appetite** | small (~1 engineer-day) |
+| **Branch** | `wish/autopg-upgrade-command` |
+| **Design** | _No brainstorm — direct wish_ |
+| **Predecessor** | [autopg-v22 wish](../autopg-v22/WISH.md) (DRAFT — partial ship caused live break) |
+
+## Summary
+
+Add `autopg upgrade` — an idempotent CLI command that transparently migrates an autopg installation across versions (port reconciliation, binary cache flush, plpgsql `.so` re-resolve, env file refresh, consumer reconnect signal). Wire it into the npm postinstall hook so users running `bun add @automagik/autopg@latest` get zero-touch migration. Restores the `autopg ships → consumer transparently picks up next install` contract that broke when autopg-v22's partial roll-out moved binaries to `~/.autopg/`, defaulted PG to port 9432, and stranded plpgsql extension references against the old `$libdir`.
+
+## Scope
+
+### IN
+
+- New CLI verb `autopg upgrade` in `bin/autopg-cli.js` (idempotent, safe to re-run)
+- Step 1 — port reconciliation: detect running pgserve on port != 8432 → stop, relaunch on 8432, update `postmaster.pid`
+- Step 2 — binary cache flush: verify `~/.autopg/bin/<platform>/postgres` exists and matches `PINNED_PG_VERSION`; if drift, re-download (extends `migrateLegacyBinaryCache` from commit 0075c4f)
+- Step 3 — plpgsql extension re-resolve: per DB in data dir, `DROP EXTENSION plpgsql; CREATE EXTENSION plpgsql;` to force fresh `.so` path lookup against current `$libdir`
+- Step 4 — app env refresh: regenerate `~/.autopg/<name>.env` URLs with new port; verify SCRAM credential still valid (rotate only if config drift detected)
+- Step 5 — consumer reconnect signal: emit a sentinel (touch `~/.autopg/state/upgrade.signal` with timestamp) that consumers (omni-api, genie-serve) can watch via fs.watch and respond with `pm2 restart self`
+- Step 6 — health validation: `pg_isready` on 8432 + `LOAD 'plpgsql'` smoke test in each DB; report PASS/FAIL summary
+- Default port hardcode change in `bin/postgres-server.js`: 9432 → 8432 (preserves user contract from pgserve@2.1.x where consumers configured 8432)
+- Postinstall wire in `package.json`: add `"postinstall": "node scripts/postinstall.cjs"`
+- `scripts/postinstall.cjs` implementation: detect upgrade vs fresh install (existence of `~/.autopg/data/`); on upgrade run `node bin/autopg-cli.js upgrade --quiet`; soft-fail (warn + exit 0) so `bun install` never breaks
+- Integration tests: fresh install path (no upgrade triggered), upgrade path from synthetic 2.1.3 state (binary in `~/.pgserve/bin/`, port 8432 expected) to 2.2.x, no-op path (already on 8432, no drift)
+- CHANGELOG.md entry naming the contract: "users upgrading from pgserve@2.1.3 → autopg@2.2.x get transparent migration via postinstall; manual `autopg upgrade` is the explicit escape hatch"
+
+### OUT
+
+- Implementing `autopg create-app` for omni/genie consumer migration (covered by `autopg-v22` wish; this wish only handles the transparent-upgrade primitive)
+- Migration of brain, rlmx, hapvida-eugenia, email consumers (per-app wishes after v2.2 ships)
+- Multi-host coordination (single-host UID-trust scope per autopg-v22 D3)
+- Web dashboard for upgrade history (deferred)
+- Rollback command (`autopg downgrade`) — out of scope; users keep snapshot via `autopg backup` if needed
+- Modifying drizzle migrations or app-level schema (autopg upgrade only touches PG-internals + binary paths)
+
+## Decisions
+
+| # | Decision | Rationale |
+|---|----------|-----------|
+| 1 | Default port stays 8432 | Felipe directive: "no hardcode that breaks user contract — 8432 as always" |
+| 2 | Postinstall auto-runs `autopg upgrade` on detected upgrade | Felipe directive: "next version post script update will run it" — zero-touch UX |
+| 3 | Postinstall soft-fails (warn + exit 0) | `bun install` must never break for downstream consumers; explicit `autopg upgrade` is escape hatch |
+| 4 | DROP+CREATE plpgsql per DB to re-resolve `.so` | Schema metadata pins absolute path; only DROP/CREATE forces re-lookup against current `$libdir` |
+| 5 | Consumer reconnect via fs.watch sentinel | Avoids tight coupling — autopg doesn't know which consumers exist; consumers opt in by watching the signal file |
+| 6 | All steps idempotent | `autopg upgrade` safe to re-run any number of times; cron-friendly |
+
+## Success Criteria
+
+- [ ] `autopg upgrade` runs end-to-end on a synthetic pgserve@2.1.3 state and leaves system functional (port 8432, plpgsql working, env files current)
+- [ ] `autopg upgrade` is no-op (exit 0, < 1s) on already-upgraded system
+- [ ] `bun add @automagik/autopg@latest` triggers postinstall which runs `autopg upgrade --quiet` invisibly
+- [ ] `bun install` succeeds even if `autopg upgrade` errors (soft-fail with warning)
+- [ ] After upgrade: `pg_isready -p 8432` returns OK in any DB AND `psql -c "LOAD 'plpgsql'"` succeeds in every public DB
+- [ ] After upgrade: omni-api (configured for 8432) reconnects without manual `pm2 restart` once consumer-side fs.watch lands
+- [ ] CHANGELOG names the upgrade contract explicitly
+- [ ] All 3 integration tests pass (fresh install, 2.1.3 → 2.2.x upgrade, no-op)
+
+## Execution Strategy
+
+Single wave, sequential — small enough scope that parallelization adds coordination overhead without shipping speed. Engineer implements all 3 groups, validates locally on dogfood machine (Felipe's box currently reproducing the break), opens PR.
+
+| Group | Agent | Description |
+|-------|-------|-------------|
+| 1 | engineer | Implement `autopg upgrade` CLI verb with all 6 steps |
+| 2 | engineer | Wire postinstall hook + soft-fail handling |
+| 3 | qa | Integration tests + CHANGELOG entry + lint pass |
+
+---
+
+## Execution Groups
+
+### Group 1: `autopg upgrade` CLI verb implementation
+**Goal:** Add idempotent `autopg upgrade` command in `bin/autopg-cli.js` that executes 6-step transparent migration sequence.
+
+**Deliverables:**
+1. `bin/autopg-cli.js` — register `upgrade` subcommand with `--quiet` and `--dry-run` flags
+2. `src/upgrade/index.js` — orchestrator running steps 1-6 in order with structured logging
+3. `src/upgrade/steps/port-reconcile.js` — stop pgserve if not on 8432, relaunch on 8432
+4. `src/upgrade/steps/binary-cache-flush.js` — extends existing `migrateLegacyBinaryCache` to verify version + re-download on drift
+5. `src/upgrade/steps/plpgsql-resolve.js` — for each user DB, run `DROP EXTENSION plpgsql; CREATE EXTENSION plpgsql;`
+6. `src/upgrade/steps/env-refresh.js` — regenerate `~/.autopg/<app>.env` with current port + validate SCRAM
+7. `src/upgrade/steps/consumer-signal.js` — write `~/.autopg/state/upgrade.signal` with epoch timestamp
+8. `src/upgrade/steps/health-validate.js` — `pg_isready` + per-DB plpgsql smoke test
+9. Default port change in `bin/postgres-server.js`: 9432 → 8432
+
+**Acceptance Criteria:**
+- [ ] `autopg upgrade --dry-run` prints planned steps without executing
+- [ ] `autopg upgrade` exits 0 on already-upgraded system in <1s (idempotent no-op)
+- [ ] `autopg upgrade` after synthetic 2.1.3 state migrates to 2.2.x state successfully
+- [ ] Each step logs `[step-name] OK|SKIP|FAIL: <detail>` to stderr
+- [ ] All 6 steps individually unit-tested
+
+**Validation:**
+```bash
+cd /home/genie/workspace/repos/pgserve && \
+  bun test src/upgrade/ && \
+  ./bin/autopg-cli.js upgrade --dry-run
+```
+
+**depends-on:** none
+
+### Group 2: Postinstall hook + soft-fail wire
+**Goal:** Auto-run `autopg upgrade --quiet` on `bun install` of new autopg version, never breaking install if upgrade fails.
+
+**Deliverables:**
+1. `scripts/postinstall.cjs` — detect upgrade (existence of `~/.autopg/data/`); skip on fresh install; invoke `node bin/autopg-cli.js upgrade --quiet` with try/catch
+2. `package.json` — add `"postinstall": "node scripts/postinstall.cjs"` script
+3. Soft-fail: any error in `autopg upgrade` → log warning to stderr → exit 0 (do not break `bun install`)
+4. Skip behavior under env override: `AUTOPG_SKIP_POSTINSTALL=1` → exit 0 immediately (CI / containers / install-only flows)
+
+**Acceptance Criteria:**
+- [ ] Fresh install (no `~/.autopg/data/`) → postinstall exits 0 silently, no upgrade attempted
+- [ ] Upgrade install (existing `~/.autopg/data/`) → postinstall calls `autopg upgrade --quiet`
+- [ ] If `autopg upgrade` fails (non-zero exit) → postinstall logs warning + exits 0 (`bun install` succeeds)
+- [ ] `AUTOPG_SKIP_POSTINSTALL=1 bun install` skips invocation entirely
+
+**Validation:**
+```bash
+cd /home/genie/workspace/repos/pgserve && \
+  AUTOPG_SKIP_POSTINSTALL=1 node scripts/postinstall.cjs && echo "skip ok" && \
+  rm -rf /tmp/test-autopg && AUTOPG_CONFIG_DIR=/tmp/test-autopg node scripts/postinstall.cjs && echo "fresh ok"
+```
+
+**depends-on:** Group 1
+
+### Group 3: Integration tests + CHANGELOG + lint
+**Goal:** End-to-end validation that the upgrade contract holds; lock the user-facing promise into CHANGELOG.
+
+**Deliverables:**
+1. `__tests__/integration/upgrade-fresh.test.ts` — fresh install path; postinstall no-op; `autopg upgrade` available as command
+2. `__tests__/integration/upgrade-from-2.1.3.test.ts` — synthetic 2.1.3 state in temp dir → run `autopg upgrade` → assert post-state matches 2.2.x expectations (port 8432, binary in `~/.autopg/bin/`, plpgsql works)
+3. `__tests__/integration/upgrade-noop.test.ts` — already-upgraded state; assert `autopg upgrade` exits 0 in <1s with all steps reporting SKIP
+4. `CHANGELOG.md` entry under `## v2.2.x — Transparent Upgrade` with the literal contract sentence: *"Users upgrading from pgserve@2.1.3 to autopg@2.2.x get transparent migration via the postinstall hook. Manual `autopg upgrade` remains as the explicit escape hatch for forced re-runs."*
+
+**Acceptance Criteria:**
+- [ ] All 3 integration tests pass via `bun test __tests__/integration/upgrade-*.test.ts`
+- [ ] CHANGELOG entry present with exact contract sentence
+- [ ] `bun run lint` clean
+- [ ] No regression in existing `bun test` suite
+
+**Validation:**
+```bash
+cd /home/genie/workspace/repos/pgserve && \
+  bun test __tests__/integration/upgrade-*.test.ts && \
+  bun run lint && \
+  grep -F "transparent migration via the postinstall hook" CHANGELOG.md
+```
+
+**depends-on:** Group 2
+
+## Dependencies
+
+- **depends-on:** `pgserve/autopg-v22` (DRAFT — needs the rename + binary cache plumbing in place; this wish patches the upgrade hole left by partial v22 ship)
+- **blocks:** consumer migration wishes for omni, brain, rlmx, etc. (those wait for stable upgrade primitive)
+
+## QA Criteria
+
+After merge to dev:
+1. Felipe's dogfood machine (currently reproducing the break) → `bun add -g @automagik/autopg@latest` → postinstall runs upgrade → `genie agent spawn trace` works again (no plpgsql error)
+2. `omni doctor` reports 11/11 OK without manual config edit
+3. `pm2 ls` shows pgserve still on port 8432 (not 9432)
+4. WhatsApp DM end-to-end test: Felipe sends message → agent responds within turn timeout (no false-stale force-close, validates timestamptz fix from omni#599 plus this upgrade fix together)
+
+## Assumptions / Risks
+
+- **Assumption:** consumers (omni-api, genie-serve) will adopt fs.watch for `~/.autopg/state/upgrade.signal` in a follow-up — until then, manual `pm2 restart` is needed after upgrade. Not a blocker for this wish.
+- **Risk:** DROP+CREATE plpgsql is technically destructive (loses user-defined plpgsql functions if any exist outside drizzle migrations). Mitigation: in step 3, gate on `pg_proc.proowner = 10` (postgres) only; skip non-system DBs containing user-owned plpgsql functions and warn operator.
+- **Risk:** Synthetic 2.1.3 state for tests is approximate — production may have edge cases not covered. Mitigation: dogfood validation on Felipe's box is the canonical test; integration tests are guard-rail.
+- **Risk:** Postinstall running `autopg upgrade` could collide with concurrent pgserve usage. Mitigation: step 1 (port-reconcile) detects running pgserve and uses graceful pg_ctl stop; if can't stop in 30s, soft-fail with operator instruction.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## v2.2.x — Transparent Upgrade
+
+**Added:** `autopg upgrade` CLI verb — idempotent migration runner that reconciles port back to canonical 8432, flushes the binary cache against the pinned PG version, re-resolves the plpgsql `.so` path per database, refreshes `~/.autopg/<app>.env` files, signals consumers, and validates final health.
+
+**Added:** npm `postinstall` hook (`scripts/postinstall.cjs`) auto-runs `autopg upgrade --quiet` when an existing `~/.autopg/data/` is detected on `bun install`. Soft-fails so package install never breaks; manual `autopg upgrade` remains the explicit escape hatch.
+
+**Contract:** Users upgrading from pgserve@2.1.3 to autopg@2.2.x get transparent migration via the postinstall hook. Manual `autopg upgrade` remains as the explicit escape hatch for forced re-runs. Patches the upgrade-path hole left by autopg-v22 partial roll-out (binary moved to `~/.autopg/`, default port silently shifted to 9432, plpgsql extensions referenced stale `$libdir`).
+
+**Override:** Set `AUTOPG_SKIP_POSTINSTALL=1` to bypass the hook (CI / containers / install-only flows).
+
 # Changelog
 
 All notable changes to `pgserve` are documented here. The format follows

--- a/bin/pgserve-wrapper.cjs
+++ b/bin/pgserve-wrapper.cjs
@@ -40,6 +40,7 @@ const __installSubcommands = new Set([
   // pm2 for restart). They don't need bun, so route them BEFORE the bun
   // probe — same rationale as the wave-1 install commands.
   'config',
+  'upgrade',
   'restart',
   'ui',
 ]);

--- a/knip.json
+++ b/knip.json
@@ -1,9 +1,28 @@
 {
   "$schema": "https://unpkg.com/knip@5/schema.json",
-  "entry": ["src/index.js", "bin/postgres-server.js", "bin/pgserve-wrapper.cjs"],
-  "project": ["src/**/*.js", "bin/**/*.js", "bin/**/*.cjs"],
-  "ignore": ["tests/**", "helpers/**", "scripts/**"],
-  "ignoreBinaries": ["scripts/test-npx.sh", "scripts/test-bun-self-heal.sh", "make"],
-  "ignoreDependencies": ["bun"],
+  "entry": [
+    "src/index.js",
+    "bin/postgres-server.js",
+    "bin/pgserve-wrapper.cjs",
+    "src/upgrade/index.js"
+  ],
+  "project": [
+    "src/**/*.js",
+    "bin/**/*.js",
+    "bin/**/*.cjs"
+  ],
+  "ignore": [
+    "tests/**",
+    "helpers/**",
+    "scripts/**"
+  ],
+  "ignoreBinaries": [
+    "scripts/test-npx.sh",
+    "scripts/test-bun-self-heal.sh",
+    "make"
+  ],
+  "ignoreDependencies": [
+    "bun"
+  ],
   "ignoreExportsUsedInFile": true
 }

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "README.md",
     "CHANGELOG.md",
     "LICENSE",
-    "SECURITY.md"
+    "SECURITY.md",
+    "scripts/"
   ],
   "scripts": {
     "bench": "bun tests/benchmarks/runner.js",
@@ -31,7 +32,8 @@
     "test:npx": "scripts/test-npx.sh",
     "test:bun-self-heal": "scripts/test-bun-self-heal.sh",
     "prepublishOnly": "npm run lint && npm run deadcode && npm run test:npx && npm run test:bun-self-heal",
-    "prepare": "husky"
+    "prepare": "husky",
+    "postinstall": "node scripts/postinstall.cjs"
   },
   "keywords": [
     "postgresql",

--- a/scripts/postinstall.cjs
+++ b/scripts/postinstall.cjs
@@ -1,0 +1,60 @@
+#!/usr/bin/env node
+/**
+ * autopg postinstall — auto-runs `autopg upgrade` on detected upgrade.
+ *
+ * Behavior:
+ *   - Fresh install (no ~/.autopg/data/) → exit 0 silently (no upgrade needed)
+ *   - Upgrade install (data dir exists) → invoke `autopg upgrade --quiet`
+ *   - Soft-fail: any error logs warning, exits 0 (never breaks `bun install`)
+ *   - Skip override: AUTOPG_SKIP_POSTINSTALL=1 → exit 0 immediately
+ *
+ * The escape hatch for forced re-runs is `autopg upgrade` (manual).
+ *
+ * See: .genie/wishes/autopg-upgrade-command/WISH.md
+ */
+
+const fs = require('node:fs');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+
+function getAutopgRoot() {
+  return process.env.AUTOPG_CONFIG_DIR || process.env.PGSERVE_CONFIG_DIR || `${process.env.HOME}/.autopg`;
+}
+
+function main() {
+  if (process.env.AUTOPG_SKIP_POSTINSTALL === '1') {
+    return;
+  }
+  const dataDir = path.join(getAutopgRoot(), 'data');
+  if (!fs.existsSync(dataDir)) {
+    // Fresh install — nothing to upgrade
+    return;
+  }
+  // Locate own CLI entry — script is run from the package dir at install time
+  const cliEntry = path.join(__dirname, '..', 'bin', 'pgserve-wrapper.cjs');
+  if (!fs.existsSync(cliEntry)) {
+    process.stderr.write(`[autopg-postinstall] wrapper not found at ${cliEntry}, skipping\n`);
+    return;
+  }
+  const result = spawnSync(process.execPath, [cliEntry, 'upgrade', '--quiet'], {
+    stdio: ['ignore', 'inherit', 'inherit'],
+    timeout: 60_000,
+  });
+  if (result.error) {
+    process.stderr.write(`[autopg-postinstall] WARNING: upgrade invocation failed: ${result.error.message}\n`);
+    process.stderr.write('[autopg-postinstall] Run `autopg upgrade` manually to retry.\n');
+    return;
+  }
+  if (result.status !== 0) {
+    process.stderr.write(`[autopg-postinstall] WARNING: \`autopg upgrade\` exited ${result.status}\n`);
+    process.stderr.write('[autopg-postinstall] Run `autopg upgrade` manually to investigate.\n');
+  }
+}
+
+try {
+  main();
+} catch (err) {
+  process.stderr.write(`[autopg-postinstall] WARNING: unexpected error: ${err.message}\n`);
+}
+
+process.exit(0);

--- a/src/cli-install.cjs
+++ b/src/cli-install.cjs
@@ -484,7 +484,6 @@ function dispatch(subcommand, args, ctx) {
     case 'port':
       return cmdPort();
     case 'upgrade': {
-      const upgrade = require(require('node:path').join(__dirname, 'upgrade'));
       const opts = {
         quiet: args.includes('--quiet'),
         dryRun: args.includes('--dry-run'),
@@ -494,7 +493,9 @@ function dispatch(subcommand, args, ctx) {
           return (args[idx + 1] || '').split(',').filter(Boolean);
         })(),
       };
-      return upgrade.upgrade(opts).then((r) => process.exit(r.ok ? 0 : 1));
+      return import(require('node:path').join(__dirname, 'upgrade', 'index.js'))
+        .then((mod) => mod.upgrade(opts))
+        .then((r) => process.exit(r.ok ? 0 : 1));
     }
     case 'config': {
       const cfg = require('./cli-config.cjs');

--- a/src/cli-install.cjs
+++ b/src/cli-install.cjs
@@ -483,6 +483,19 @@ function dispatch(subcommand, args, ctx) {
       return cmdUrl();
     case 'port':
       return cmdPort();
+    case 'upgrade': {
+      const upgrade = require(require('node:path').join(__dirname, 'upgrade'));
+      const opts = {
+        quiet: args.includes('--quiet'),
+        dryRun: args.includes('--dry-run'),
+        skipSteps: (() => {
+          const idx = args.indexOf('--skip-steps');
+          if (idx === -1) return [];
+          return (args[idx + 1] || '').split(',').filter(Boolean);
+        })(),
+      };
+      return upgrade.upgrade(opts).then((r) => process.exit(r.ok ? 0 : 1));
+    }
     case 'config': {
       const cfg = require('./cli-config.cjs');
       const [sub, ...rest] = args;

--- a/src/upgrade/index.js
+++ b/src/upgrade/index.js
@@ -9,30 +9,28 @@
  *   5. consumer-signal   — touch ~/.autopg/state/upgrade.signal
  *   6. health-validate   — pg_isready + per-DB plpgsql smoke test
  *
- * Patches the upgrade-path hole left by autopg-v22 partial roll-out:
- * users running pgserve@2.1.x → autopg@2.2.x get transparent migration.
- *
+ * Patches the upgrade-path hole left by autopg-v22 partial roll-out.
  * See: .genie/wishes/autopg-upgrade-command/WISH.md
  */
 
-const { runStep } = require('./runner');
+import { runStep } from './runner.js';
+import * as portReconcile from './steps/port-reconcile.js';
+import * as binaryCacheFlush from './steps/binary-cache-flush.js';
+import * as plpgsqlResolve from './steps/plpgsql-resolve.js';
+import * as envRefresh from './steps/env-refresh.js';
+import * as consumerSignal from './steps/consumer-signal.js';
+import * as healthValidate from './steps/health-validate.js';
 
-const STEPS = [
-  { name: 'port-reconcile', module: './steps/port-reconcile' },
-  { name: 'binary-cache-flush', module: './steps/binary-cache-flush' },
-  { name: 'plpgsql-resolve', module: './steps/plpgsql-resolve' },
-  { name: 'env-refresh', module: './steps/env-refresh' },
-  { name: 'consumer-signal', module: './steps/consumer-signal' },
-  { name: 'health-validate', module: './steps/health-validate' },
+export const STEPS = [
+  { name: 'port-reconcile', impl: portReconcile },
+  { name: 'binary-cache-flush', impl: binaryCacheFlush },
+  { name: 'plpgsql-resolve', impl: plpgsqlResolve },
+  { name: 'env-refresh', impl: envRefresh },
+  { name: 'consumer-signal', impl: consumerSignal },
+  { name: 'health-validate', impl: healthValidate },
 ];
 
-/**
- * Run upgrade. Options:
- *   - quiet   (bool): suppress per-step OK lines; only print summary + warnings
- *   - dryRun  (bool): print planned actions without executing
- *   - skipSteps (string[]): step names to skip (testing / partial recovery)
- */
-async function upgrade(options = {}) {
+export async function upgrade(options = {}) {
   const { quiet = false, dryRun = false, skipSteps = [] } = options;
   const log = (msg) => { if (!quiet) process.stderr.write(`${msg}\n`); };
   const warn = (msg) => process.stderr.write(`${msg}\n`);
@@ -47,13 +45,11 @@ async function upgrade(options = {}) {
       continue;
     }
     try {
-      const stepImpl = require(step.module);
-      const result = await runStep(step.name, stepImpl, { dryRun, log, warn });
+      const result = await runStep(step.name, step.impl, { dryRun, log, warn });
       results.push(result);
     } catch (err) {
       warn(`[${step.name}] FAIL: ${err.message}`);
       results.push({ name: step.name, status: 'FAIL', detail: err.message });
-      // Continue — upgrade is best-effort across steps; user runs `autopg upgrade` again if needed
     }
   }
 
@@ -67,5 +63,3 @@ async function upgrade(options = {}) {
   }
   return { ok: true, results, summary };
 }
-
-module.exports = { upgrade, STEPS };

--- a/src/upgrade/index.js
+++ b/src/upgrade/index.js
@@ -1,0 +1,71 @@
+/**
+ * autopg upgrade — idempotent migration orchestrator.
+ *
+ * Runs 6 steps in order, each safe to re-run any number of times:
+ *   1. port-reconcile    — ensure pgserve listens on canonical port (8432)
+ *   2. binary-cache-flush — verify binary version matches PINNED_PG_VERSION
+ *   3. plpgsql-resolve   — DROP+CREATE plpgsql per DB to refresh .so path
+ *   4. env-refresh       — regenerate ~/.autopg/<app>.env URLs
+ *   5. consumer-signal   — touch ~/.autopg/state/upgrade.signal
+ *   6. health-validate   — pg_isready + per-DB plpgsql smoke test
+ *
+ * Patches the upgrade-path hole left by autopg-v22 partial roll-out:
+ * users running pgserve@2.1.x → autopg@2.2.x get transparent migration.
+ *
+ * See: .genie/wishes/autopg-upgrade-command/WISH.md
+ */
+
+const { runStep } = require('./runner');
+
+const STEPS = [
+  { name: 'port-reconcile', module: './steps/port-reconcile' },
+  { name: 'binary-cache-flush', module: './steps/binary-cache-flush' },
+  { name: 'plpgsql-resolve', module: './steps/plpgsql-resolve' },
+  { name: 'env-refresh', module: './steps/env-refresh' },
+  { name: 'consumer-signal', module: './steps/consumer-signal' },
+  { name: 'health-validate', module: './steps/health-validate' },
+];
+
+/**
+ * Run upgrade. Options:
+ *   - quiet   (bool): suppress per-step OK lines; only print summary + warnings
+ *   - dryRun  (bool): print planned actions without executing
+ *   - skipSteps (string[]): step names to skip (testing / partial recovery)
+ */
+async function upgrade(options = {}) {
+  const { quiet = false, dryRun = false, skipSteps = [] } = options;
+  const log = (msg) => { if (!quiet) process.stderr.write(`${msg}\n`); };
+  const warn = (msg) => process.stderr.write(`${msg}\n`);
+
+  log(`autopg upgrade starting (dryRun=${dryRun}, quiet=${quiet})`);
+
+  const results = [];
+  for (const step of STEPS) {
+    if (skipSteps.includes(step.name)) {
+      log(`[${step.name}] SKIP (excluded by --skip-steps)`);
+      results.push({ name: step.name, status: 'SKIP', detail: 'excluded' });
+      continue;
+    }
+    try {
+      const stepImpl = require(step.module);
+      const result = await runStep(step.name, stepImpl, { dryRun, log, warn });
+      results.push(result);
+    } catch (err) {
+      warn(`[${step.name}] FAIL: ${err.message}`);
+      results.push({ name: step.name, status: 'FAIL', detail: err.message });
+      // Continue — upgrade is best-effort across steps; user runs `autopg upgrade` again if needed
+    }
+  }
+
+  const failed = results.filter((r) => r.status === 'FAIL');
+  const summary = `autopg upgrade complete: ${results.length - failed.length}/${results.length} steps OK`;
+  log(summary);
+  if (failed.length > 0) {
+    warn(`Failed steps: ${failed.map((r) => r.name).join(', ')}`);
+    warn('Re-run `autopg upgrade` after addressing the above.');
+    return { ok: false, results, summary };
+  }
+  return { ok: true, results, summary };
+}
+
+module.exports = { upgrade, STEPS };

--- a/src/upgrade/runner.js
+++ b/src/upgrade/runner.js
@@ -1,0 +1,28 @@
+/**
+ * Step runner — wraps each step with consistent logging + error capture.
+ *
+ * A step module exports `{ name, plan(ctx), execute(ctx) }`:
+ *   - plan(ctx)    → returns a string describing what would happen (dry-run output)
+ *   - execute(ctx) → returns { status: 'OK'|'SKIP'|'FAIL', detail: string }
+ *
+ * The runner ensures both modes (dry-run + execute) emit a consistent
+ * `[name] STATUS: detail` line so logs are grep-friendly.
+ */
+
+async function runStep(name, stepImpl, { dryRun, log, warn }) {
+  if (typeof stepImpl.plan !== 'function' || typeof stepImpl.execute !== 'function') {
+    throw new Error(`step ${name} missing plan() or execute()`);
+  }
+  if (dryRun) {
+    const planned = await stepImpl.plan({ log, warn });
+    log(`[${name}] DRY-RUN: ${planned}`);
+    return { name, status: 'DRY-RUN', detail: planned };
+  }
+  const result = await stepImpl.execute({ log, warn });
+  const status = result.status || 'OK';
+  const detail = result.detail || '';
+  log(`[${name}] ${status}: ${detail}`);
+  return { name, status, detail };
+}
+
+module.exports = { runStep };

--- a/src/upgrade/runner.js
+++ b/src/upgrade/runner.js
@@ -2,14 +2,11 @@
  * Step runner — wraps each step with consistent logging + error capture.
  *
  * A step module exports `{ name, plan(ctx), execute(ctx) }`:
- *   - plan(ctx)    → returns a string describing what would happen (dry-run output)
- *   - execute(ctx) → returns { status: 'OK'|'SKIP'|'FAIL', detail: string }
- *
- * The runner ensures both modes (dry-run + execute) emit a consistent
- * `[name] STATUS: detail` line so logs are grep-friendly.
+ *   - plan(ctx)    → string describing what would happen (dry-run output)
+ *   - execute(ctx) → { status: 'OK'|'SKIP'|'FAIL', detail: string }
  */
 
-async function runStep(name, stepImpl, { dryRun, log, warn }) {
+export async function runStep(name, stepImpl, { dryRun, log, warn }) {
   if (typeof stepImpl.plan !== 'function' || typeof stepImpl.execute !== 'function') {
     throw new Error(`step ${name} missing plan() or execute()`);
   }
@@ -24,5 +21,3 @@ async function runStep(name, stepImpl, { dryRun, log, warn }) {
   log(`[${name}] ${status}: ${detail}`);
   return { name, status, detail };
 }
-
-module.exports = { runStep };

--- a/src/upgrade/steps/binary-cache-flush.js
+++ b/src/upgrade/steps/binary-cache-flush.js
@@ -1,0 +1,84 @@
+/**
+ * Step 2 — Binary cache flush.
+ *
+ * Verifies ~/.autopg/bin/<platform>/postgres matches PINNED_PG_VERSION.
+ * If drift detected (version marker missing or mismatch), re-download via
+ * the existing src/postgres.js download path.
+ *
+ * Idempotent: if version matches, SKIP. Extends migrateLegacyBinaryCache
+ * (commit 0075c4f) with version-aware re-download.
+ */
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+function getAutopgRoot() {
+  return process.env.AUTOPG_CONFIG_DIR || process.env.PGSERVE_CONFIG_DIR || `${process.env.HOME}/.autopg`;
+}
+
+function getBinaryCacheDir() {
+  const platform = `${process.platform}-${process.arch}`;
+  return path.join(getAutopgRoot(), 'bin', platform);
+}
+
+function getPinnedVersion() {
+  // Attempt to read from package.json's autopg.pinnedPgVersion field, fallback to env, fallback to a sane default.
+  try {
+    const pkgPath = path.join(__dirname, '..', '..', '..', 'package.json');
+    const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
+    if (pkg.autopg && pkg.autopg.pinnedPgVersion) return pkg.autopg.pinnedPgVersion;
+  } catch { /* fall through */ }
+  return process.env.AUTOPG_PINNED_PG_VERSION || '18.3';
+}
+
+function readVersionMarker(cacheDir) {
+  try {
+    return fs.readFileSync(path.join(cacheDir, '.version'), 'utf8').trim();
+  } catch {
+    return null;
+  }
+}
+
+async function plan() {
+  const cacheDir = getBinaryCacheDir();
+  const pinned = getPinnedVersion();
+  const marker = readVersionMarker(cacheDir);
+  if (!fs.existsSync(path.join(cacheDir, 'bin', 'postgres'))) {
+    return `binary missing at ${cacheDir} — would trigger download for PG ${pinned}`;
+  }
+  if (marker !== pinned) {
+    return `version drift (cached=${marker || 'unknown'}, pinned=${pinned}) — would re-download`;
+  }
+  return `binary present and matches pinned ${pinned}, no action needed`;
+}
+
+async function execute({ log, warn }) {
+  const cacheDir = getBinaryCacheDir();
+  const pinned = getPinnedVersion();
+  const marker = readVersionMarker(cacheDir);
+  const binaryExists = fs.existsSync(path.join(cacheDir, 'bin', 'postgres'));
+
+  if (binaryExists && marker === pinned) {
+    return { status: 'SKIP', detail: `binary OK (PG ${pinned} matches marker)` };
+  }
+
+  // Delegate to existing postgres.js downloadBinary if available; else fail-loud
+  // and instruct operator. We avoid duplicating the download logic here.
+  let downloadFn;
+  try {
+    const postgres = require('../../postgres');
+    downloadFn = postgres.ensureBinary || postgres.downloadBinary || postgres.installBinary;
+  } catch { /* postgres.js not loadable inline — operator path */ }
+
+  if (!downloadFn) {
+    warn(`binary needs refresh (pinned=${pinned}, cached=${marker || 'missing'}) but autopg postgres module not exposing download API`);
+    warn(`operator action: rerun \`bun install -g @automagik/autopg@latest\` to repopulate binary cache`);
+    return { status: 'FAIL', detail: 'binary refresh needs autopg npm reinstall' };
+  }
+  log(`re-downloading PG ${pinned} into ${cacheDir}`);
+  await downloadFn({ version: pinned, targetDir: cacheDir });
+  fs.writeFileSync(path.join(cacheDir, '.version'), pinned, { mode: 0o644 });
+  return { status: 'OK', detail: `binary refreshed to PG ${pinned}` };
+}
+
+module.exports = { name: 'binary-cache-flush', plan, execute };

--- a/src/upgrade/steps/binary-cache-flush.js
+++ b/src/upgrade/steps/binary-cache-flush.js
@@ -1,78 +1,63 @@
 /**
- * Step 2 — Binary cache flush.
- *
- * Verifies ~/.autopg/bin/<platform>/postgres matches PINNED_PG_VERSION.
- * If drift detected (version marker missing or mismatch), re-download via
- * the existing src/postgres.js download path.
- *
- * Idempotent: if version matches, SKIP. Extends migrateLegacyBinaryCache
- * (commit 0075c4f) with version-aware re-download.
+ * Step 2 — Binary cache flush against PINNED_PG_VERSION.
+ * Re-downloads if version marker missing or mismatch. Idempotent.
  */
 
-const fs = require('node:fs');
-const path = require('node:path');
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+export const name = 'binary-cache-flush';
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 function getAutopgRoot() {
   return process.env.AUTOPG_CONFIG_DIR || process.env.PGSERVE_CONFIG_DIR || `${process.env.HOME}/.autopg`;
 }
 
 function getBinaryCacheDir() {
-  const platform = `${process.platform}-${process.arch}`;
-  return path.join(getAutopgRoot(), 'bin', platform);
+  return path.join(getAutopgRoot(), 'bin', `${process.platform}-${process.arch}`);
 }
 
 function getPinnedVersion() {
-  // Attempt to read from package.json's autopg.pinnedPgVersion field, fallback to env, fallback to a sane default.
   try {
-    const pkgPath = path.join(__dirname, '..', '..', '..', 'package.json');
-    const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
+    const pkg = JSON.parse(fs.readFileSync(path.join(__dirname, '..', '..', '..', 'package.json'), 'utf8'));
     if (pkg.autopg && pkg.autopg.pinnedPgVersion) return pkg.autopg.pinnedPgVersion;
   } catch { /* fall through */ }
   return process.env.AUTOPG_PINNED_PG_VERSION || '18.3';
 }
 
 function readVersionMarker(cacheDir) {
-  try {
-    return fs.readFileSync(path.join(cacheDir, '.version'), 'utf8').trim();
-  } catch {
-    return null;
-  }
+  try { return fs.readFileSync(path.join(cacheDir, '.version'), 'utf8').trim(); } catch { return null; }
 }
 
-async function plan() {
+export async function plan() {
   const cacheDir = getBinaryCacheDir();
   const pinned = getPinnedVersion();
   const marker = readVersionMarker(cacheDir);
   if (!fs.existsSync(path.join(cacheDir, 'bin', 'postgres'))) {
     return `binary missing at ${cacheDir} — would trigger download for PG ${pinned}`;
   }
-  if (marker !== pinned) {
-    return `version drift (cached=${marker || 'unknown'}, pinned=${pinned}) — would re-download`;
-  }
+  if (marker !== pinned) return `version drift (cached=${marker || 'unknown'}, pinned=${pinned}) — would re-download`;
   return `binary present and matches pinned ${pinned}, no action needed`;
 }
 
-async function execute({ log, warn }) {
+export async function execute({ log, warn }) {
   const cacheDir = getBinaryCacheDir();
   const pinned = getPinnedVersion();
   const marker = readVersionMarker(cacheDir);
   const binaryExists = fs.existsSync(path.join(cacheDir, 'bin', 'postgres'));
 
-  if (binaryExists && marker === pinned) {
-    return { status: 'SKIP', detail: `binary OK (PG ${pinned} matches marker)` };
-  }
+  if (binaryExists && marker === pinned) return { status: 'SKIP', detail: `binary OK (PG ${pinned})` };
 
-  // Delegate to existing postgres.js downloadBinary if available; else fail-loud
-  // and instruct operator. We avoid duplicating the download logic here.
   let downloadFn;
   try {
-    const postgres = require('../../postgres');
+    const postgres = await import('../../postgres.js');
     downloadFn = postgres.ensureBinary || postgres.downloadBinary || postgres.installBinary;
-  } catch { /* postgres.js not loadable inline — operator path */ }
+  } catch { /* postgres module not loadable here */ }
 
   if (!downloadFn) {
     warn(`binary needs refresh (pinned=${pinned}, cached=${marker || 'missing'}) but autopg postgres module not exposing download API`);
-    warn(`operator action: rerun \`bun install -g @automagik/autopg@latest\` to repopulate binary cache`);
+    warn(`operator action: rerun \`bun install -g @automagik/autopg@latest\``);
     return { status: 'FAIL', detail: 'binary refresh needs autopg npm reinstall' };
   }
   log(`re-downloading PG ${pinned} into ${cacheDir}`);
@@ -80,5 +65,3 @@ async function execute({ log, warn }) {
   fs.writeFileSync(path.join(cacheDir, '.version'), pinned, { mode: 0o644 });
   return { status: 'OK', detail: `binary refreshed to PG ${pinned}` };
 }
-
-module.exports = { name: 'binary-cache-flush', plan, execute };

--- a/src/upgrade/steps/consumer-signal.js
+++ b/src/upgrade/steps/consumer-signal.js
@@ -1,20 +1,14 @@
 /**
- * Step 5 — Consumer reconnect signal.
- *
- * Touches ~/.autopg/state/upgrade.signal with epoch timestamp + autopg
- * version. Consumers (omni-api, genie-serve) opt-in by watching this
- * file via fs.watch and respond with `pm2 restart self` (or equivalent
- * reconnect logic).
- *
- * Decoupled by design: autopg doesn't need to know which consumers
- * exist. Consumers add fs.watch in a follow-up — until then this step
- * is harmless.
- *
- * Idempotent: just rewrites the signal file with current timestamp.
+ * Step 5 — Consumer reconnect signal. Touches ~/.autopg/state/upgrade.signal
+ * with epoch + autopg version. Consumers (omni-api, genie-serve) opt-in via fs.watch.
  */
 
-const fs = require('node:fs');
-const path = require('node:path');
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+export const name = 'consumer-signal';
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 function getAutopgRoot() {
   return process.env.AUTOPG_CONFIG_DIR || process.env.PGSERVE_CONFIG_DIR || `${process.env.HOME}/.autopg`;
@@ -24,17 +18,14 @@ function getAutopgVersion() {
   try {
     const pkg = JSON.parse(fs.readFileSync(path.join(__dirname, '..', '..', '..', 'package.json'), 'utf8'));
     return pkg.version || 'unknown';
-  } catch {
-    return 'unknown';
-  }
+  } catch { return 'unknown'; }
 }
 
-async function plan() {
-  const signalDir = path.join(getAutopgRoot(), 'state');
-  return `would write upgrade signal at ${path.join(signalDir, 'upgrade.signal')}`;
+export async function plan() {
+  return `would write upgrade signal at ${path.join(getAutopgRoot(), 'state', 'upgrade.signal')}`;
 }
 
-async function execute({ log }) {
+export async function execute() {
   const signalDir = path.join(getAutopgRoot(), 'state');
   fs.mkdirSync(signalDir, { recursive: true });
   const payload = {
@@ -47,5 +38,3 @@ async function execute({ log }) {
   fs.writeFileSync(signalPath, `${JSON.stringify(payload, null, 2)}\n`, { mode: 0o644 });
   return { status: 'OK', detail: `signal written at ${signalPath}` };
 }
-
-module.exports = { name: 'consumer-signal', plan, execute };

--- a/src/upgrade/steps/consumer-signal.js
+++ b/src/upgrade/steps/consumer-signal.js
@@ -1,0 +1,51 @@
+/**
+ * Step 5 — Consumer reconnect signal.
+ *
+ * Touches ~/.autopg/state/upgrade.signal with epoch timestamp + autopg
+ * version. Consumers (omni-api, genie-serve) opt-in by watching this
+ * file via fs.watch and respond with `pm2 restart self` (or equivalent
+ * reconnect logic).
+ *
+ * Decoupled by design: autopg doesn't need to know which consumers
+ * exist. Consumers add fs.watch in a follow-up — until then this step
+ * is harmless.
+ *
+ * Idempotent: just rewrites the signal file with current timestamp.
+ */
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+function getAutopgRoot() {
+  return process.env.AUTOPG_CONFIG_DIR || process.env.PGSERVE_CONFIG_DIR || `${process.env.HOME}/.autopg`;
+}
+
+function getAutopgVersion() {
+  try {
+    const pkg = JSON.parse(fs.readFileSync(path.join(__dirname, '..', '..', '..', 'package.json'), 'utf8'));
+    return pkg.version || 'unknown';
+  } catch {
+    return 'unknown';
+  }
+}
+
+async function plan() {
+  const signalDir = path.join(getAutopgRoot(), 'state');
+  return `would write upgrade signal at ${path.join(signalDir, 'upgrade.signal')}`;
+}
+
+async function execute({ log }) {
+  const signalDir = path.join(getAutopgRoot(), 'state');
+  fs.mkdirSync(signalDir, { recursive: true });
+  const payload = {
+    timestamp: new Date().toISOString(),
+    epoch_ms: Date.now(),
+    autopg_version: getAutopgVersion(),
+    canonical_port: 8432,
+  };
+  const signalPath = path.join(signalDir, 'upgrade.signal');
+  fs.writeFileSync(signalPath, `${JSON.stringify(payload, null, 2)}\n`, { mode: 0o644 });
+  return { status: 'OK', detail: `signal written at ${signalPath}` };
+}
+
+module.exports = { name: 'consumer-signal', plan, execute };

--- a/src/upgrade/steps/env-refresh.js
+++ b/src/upgrade/steps/env-refresh.js
@@ -1,17 +1,13 @@
 /**
- * Step 4 — App env file refresh.
- *
- * Regenerates ~/.autopg/<name>.env files with current canonical port
- * (8432). Verifies SCRAM credential still validates (try connect);
- * skips rotation if cred works.
- *
- * Idempotent: if file content matches, no rewrite.
+ * Step 4 — App env file refresh. Regenerates ~/.autopg/<name>.env with
+ * canonical port. Verifies SCRAM cred works; warns if rotation needed.
  */
 
-const fs = require('node:fs');
-const path = require('node:path');
-const { execSync } = require('node:child_process');
+import fs from 'node:fs';
+import path from 'node:path';
+import { execSync } from 'node:child_process';
 
+export const name = 'env-refresh';
 const CANONICAL_PORT = 8432;
 
 function getAutopgRoot() {
@@ -44,33 +40,29 @@ function tryConnect(url) {
   try {
     execSync(`psql ${JSON.stringify(url)} -At -c "SELECT 1"`, { stdio: 'pipe', env: process.env });
     return true;
-  } catch {
-    return false;
-  }
+  } catch { return false; }
 }
 
-async function plan() {
+export async function plan() {
   const files = listAppEnvFiles();
   if (files.length === 0) return 'no app .env files found in autopg root';
   return `would verify+rewrite ${files.length} env file(s): ${files.map((f) => path.basename(f)).join(', ')}`;
 }
 
-async function execute({ log, warn }) {
+export async function execute({ warn }) {
   const files = listAppEnvFiles();
   if (files.length === 0) return { status: 'SKIP', detail: 'no .env files' };
 
-  let updated = 0;
-  let valid = 0;
+  let updated = 0, valid = 0;
   for (const file of files) {
     try {
       const content = fs.readFileSync(file, 'utf8');
       const env = parseEnv(content);
       const url = env.DATABASE_URL || env.PG_URL || env.POSTGRES_URL;
       if (!url) {
-        warn(`[env-refresh] ${path.basename(file)}: no DATABASE_URL key, skipping`);
+        warn(`[env-refresh] ${path.basename(file)}: no DATABASE_URL key`);
         continue;
       }
-      // Parse current URL to extract user/password/db
       const parsed = new URL(url);
       const newUrl = buildUrl({
         user: decodeURIComponent(parsed.username),
@@ -82,13 +74,12 @@ async function execute({ log, warn }) {
       if (tryConnect(newUrl)) {
         valid++;
         if (newUrl !== url) {
-          // Rewrite with corrected port
           const newContent = content.replace(/^(DATABASE_URL|PG_URL|POSTGRES_URL)=.*/m, `$1=${newUrl}`);
           fs.writeFileSync(file, newContent, { mode: 0o600 });
           updated++;
         }
       } else {
-        warn(`[env-refresh] ${path.basename(file)}: SCRAM cred fails — manual rotation needed via \`autopg rotate <app>\``);
+        warn(`[env-refresh] ${path.basename(file)}: SCRAM cred fails — rotate via \`autopg rotate <app>\``);
       }
     } catch (err) {
       warn(`[env-refresh] ${path.basename(file)} failed: ${err.message}`);
@@ -96,5 +87,3 @@ async function execute({ log, warn }) {
   }
   return { status: 'OK', detail: `validated ${valid}/${files.length}, rewrote ${updated}` };
 }
-
-module.exports = { name: 'env-refresh', plan, execute };

--- a/src/upgrade/steps/env-refresh.js
+++ b/src/upgrade/steps/env-refresh.js
@@ -1,0 +1,100 @@
+/**
+ * Step 4 — App env file refresh.
+ *
+ * Regenerates ~/.autopg/<name>.env files with current canonical port
+ * (8432). Verifies SCRAM credential still validates (try connect);
+ * skips rotation if cred works.
+ *
+ * Idempotent: if file content matches, no rewrite.
+ */
+
+const fs = require('node:fs');
+const path = require('node:path');
+const { execSync } = require('node:child_process');
+
+const CANONICAL_PORT = 8432;
+
+function getAutopgRoot() {
+  return process.env.AUTOPG_CONFIG_DIR || process.env.PGSERVE_CONFIG_DIR || `${process.env.HOME}/.autopg`;
+}
+
+function listAppEnvFiles() {
+  const root = getAutopgRoot();
+  if (!fs.existsSync(root)) return [];
+  return fs.readdirSync(root)
+    .filter((f) => f.endsWith('.env') && !f.startsWith('.'))
+    .map((f) => path.join(root, f));
+}
+
+function parseEnv(content) {
+  const out = {};
+  for (const line of content.split('\n')) {
+    const m = line.match(/^([A-Z_][A-Z0-9_]*)=(.*)$/);
+    if (m) out[m[1]] = m[2].replace(/^"(.*)"$/, '$1');
+  }
+  return out;
+}
+
+function buildUrl({ user, password, port, db }) {
+  const enc = (s) => encodeURIComponent(s);
+  return `postgresql://${enc(user)}:${enc(password)}@127.0.0.1:${port}/${db}`;
+}
+
+function tryConnect(url) {
+  try {
+    execSync(`psql ${JSON.stringify(url)} -At -c "SELECT 1"`, { stdio: 'pipe', env: process.env });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function plan() {
+  const files = listAppEnvFiles();
+  if (files.length === 0) return 'no app .env files found in autopg root';
+  return `would verify+rewrite ${files.length} env file(s): ${files.map((f) => path.basename(f)).join(', ')}`;
+}
+
+async function execute({ log, warn }) {
+  const files = listAppEnvFiles();
+  if (files.length === 0) return { status: 'SKIP', detail: 'no .env files' };
+
+  let updated = 0;
+  let valid = 0;
+  for (const file of files) {
+    try {
+      const content = fs.readFileSync(file, 'utf8');
+      const env = parseEnv(content);
+      const url = env.DATABASE_URL || env.PG_URL || env.POSTGRES_URL;
+      if (!url) {
+        warn(`[env-refresh] ${path.basename(file)}: no DATABASE_URL key, skipping`);
+        continue;
+      }
+      // Parse current URL to extract user/password/db
+      const parsed = new URL(url);
+      const newUrl = buildUrl({
+        user: decodeURIComponent(parsed.username),
+        password: decodeURIComponent(parsed.password),
+        port: CANONICAL_PORT,
+        db: parsed.pathname.replace(/^\//, ''),
+      });
+
+      if (tryConnect(newUrl)) {
+        valid++;
+        if (newUrl !== url) {
+          // Rewrite with corrected port
+          const newContent = content.replace(/^(DATABASE_URL|PG_URL|POSTGRES_URL)=.*/m, `$1=${newUrl}`);
+          fs.writeFileSync(file, newContent, { mode: 0o600 });
+          updated++;
+        }
+      } else {
+        warn(`[env-refresh] ${path.basename(file)}: SCRAM cred fails — manual rotation needed via \`autopg rotate <app>\``);
+      }
+    } catch (err) {
+      warn(`[env-refresh] ${path.basename(file)} failed: ${err.message}`);
+    }
+  }
+  return { status: 'OK', detail: `validated ${valid}/${files.length}, rewrote ${updated}` };
+}
+
+module.exports = { name: 'env-refresh', plan, execute };

--- a/src/upgrade/steps/health-validate.js
+++ b/src/upgrade/steps/health-validate.js
@@ -1,25 +1,16 @@
 /**
- * Step 6 — Health validation.
- *
- * Final check: pg_isready on canonical port + per-DB plpgsql smoke test
- * (DO block runs without "could not access file" error).
- *
- * Returns FAIL if any check breaks. Caller (orchestrator) surfaces this
- * to operator.
+ * Step 6 — Health validation. pg_isready + per-DB plpgsql smoke test.
  */
 
-const { execSync } = require('node:child_process');
+import { execSync } from 'node:child_process';
 
+export const name = 'health-validate';
 const CANONICAL_PORT = 8432;
 const SYSTEM_DBS = new Set(['template0', 'template1']);
 
 function pgIsReady() {
-  try {
-    execSync(`pg_isready -h 127.0.0.1 -p ${CANONICAL_PORT}`, { stdio: 'pipe' });
-    return true;
-  } catch {
-    return false;
-  }
+  try { execSync(`pg_isready -h 127.0.0.1 -p ${CANONICAL_PORT}`, { stdio: 'pipe' }); return true; }
+  catch { return false; }
 }
 
 function listAllDbs() {
@@ -39,19 +30,15 @@ function plpgsqlSmoke(db) {
       { env, stdio: 'pipe' },
     );
     return true;
-  } catch {
-    return false;
-  }
+  } catch { return false; }
 }
 
-async function plan() {
+export async function plan() {
   return `would check pg_isready on :${CANONICAL_PORT} + plpgsql smoke test in each user DB`;
 }
 
-async function execute({ warn }) {
-  if (!pgIsReady()) {
-    return { status: 'FAIL', detail: `pg_isready failed on port ${CANONICAL_PORT}` };
-  }
+export async function execute({ warn }) {
+  if (!pgIsReady()) return { status: 'FAIL', detail: `pg_isready failed on port ${CANONICAL_PORT}` };
   let dbs;
   try { dbs = listAllDbs(); } catch (err) { return { status: 'FAIL', detail: `cannot list DBs: ${err.message}` }; }
 
@@ -61,8 +48,6 @@ async function execute({ warn }) {
     if (plpgsqlSmoke(db)) pass++;
     else { fail++; warn(`[health-validate] plpgsql smoke FAIL in ${db}`); }
   }
-  if (fail > 0) return { status: 'FAIL', detail: `${pass}/${pass + fail} DBs healthy; ${fail} plpgsql smoke failure(s)` };
+  if (fail > 0) return { status: 'FAIL', detail: `${pass}/${pass + fail} DBs healthy; ${fail} failure(s)` };
   return { status: 'OK', detail: `pg_isready OK, plpgsql healthy in ${pass}/${pass} DBs` };
 }
-
-module.exports = { name: 'health-validate', plan, execute };

--- a/src/upgrade/steps/health-validate.js
+++ b/src/upgrade/steps/health-validate.js
@@ -1,0 +1,68 @@
+/**
+ * Step 6 — Health validation.
+ *
+ * Final check: pg_isready on canonical port + per-DB plpgsql smoke test
+ * (DO block runs without "could not access file" error).
+ *
+ * Returns FAIL if any check breaks. Caller (orchestrator) surfaces this
+ * to operator.
+ */
+
+const { execSync } = require('node:child_process');
+
+const CANONICAL_PORT = 8432;
+const SYSTEM_DBS = new Set(['template0', 'template1']);
+
+function pgIsReady() {
+  try {
+    execSync(`pg_isready -h 127.0.0.1 -p ${CANONICAL_PORT}`, { stdio: 'pipe' });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function listAllDbs() {
+  const env = { ...process.env, PGPASSWORD: process.env.PGPASSWORD || 'postgres' };
+  const out = execSync(
+    `psql -h 127.0.0.1 -p ${CANONICAL_PORT} -U postgres -At -c "SELECT datname FROM pg_database WHERE NOT datistemplate"`,
+    { env, stdio: ['ignore', 'pipe', 'pipe'] },
+  ).toString().trim();
+  return out ? out.split('\n').filter(Boolean) : [];
+}
+
+function plpgsqlSmoke(db) {
+  try {
+    const env = { ...process.env, PGPASSWORD: process.env.PGPASSWORD || 'postgres' };
+    execSync(
+      `psql -h 127.0.0.1 -p ${CANONICAL_PORT} -U postgres -d ${db} -At -c "DO \\$\\$ BEGIN RAISE NOTICE 'ok'; END; \\$\\$"`,
+      { env, stdio: 'pipe' },
+    );
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function plan() {
+  return `would check pg_isready on :${CANONICAL_PORT} + plpgsql smoke test in each user DB`;
+}
+
+async function execute({ warn }) {
+  if (!pgIsReady()) {
+    return { status: 'FAIL', detail: `pg_isready failed on port ${CANONICAL_PORT}` };
+  }
+  let dbs;
+  try { dbs = listAllDbs(); } catch (err) { return { status: 'FAIL', detail: `cannot list DBs: ${err.message}` }; }
+
+  let pass = 0, fail = 0;
+  for (const db of dbs) {
+    if (SYSTEM_DBS.has(db)) continue;
+    if (plpgsqlSmoke(db)) pass++;
+    else { fail++; warn(`[health-validate] plpgsql smoke FAIL in ${db}`); }
+  }
+  if (fail > 0) return { status: 'FAIL', detail: `${pass}/${pass + fail} DBs healthy; ${fail} plpgsql smoke failure(s)` };
+  return { status: 'OK', detail: `pg_isready OK, plpgsql healthy in ${pass}/${pass} DBs` };
+}
+
+module.exports = { name: 'health-validate', plan, execute };

--- a/src/upgrade/steps/plpgsql-resolve.js
+++ b/src/upgrade/steps/plpgsql-resolve.js
@@ -1,0 +1,73 @@
+/**
+ * Step 3 — plpgsql extension re-resolve.
+ *
+ * For each user DB, DROP+CREATE plpgsql to force PG to re-lookup the
+ * .so file path against the current $libdir. This fixes the "could not
+ * access file 'plpgsql'" error that surfaces after autopg moves the
+ * binary cache (commit 0075c4f) — pg_extension metadata pins absolute
+ * paths and only DROP/CREATE refreshes them.
+ *
+ * Safety: skips template/system DBs and any DB containing user-owned
+ * plpgsql functions (gate on pg_proc.proowner != 10). Skipping one DB
+ * does not abort the whole step.
+ *
+ * Idempotent: extension is always present after CREATE.
+ */
+
+const { execSync } = require('node:child_process');
+
+const CANONICAL_PORT = 8432;
+const SYSTEM_DBS = new Set(['postgres', 'template0', 'template1']);
+
+function pgQuery({ db, sql, captureStdout = false }) {
+  const env = { ...process.env, PGPASSWORD: process.env.PGPASSWORD || 'postgres' };
+  const cmd = `psql -h 127.0.0.1 -p ${CANONICAL_PORT} -U postgres -d ${db} -At -c ${JSON.stringify(sql)}`;
+  return captureStdout
+    ? execSync(cmd, { env, stdio: ['ignore', 'pipe', 'pipe'] }).toString().trim()
+    : execSync(cmd, { env, stdio: 'pipe' });
+}
+
+function listUserDbs() {
+  const sql = "SELECT datname FROM pg_database WHERE NOT datistemplate AND datname != 'postgres' ORDER BY datname";
+  const out = pgQuery({ db: 'postgres', sql, captureStdout: true });
+  return out ? out.split('\n').filter(Boolean) : [];
+}
+
+function hasUserOwnedPlpgsqlFunctions(db) {
+  const sql = "SELECT count(*) FROM pg_proc p JOIN pg_language l ON p.prolang = l.oid WHERE l.lanname = 'plpgsql' AND p.proowner != 10";
+  const out = pgQuery({ db, sql, captureStdout: true });
+  return parseInt(out, 10) > 0;
+}
+
+async function plan() {
+  let dbs;
+  try { dbs = listUserDbs(); } catch (err) { return `cannot enumerate DBs: ${err.message}`; }
+  return `would DROP+CREATE plpgsql in ${dbs.length} user DB(s): ${dbs.join(', ')} (skipping any with user-owned plpgsql functions)`;
+}
+
+async function execute({ log, warn }) {
+  let dbs;
+  try { dbs = listUserDbs(); } catch (err) { return { status: 'FAIL', detail: `cannot enumerate DBs: ${err.message}` }; }
+  if (dbs.length === 0) return { status: 'SKIP', detail: 'no user DBs to refresh' };
+
+  let refreshed = 0;
+  let skipped = 0;
+  for (const db of dbs) {
+    if (SYSTEM_DBS.has(db)) { skipped++; continue; }
+    try {
+      if (hasUserOwnedPlpgsqlFunctions(db)) {
+        warn(`[plpgsql-resolve] skip ${db}: has user-owned plpgsql functions (DROP CASCADE would lose them)`);
+        skipped++;
+        continue;
+      }
+      pgQuery({ db, sql: 'DROP EXTENSION IF EXISTS plpgsql CASCADE; CREATE EXTENSION plpgsql' });
+      refreshed++;
+    } catch (err) {
+      warn(`[plpgsql-resolve] ${db} failed: ${err.message}`);
+      skipped++;
+    }
+  }
+  return { status: 'OK', detail: `refreshed ${refreshed} DB(s), skipped ${skipped}` };
+}
+
+module.exports = { name: 'plpgsql-resolve', plan, execute };

--- a/src/upgrade/steps/plpgsql-resolve.js
+++ b/src/upgrade/steps/plpgsql-resolve.js
@@ -1,21 +1,12 @@
 /**
  * Step 3 — plpgsql extension re-resolve.
- *
- * For each user DB, DROP+CREATE plpgsql to force PG to re-lookup the
- * .so file path against the current $libdir. This fixes the "could not
- * access file 'plpgsql'" error that surfaces after autopg moves the
- * binary cache (commit 0075c4f) — pg_extension metadata pins absolute
- * paths and only DROP/CREATE refreshes them.
- *
- * Safety: skips template/system DBs and any DB containing user-owned
- * plpgsql functions (gate on pg_proc.proowner != 10). Skipping one DB
- * does not abort the whole step.
- *
- * Idempotent: extension is always present after CREATE.
+ * DROP+CREATE plpgsql per user DB to refresh `.so` path against current $libdir.
+ * Skips DBs with user-owned plpgsql functions (CASCADE would drop them).
  */
 
-const { execSync } = require('node:child_process');
+import { execSync } from 'node:child_process';
 
+export const name = 'plpgsql-resolve';
 const CANONICAL_PORT = 8432;
 const SYSTEM_DBS = new Set(['postgres', 'template0', 'template1']);
 
@@ -28,37 +19,41 @@ function pgQuery({ db, sql, captureStdout = false }) {
 }
 
 function listUserDbs() {
-  const sql = "SELECT datname FROM pg_database WHERE NOT datistemplate AND datname != 'postgres' ORDER BY datname";
-  const out = pgQuery({ db: 'postgres', sql, captureStdout: true });
+  const out = pgQuery({
+    db: 'postgres',
+    sql: "SELECT datname FROM pg_database WHERE NOT datistemplate AND datname != 'postgres' ORDER BY datname",
+    captureStdout: true,
+  });
   return out ? out.split('\n').filter(Boolean) : [];
 }
 
 function hasUserOwnedPlpgsqlFunctions(db) {
-  const sql = "SELECT count(*) FROM pg_proc p JOIN pg_language l ON p.prolang = l.oid WHERE l.lanname = 'plpgsql' AND p.proowner != 10";
-  const out = pgQuery({ db, sql, captureStdout: true });
+  const out = pgQuery({
+    db,
+    sql: "SELECT count(*) FROM pg_proc p JOIN pg_language l ON p.prolang = l.oid WHERE l.lanname = 'plpgsql' AND p.proowner != 10",
+    captureStdout: true,
+  });
   return parseInt(out, 10) > 0;
 }
 
-async function plan() {
+export async function plan() {
   let dbs;
   try { dbs = listUserDbs(); } catch (err) { return `cannot enumerate DBs: ${err.message}`; }
-  return `would DROP+CREATE plpgsql in ${dbs.length} user DB(s): ${dbs.join(', ')} (skipping any with user-owned plpgsql functions)`;
+  return `would DROP+CREATE plpgsql in ${dbs.length} user DB(s): ${dbs.join(', ')}`;
 }
 
-async function execute({ log, warn }) {
+export async function execute({ warn }) {
   let dbs;
   try { dbs = listUserDbs(); } catch (err) { return { status: 'FAIL', detail: `cannot enumerate DBs: ${err.message}` }; }
   if (dbs.length === 0) return { status: 'SKIP', detail: 'no user DBs to refresh' };
 
-  let refreshed = 0;
-  let skipped = 0;
+  let refreshed = 0, skipped = 0;
   for (const db of dbs) {
     if (SYSTEM_DBS.has(db)) { skipped++; continue; }
     try {
       if (hasUserOwnedPlpgsqlFunctions(db)) {
-        warn(`[plpgsql-resolve] skip ${db}: has user-owned plpgsql functions (DROP CASCADE would lose them)`);
-        skipped++;
-        continue;
+        warn(`[plpgsql-resolve] skip ${db}: user-owned plpgsql functions present (DROP CASCADE would lose them)`);
+        skipped++; continue;
       }
       pgQuery({ db, sql: 'DROP EXTENSION IF EXISTS plpgsql CASCADE; CREATE EXTENSION plpgsql' });
       refreshed++;
@@ -69,5 +64,3 @@ async function execute({ log, warn }) {
   }
   return { status: 'OK', detail: `refreshed ${refreshed} DB(s), skipped ${skipped}` };
 }
-
-module.exports = { name: 'plpgsql-resolve', plan, execute };

--- a/src/upgrade/steps/port-reconcile.js
+++ b/src/upgrade/steps/port-reconcile.js
@@ -1,25 +1,17 @@
 /**
- * Step 1 — Port reconciliation.
- *
- * Ensures pgserve listens on the canonical port (8432). If a running
- * pgserve is bound to a different port, stop it and relaunch on 8432.
- *
- * Idempotent: if already on 8432 (or not running), SKIP.
- *
- * Why: autopg-v22 partial roll-out launched pgserve on 9432 (default of
- * the new postgres-server.js multi-tenant mode after proxy deletion).
- * Existing consumers (omni-api, genie-serve) hardcode 8432 and silently
- * fail to connect. This step restores the user-facing contract.
+ * Step 1 — Port reconciliation. Ensures pgserve listens on canonical 8432.
+ * If running on a different port, stop and relaunch on 8432. Idempotent.
  */
 
-const { execSync } = require('node:child_process');
+import { execSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
 
+export const name = 'port-reconcile';
 const CANONICAL_PORT = 8432;
 
 function readPostmasterPid(dataDir) {
   try {
-    const fs = require('node:fs');
-    const path = require('node:path');
     const content = fs.readFileSync(path.join(dataDir, 'postmaster.pid'), 'utf8');
     const lines = content.trim().split('\n');
     return { pid: parseInt(lines[0], 10), port: parseInt(lines[3], 10) };
@@ -32,34 +24,29 @@ function getDataDir() {
   return process.env.PGSERVE_DATA || `${process.env.HOME}/.pgserve/data`;
 }
 
-async function plan() {
+export async function plan() {
   const info = readPostmasterPid(getDataDir());
   if (!info) return 'no running pgserve detected — nothing to reconcile';
   if (info.port === CANONICAL_PORT) return `already on port ${CANONICAL_PORT}, no action needed`;
   return `would stop pgserve PID ${info.pid} (port ${info.port}) and relaunch on ${CANONICAL_PORT}`;
 }
 
-async function execute({ log, warn }) {
+export async function execute({ log, warn }) {
   const info = readPostmasterPid(getDataDir());
   if (!info) return { status: 'SKIP', detail: 'no running pgserve' };
   if (info.port === CANONICAL_PORT) return { status: 'SKIP', detail: `already on ${CANONICAL_PORT}` };
 
   log(`stopping pgserve PID ${info.pid} (port ${info.port})`);
   try {
-    // Prefer pm2 if pgserve is supervised; falls through to direct signal.
     execSync(`pm2 restart pgserve --update-env -- --port ${CANONICAL_PORT}`, { stdio: 'pipe' });
     return { status: 'OK', detail: `pm2 restart pgserve on port ${CANONICAL_PORT}` };
   } catch (pm2Err) {
     warn(`pm2 restart failed (${pm2Err.message}) — falling back to direct pg_ctl`);
     try {
       execSync(`pg_ctl -D ${getDataDir()} -m fast stop`, { stdio: 'pipe' });
-      // Caller will need to relaunch via `autopg install` or pm2 — we don't auto-launch
-      // because the launch invocation differs by topology (single-tenant vs multi-tenant).
       return { status: 'OK', detail: `stopped pgserve; relaunch via pm2 or autopg install` };
     } catch (ctlErr) {
-      throw new Error(`could not reconcile port: pm2 (${pm2Err.message}) and pg_ctl (${ctlErr.message}) both failed`);
+      throw new Error(`port reconcile failed: pm2 (${pm2Err.message}) and pg_ctl (${ctlErr.message})`);
     }
   }
 }
-
-module.exports = { name: 'port-reconcile', plan, execute };

--- a/src/upgrade/steps/port-reconcile.js
+++ b/src/upgrade/steps/port-reconcile.js
@@ -1,0 +1,65 @@
+/**
+ * Step 1 — Port reconciliation.
+ *
+ * Ensures pgserve listens on the canonical port (8432). If a running
+ * pgserve is bound to a different port, stop it and relaunch on 8432.
+ *
+ * Idempotent: if already on 8432 (or not running), SKIP.
+ *
+ * Why: autopg-v22 partial roll-out launched pgserve on 9432 (default of
+ * the new postgres-server.js multi-tenant mode after proxy deletion).
+ * Existing consumers (omni-api, genie-serve) hardcode 8432 and silently
+ * fail to connect. This step restores the user-facing contract.
+ */
+
+const { execSync } = require('node:child_process');
+
+const CANONICAL_PORT = 8432;
+
+function readPostmasterPid(dataDir) {
+  try {
+    const fs = require('node:fs');
+    const path = require('node:path');
+    const content = fs.readFileSync(path.join(dataDir, 'postmaster.pid'), 'utf8');
+    const lines = content.trim().split('\n');
+    return { pid: parseInt(lines[0], 10), port: parseInt(lines[3], 10) };
+  } catch {
+    return null;
+  }
+}
+
+function getDataDir() {
+  return process.env.PGSERVE_DATA || `${process.env.HOME}/.pgserve/data`;
+}
+
+async function plan() {
+  const info = readPostmasterPid(getDataDir());
+  if (!info) return 'no running pgserve detected — nothing to reconcile';
+  if (info.port === CANONICAL_PORT) return `already on port ${CANONICAL_PORT}, no action needed`;
+  return `would stop pgserve PID ${info.pid} (port ${info.port}) and relaunch on ${CANONICAL_PORT}`;
+}
+
+async function execute({ log, warn }) {
+  const info = readPostmasterPid(getDataDir());
+  if (!info) return { status: 'SKIP', detail: 'no running pgserve' };
+  if (info.port === CANONICAL_PORT) return { status: 'SKIP', detail: `already on ${CANONICAL_PORT}` };
+
+  log(`stopping pgserve PID ${info.pid} (port ${info.port})`);
+  try {
+    // Prefer pm2 if pgserve is supervised; falls through to direct signal.
+    execSync(`pm2 restart pgserve --update-env -- --port ${CANONICAL_PORT}`, { stdio: 'pipe' });
+    return { status: 'OK', detail: `pm2 restart pgserve on port ${CANONICAL_PORT}` };
+  } catch (pm2Err) {
+    warn(`pm2 restart failed (${pm2Err.message}) — falling back to direct pg_ctl`);
+    try {
+      execSync(`pg_ctl -D ${getDataDir()} -m fast stop`, { stdio: 'pipe' });
+      // Caller will need to relaunch via `autopg install` or pm2 — we don't auto-launch
+      // because the launch invocation differs by topology (single-tenant vs multi-tenant).
+      return { status: 'OK', detail: `stopped pgserve; relaunch via pm2 or autopg install` };
+    } catch (ctlErr) {
+      throw new Error(`could not reconcile port: pm2 (${pm2Err.message}) and pg_ctl (${ctlErr.message}) both failed`);
+    }
+  }
+}
+
+module.exports = { name: 'port-reconcile', plan, execute };

--- a/tests/upgrade/postinstall.test.js
+++ b/tests/upgrade/postinstall.test.js
@@ -1,15 +1,16 @@
 /**
- * Smoke test: postinstall hook short-circuits on fresh install + skip flag.
- * Full integration tests (synthetic 2.1.3 → 2.2.x migration, no-op idempotence)
- * require pg fixtures and live in tests/integration/upgrade-*.test.js (TBD).
+ * Smoke tests: postinstall hook short-circuits on fresh install + skip flag.
+ * Full integration tests (synthetic 2.1.3 → 2.2.x) live in tests/integration/upgrade-*.test.js (TBD).
  */
 
-const { test, expect } = require('bun:test');
-const { spawnSync } = require('node:child_process');
-const path = require('node:path');
-const fs = require('node:fs');
-const os = require('node:os');
+import { test, expect } from 'bun:test';
+import { spawnSync } from 'node:child_process';
+import path from 'node:path';
+import fs from 'node:fs';
+import os from 'node:os';
+import { fileURLToPath } from 'node:url';
 
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const POSTINSTALL = path.join(__dirname, '..', '..', 'scripts', 'postinstall.cjs');
 
 test('postinstall: AUTOPG_SKIP_POSTINSTALL=1 short-circuits silently', () => {
@@ -24,8 +25,10 @@ test('postinstall: AUTOPG_SKIP_POSTINSTALL=1 short-circuits silently', () => {
 
 test('postinstall: fresh install (no data dir) exits 0 silently', () => {
   const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'autopg-test-'));
+  const env = { ...process.env, AUTOPG_CONFIG_DIR: tmp };
+  delete env.AUTOPG_SKIP_POSTINSTALL;
   const r = spawnSync(process.execPath, [POSTINSTALL], {
-    env: { ...process.env, AUTOPG_CONFIG_DIR: tmp, AUTOPG_SKIP_POSTINSTALL: undefined },
+    env,
     stdio: ['ignore', 'pipe', 'pipe'],
     timeout: 5000,
   });
@@ -34,9 +37,8 @@ test('postinstall: fresh install (no data dir) exits 0 silently', () => {
 });
 
 test('upgrade orchestrator: dry-run lists 6 steps without executing', async () => {
-  const { upgrade, STEPS } = require(path.join(__dirname, '..', '..', 'src', 'upgrade'));
+  const { upgrade, STEPS } = await import(path.join(__dirname, '..', '..', 'src', 'upgrade', 'index.js'));
   expect(STEPS.length).toBe(6);
-  // dry-run should not throw and should report all steps
   const r = await upgrade({ dryRun: true, quiet: true });
   expect(r.results.length).toBe(6);
   expect(r.results.every((x) => x.status === 'DRY-RUN')).toBe(true);

--- a/tests/upgrade/postinstall.test.js
+++ b/tests/upgrade/postinstall.test.js
@@ -1,0 +1,43 @@
+/**
+ * Smoke test: postinstall hook short-circuits on fresh install + skip flag.
+ * Full integration tests (synthetic 2.1.3 → 2.2.x migration, no-op idempotence)
+ * require pg fixtures and live in tests/integration/upgrade-*.test.js (TBD).
+ */
+
+const { test, expect } = require('bun:test');
+const { spawnSync } = require('node:child_process');
+const path = require('node:path');
+const fs = require('node:fs');
+const os = require('node:os');
+
+const POSTINSTALL = path.join(__dirname, '..', '..', 'scripts', 'postinstall.cjs');
+
+test('postinstall: AUTOPG_SKIP_POSTINSTALL=1 short-circuits silently', () => {
+  const r = spawnSync(process.execPath, [POSTINSTALL], {
+    env: { ...process.env, AUTOPG_SKIP_POSTINSTALL: '1' },
+    stdio: ['ignore', 'pipe', 'pipe'],
+    timeout: 5000,
+  });
+  expect(r.status).toBe(0);
+  expect(r.stdout.toString()).toBe('');
+});
+
+test('postinstall: fresh install (no data dir) exits 0 silently', () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'autopg-test-'));
+  const r = spawnSync(process.execPath, [POSTINSTALL], {
+    env: { ...process.env, AUTOPG_CONFIG_DIR: tmp, AUTOPG_SKIP_POSTINSTALL: undefined },
+    stdio: ['ignore', 'pipe', 'pipe'],
+    timeout: 5000,
+  });
+  expect(r.status).toBe(0);
+  fs.rmSync(tmp, { recursive: true, force: true });
+});
+
+test('upgrade orchestrator: dry-run lists 6 steps without executing', async () => {
+  const { upgrade, STEPS } = require(path.join(__dirname, '..', '..', 'src', 'upgrade'));
+  expect(STEPS.length).toBe(6);
+  // dry-run should not throw and should report all steps
+  const r = await upgrade({ dryRun: true, quiet: true });
+  expect(r.results.length).toBe(6);
+  expect(r.results.every((x) => x.status === 'DRY-RUN')).toBe(true);
+});


### PR DESCRIPTION
See branch + commit message for full detail. Wish: .genie/wishes/autopg-upgrade-command/WISH.md (lint clean). Implements idempotent autopg upgrade CLI verb + postinstall auto-wire to patch the upgrade-path hole left by autopg-v22 partial roll-out (port silently shifted to 9432, plpgsql .so refs stale). 6 idempotent steps + soft-fail postinstall. Default port stays 8432 (Felipe directive). Tests: 3/3 smoke pass; full integration recommended as follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `autopg upgrade` command for transparent, idempotent version migrations, preserving the port 8432 contract and validating post-upgrade health.
  * Integrated automatic upgrade hook during package installation for existing deployments; non-breaking and can be skipped via `AUTOPG_SKIP_POSTINSTALL=1`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->