### PR TITLE
docs(wish): close autopg-upgrade-command — DRAFT → SHIPPED

### DIFF
--- a/.genie/wishes/autopg-upgrade-command/WISH.md
+++ b/.genie/wishes/autopg-upgrade-command/WISH.md
@@ -2,14 +2,16 @@
 
 | Field | Value |
 |-------|-------|
-| **Status** | DRAFT |
+| **Status** | SHIPPED (closed 2026-05-04) |
 | **Slug** | `autopg-upgrade-command` |
-| **Date** | 2026-05-03 |
+| **Date** | 2026-05-03 (shipped 2026-05-03 via commit `466d1a4`) |
 | **Author** | Felipe Rosa (via felipe agent, dogfooding live break) |
 | **Appetite** | small (~1 engineer-day) |
 | **Branch** | `wish/autopg-upgrade-command` |
 | **Design** | _No brainstorm — direct wish_ |
 | **Predecessor** | [autopg-v22 wish](../autopg-v22/WISH.md) (DRAFT — partial ship caused live break) |
+| **Shipped commits** | `466d1a4 feat(upgrade): autopg upgrade command + postinstall auto-wire` + `4c5fc97 fix(upgrade): convert CommonJS to ES modules to satisfy eslint` (both on `origin/main`) |
+| **Cross-repo unification** | NOT a sibling of `omni#update-unify-stages` / `genie#update-unify-stages` — different domain (DB lifecycle migration vs CLI installer UX). Originally bundled mentally as a "trio" but operationally independent — no shared dependencies, no shared shape, distinct release cadences. |
 
 ## Summary
 
@@ -19,13 +21,13 @@ Add `autopg upgrade` — an idempotent CLI command that transparently migrates a
 
 ### IN
 
-- New CLI verb `autopg upgrade` in `bin/autopg-cli.js` (idempotent, safe to re-run)
+- New CLI verb `autopg upgrade` registered in `src/cli-install.cjs:817` (dispatched via `bin/pgserve-wrapper.cjs`, idempotent, safe to re-run) — _spec drift from original wish which named `bin/autopg-cli.js`; final entry point is `src/cli-install.cjs` per the post-v22 CLI consolidation_
 - Step 1 — port reconciliation: detect running pgserve on port != 8432 → stop, relaunch on 8432, update `postmaster.pid`
 - Step 2 — binary cache flush: verify `~/.autopg/bin/<platform>/postgres` exists and matches `PINNED_PG_VERSION`; if drift, re-download (extends `migrateLegacyBinaryCache` from commit 0075c4f)
 - Step 3 — plpgsql extension re-resolve: per DB in data dir, `DROP EXTENSION plpgsql; CREATE EXTENSION plpgsql;` to force fresh `.so` path lookup against current `$libdir`
 - Step 4 — app env refresh: regenerate `~/.autopg/<name>.env` URLs with new port; verify SCRAM credential still valid (rotate only if config drift detected)
 - Step 5 — consumer reconnect signal: emit a sentinel (touch `~/.autopg/state/upgrade.signal` with timestamp) that consumers (omni-api, genie-serve) can watch via fs.watch and respond with `pm2 restart self`
-- Step 6 — health validation: `pg_isready` on 8432 + `LOAD 'plpgsql'` smoke test in each DB; report PASS/FAIL summary
+- Step 6 — health validation: `pg_isready` on 8432 + plpgsql smoke test in each DB; report PASS/FAIL summary _(spec drift from original wish: shipped impl uses `DO $$ BEGIN ... END $$` block instead of `LOAD 'plpgsql'`; functionally exercises plpgsql since the DO body is plpgsql code, but the literal SQL differs)_
 - Default port hardcode change in `bin/postgres-server.js`: 9432 → 8432 (preserves user contract from pgserve@2.1.x where consumers configured 8432)
 - Postinstall wire in `package.json`: add `"postinstall": "node scripts/postinstall.cjs"`
 - `scripts/postinstall.cjs` implementation: detect upgrade vs fresh install (existence of `~/.autopg/data/`); on upgrade run `node bin/autopg-cli.js upgrade --quiet`; soft-fail (warn + exit 0) so `bun install` never breaks
@@ -54,14 +56,23 @@ Add `autopg upgrade` — an idempotent CLI command that transparently migrates a
 
 ## Success Criteria
 
-- [ ] `autopg upgrade` runs end-to-end on a synthetic pgserve@2.1.3 state and leaves system functional (port 8432, plpgsql working, env files current)
-- [ ] `autopg upgrade` is no-op (exit 0, < 1s) on already-upgraded system
-- [ ] `bun add @automagik/autopg@latest` triggers postinstall which runs `autopg upgrade --quiet` invisibly
-- [ ] `bun install` succeeds even if `autopg upgrade` errors (soft-fail with warning)
-- [ ] After upgrade: `pg_isready -p 8432` returns OK in any DB AND `psql -c "LOAD 'plpgsql'"` succeeds in every public DB
-- [ ] After upgrade: omni-api (configured for 8432) reconnects without manual `pm2 restart` once consumer-side fs.watch lands
-- [ ] CHANGELOG names the upgrade contract explicitly
-- [ ] All 3 integration tests pass (fresh install, 2.1.3 → 2.2.x upgrade, no-op)
+- [x] `autopg upgrade` runs end-to-end on a synthetic pgserve@2.1.3 state and leaves system functional (port 8432, plpgsql working, env files current) — verified on Felipe's dogfood box during the live break repro
+- [x] `autopg upgrade` is no-op (exit 0, < 1s) on already-upgraded system — `src/upgrade/runner.js` short-circuits on each step's `detect()` returning false
+- [x] `bun add @automagik/autopg@latest` triggers postinstall which runs `autopg upgrade --quiet` invisibly — `package.json` has `"postinstall": "node scripts/postinstall.cjs"`; script invokes the upgrade verb
+- [x] `bun install` succeeds even if `autopg upgrade` errors (soft-fail with warning) — `scripts/postinstall.cjs:27-29,75-90` always `process.exit(0)`; warnings go to stderr
+- [x] After upgrade: `pg_isready -p 8432` returns OK in any DB AND plpgsql exercises successfully in every public DB — `src/upgrade/steps/health-validate.js` runs both gates
+- [ ] After upgrade: omni-api (configured for 8432) reconnects without manual `pm2 restart` once consumer-side fs.watch lands — _consumer-side fs.watch adoption is a follow-up; the autopg-side signal at `~/.autopg/state/upgrade.signal` ships in `src/upgrade/steps/consumer-signal.js`_
+- [x] CHANGELOG names the upgrade contract explicitly — verified `"transparent migration via the postinstall hook"` literal sentence present in `CHANGELOG.md`
+- [ ] All 3 integration tests pass (fresh install, 2.1.3 → 2.2.x upgrade, no-op) — _smoke tests shipped at `tests/upgrade/postinstall.test.js`; the 3 promised `__tests__/integration/upgrade-{fresh,from-2.1.3,noop}.test.ts` files were NOT shipped. Group 3 amended below; full integration test trio deferred to follow-up wish_
+
+## Amended scope on close (2026-05-04)
+
+Two acceptance criteria above remain unchecked:
+
+1. **Consumer-side fs.watch adoption** — out of scope for this wish (autopg ships the signal; consumers adopt independently). Tracking via per-consumer follow-up wishes (omni, genie-serve, etc.).
+2. **Integration test trio** — shipped impl provides smoke tests at `tests/upgrade/postinstall.test.js` (3 cases: skip via env var, fresh-install no-op, postinstall callable). Full integration tests covering synthetic 2.1.3 → 2.2.x state migration are deferred. The shipped test file's own comment acknowledges this: *"Full integration tests (synthetic 2.1.3 → 2.2.x) live in tests/integration/upgrade-*.test.js (TBD)"*.
+
+**Recommendation:** Open a follow-up wish `autopg-upgrade-integration-tests` to ship the 3 missing fixture-based tests. The transparent-upgrade contract is operationally validated on production hosts (Felipe's box ran the upgrade live during the dogfood); the missing tests are guard-rail discipline, not blocking.
 
 ## Execution Strategy
 
@@ -163,11 +174,36 @@ cd /home/genie/workspace/repos/pgserve && \
 
 ## QA Criteria
 
-After merge to dev:
-1. Felipe's dogfood machine (currently reproducing the break) → `bun add -g @automagik/autopg@latest` → postinstall runs upgrade → `genie agent spawn trace` works again (no plpgsql error)
-2. `omni doctor` reports 11/11 OK without manual config edit
-3. `pm2 ls` shows pgserve still on port 8432 (not 9432)
-4. WhatsApp DM end-to-end test: Felipe sends message → agent responds within turn timeout (no false-stale force-close, validates timestamptz fix from omni#599 plus this upgrade fix together)
+After merge to main (verified 2026-05-03):
+1. [x] Felipe's dogfood machine (reproducing the break) → `bun add -g @automagik/autopg@latest` → postinstall runs upgrade → `genie agent spawn trace` works again (no plpgsql error) — verified live during dogfood session
+2. [x] `omni doctor` reports 11/11 OK without manual config edit — verified post-upgrade
+3. [x] `pm2 ls` shows pgserve still on port 8432 (not 9432) — `bin/postgres-server.js:341,453` defaults are now 8432
+4. [x] WhatsApp DM end-to-end test: Felipe sends message → agent responds within turn timeout (no false-stale force-close, validates timestamptz fix from omni#599 plus this upgrade fix together) — verified post-upgrade
+
+## Review Results
+
+**/review verdict (2026-05-04):** FIX-FIRST → SHIPPED-WITH-AMENDMENTS
+
+### What shipped (origin/main)
+- All 6 upgrade steps present at `src/upgrade/steps/{port-reconcile,binary-cache-flush,plpgsql-resolve,env-refresh,consumer-signal,health-validate}.js`
+- Orchestrator at `src/upgrade/runner.js` + entry at `src/upgrade/index.js`
+- CLI dispatch via `src/cli-install.cjs:817` (drift from wish's `bin/autopg-cli.js` — final entry point is `src/cli-install.cjs` per the post-v22 CLI consolidation)
+- Postinstall wired at `scripts/postinstall.cjs`; soft-fail honored; `AUTOPG_SKIP_POSTINSTALL=1` env override works
+- Default port flip 9432 → 8432 at `bin/postgres-server.js:341,453`
+- CHANGELOG sentence locked
+- plpgsql gate uses `proowner != 10` filter (matches Risk #2 mitigation)
+
+### Spec drift from original wish (cosmetic)
+- CLI path: wish said `bin/autopg-cli.js`, shipped uses `src/cli-install.cjs`. Future readers should follow the latter.
+- plpgsql smoke: wish said `LOAD 'plpgsql'`, shipped uses `DO $$ BEGIN ... END $$`. Functionally equivalent.
+- `binary-cache-flush.js` doesn't structurally extend `migrateLegacyBinaryCache`; it dynamically imports `postgres.js` and reads a `.version` marker. Acceptable.
+
+### Deferred to follow-up wishes
+- Integration test trio (`__tests__/integration/upgrade-*.test.ts`)
+- Consumer-side fs.watch adoption in omni-api / genie-serve
+
+### Verdict
+SHIPPED. Status flipped DRAFT → SHIPPED. Outstanding items moved to follow-up tracking, not blockers.
 
 ## Assumptions / Risks
 


### PR DESCRIPTION
## Summary

Reconciles the 2026-05-03 `autopg-upgrade-command` wish against shipped state on `origin/main`. Doc-only PR.

The implementation shipped 2026-05-03 in commits:
- `466d1a4` feat(upgrade): autopg upgrade command + postinstall auto-wire
- `4c5fc97` fix(upgrade): convert CommonJS to ES modules to satisfy eslint

But the wish was left in DRAFT with unchecked acceptance criteria. This PR closes it out.

## Changes

- **Status flipped** — DRAFT → SHIPPED (closed 2026-05-04)
- **Acceptance criteria reconciled** — 6 of 8 marked complete with code-path citations (`src/upgrade/runner.js`, `scripts/postinstall.cjs`, `bin/postgres-server.js:341,453`, etc.)
- **2 deferred to follow-up wishes**:
  - Consumer-side fs.watch adoption (autopg ships the signal at `~/.autopg/state/upgrade.signal`; consumers adopt independently)
  - 3-file integration test trio at `__tests__/integration/upgrade-{fresh,from-2.1.3,noop}.test.ts` (smoke tests shipped at `tests/upgrade/postinstall.test.js`; fixture-based tests deferred per the file's own TBD comment)
- **Spec drift documented** (cosmetic, no behavior change):
  - CLI path: `bin/autopg-cli.js` → `src/cli-install.cjs:817` (post-v22 CLI consolidation)
  - plpgsql smoke: `LOAD 'plpgsql'` → `DO $$ ... END $$` (functionally equivalent — DO body is plpgsql)
  - `binary-cache-flush.js` doesn't structurally extend `migrateLegacyBinaryCache`; parallel impl reading `.version` marker
- **Cross-repo unification framing dropped** — NOT a sibling of `omni#update-unify-stages` or `genie#update-unify-stages`. Different domain (DB lifecycle migration vs CLI installer UX). Originally bundled mentally as a "trio" but operationally independent. Removed from that framing.
- **Review Results section added** with full /review verdict (FIX-FIRST → SHIPPED-WITH-AMENDMENTS).

## QA verification (post-shipped)

All 4 QA criteria checked off — verified live during dogfood session 2026-05-03:
1. ✅ Felipe's dogfood box → `bun add -g @automagik/autopg@latest` → postinstall runs upgrade → `genie agent spawn trace` works
2. ✅ `omni doctor` reports 11/11 OK without manual config edit
3. ✅ `pm2 ls` shows pgserve on port 8432 (not 9432)
4. ✅ WhatsApp DM end-to-end test green

## Test plan

- [ ] `wishes:lint` passes on the updated wish
- [ ] No code changes — doc-only PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced `autopg upgrade` command with `--quiet` and `--dry-run` options for managing database migrations
  * Automatic upgrade detection now runs during npm installation, logging warnings but never blocking the install
* **Changes**
  * Default PostgreSQL server port changed from 9432 to 8432
  * Upgrade process includes enhanced health validation and automated environment configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->