### PR TITLE
fix(cluster): wrapper exits when postgres backend dies in cluster mode

### DIFF
--- a/src/cluster.js
+++ b/src/cluster.js
@@ -396,6 +396,51 @@ class ClusterRouter extends EventEmitter {
 
 
 /**
+ * Build a `backendExited` handler for cluster mode supervision.
+ *
+ * On unexpected exit (`expected: false`) — postgres SIGKILL'd, OOM-killed,
+ * segfaulted, etc. — the handler:
+ *   1. logs the exit code,
+ *   2. flips `shuttingDown` so the cluster.on('exit') worker-respawn path
+ *      no longer forks new workers,
+ *   3. SIGTERMs every live worker (no point routing to a dead backend), and
+ *   4. calls `exitFn(1)` so the parent process supervisor restarts us.
+ *
+ * On clean exit (`expected: true`, initiated by `pgManager.stop()`) the
+ * handler is silent — the surrounding shutdown logic handles teardown.
+ *
+ * Exported so the supervision contract can be unit-tested without spawning
+ * a real cluster (the integration path is already covered for single-process
+ * mode by tests/wrapper-supervision.test.js).
+ *
+ * @param {object} args
+ * @param {Map<number, {kill: (sig: string) => void}>} args.workers - live worker registry
+ * @param {(v: boolean) => void} args.setShuttingDown - flips outer-scope `shuttingDown`
+ * @param {(code: number) => void} [args.exitFn=process.exit] - test seam
+ * @param {(...args: unknown[]) => void} [args.log=console.error] - test seam
+ * @returns {(info: {code: number, expected: boolean}) => void}
+ */
+export function buildClusterSupervisionHandler({
+  workers,
+  setShuttingDown,
+  exitFn = process.exit,
+  log = console.error,
+}) {
+  return ({ code, expected }) => {
+    if (expected) return;
+    log(
+      `[pgserve] postgres backend exited unexpectedly (code=${code}) in cluster mode; ` +
+      `the primary is exiting so a process supervisor can restart it.`
+    );
+    setShuttingDown(true);
+    for (const worker of workers.values()) {
+      try { worker.kill('SIGTERM'); } catch { /* worker may already be dead */ }
+    }
+    exitFn(1);
+  };
+}
+
+/**
  * Start pgserve in cluster mode
  */
 export async function startClusterServer(options = {}) {
@@ -425,8 +470,26 @@ export async function startClusterServer(options = {}) {
     console.log(`[pgserve] Embedded PostgreSQL started`);
     console.log(`[pgserve] Socket: ${pgSocketPath || `TCP port ${pgPort}`}`);
 
+    // Track shutdown state and worker registry early so the supervision
+    // handler below can tear workers down on unexpected backend death.
+    let shuttingDown = false;
     const workers = new Map();
     const workerStats = new Map(); // Track stats from each worker
+
+    // Supervision: when the embedded postgres backend dies unexpectedly
+    // (SIGKILL/OOM/segfault — anything other than a clean stop()), exit the
+    // primary so a process supervisor (`genie serve`, pm2, systemd) restarts
+    // the cluster cleanly with a fresh backend. Without this, the primary
+    // keeps running with a zombie pgManager (socketDir nulled) and every
+    // worker fails StartupMessages with "Connection closed" forever while
+    // pm2 reports the process as healthy. Mirrors the single-process fix
+    // in bin/postgres-server.js (PgserveDaemon.on('backendDiedUnexpectedly'))
+    // — pgserve#45 only protected the daemon path, not cluster mode (default
+    // on multi-core systems).
+    pgManager.on('backendExited', buildClusterSupervisionHandler({
+      workers,
+      setShuttingDown: (v) => { shuttingDown = v; },
+    }));
 
     // Fork workers with PostgreSQL connection info.
     //
@@ -456,8 +519,7 @@ export async function startClusterServer(options = {}) {
       workers.set(worker.id, worker);
     }
 
-    // Track shutdown state to prevent worker restart during shutdown
-    let shuttingDown = false;
+    // (shuttingDown declared above with the supervision handler.)
 
     // Restart dead workers (unless shutting down)
     cluster.on('exit', (worker, code, signal) => {

--- a/tests/wrapper-supervision.test.js
+++ b/tests/wrapper-supervision.test.js
@@ -17,6 +17,7 @@
 
 import { PostgresManager } from '../src/postgres.js';
 import { PgserveDaemon } from '../src/daemon.js';
+import { buildClusterSupervisionHandler } from '../src/cluster.js';
 import { EventEmitter } from 'events';
 import { test, expect } from 'bun:test';
 import fs from 'fs';
@@ -104,4 +105,83 @@ test('PgserveDaemon re-emits backendDiedUnexpectedly only on unexpected exit', (
   expect(events[0]).toEqual({ code: 137, expected: false });
 
   fs.rmSync(dir, { recursive: true, force: true });
+});
+
+// -----------------------------------------------------------------------------
+// Cluster-mode supervision (the gap between pgserve#45's daemon-only fix and
+// the auto-cluster default on multi-core systems — see fix/cluster-supervision-gap).
+// -----------------------------------------------------------------------------
+
+test('buildClusterSupervisionHandler is silent on clean stop (expected=true)', () => {
+  const exits = [];
+  const logs = [];
+  let down = false;
+  const workers = new Map();
+  const handler = buildClusterSupervisionHandler({
+    workers,
+    setShuttingDown: (v) => { down = v; },
+    exitFn: (code) => exits.push(code),
+    log: (msg) => logs.push(msg),
+  });
+  handler({ code: 0, expected: true });
+  expect(exits).toHaveLength(0);
+  expect(logs).toHaveLength(0);
+  expect(down).toBe(false);
+});
+
+test('buildClusterSupervisionHandler exits with 1 and SIGTERMs workers on unexpected exit', () => {
+  const killed = [];
+  const w1 = { kill: (sig) => killed.push(['w1', sig]) };
+  const w2 = { kill: (sig) => killed.push(['w2', sig]) };
+  const workers = new Map([[1, w1], [2, w2]]);
+  let down = false;
+  const exits = [];
+  const logs = [];
+  const handler = buildClusterSupervisionHandler({
+    workers,
+    setShuttingDown: (v) => { down = v; },
+    exitFn: (code) => exits.push(code),
+    log: (msg) => logs.push(msg),
+  });
+  handler({ code: 137, expected: false });
+  expect(down).toBe(true);
+  expect(killed).toEqual([['w1', 'SIGTERM'], ['w2', 'SIGTERM']]);
+  expect(exits).toEqual([1]);
+  expect(logs).toHaveLength(1);
+  expect(logs[0]).toMatch(/code=137/);
+  expect(logs[0]).toMatch(/process supervisor can restart it/);
+});
+
+test('buildClusterSupervisionHandler tolerates already-dead workers (kill throws)', () => {
+  const wAlive = { kill: () => {} };
+  const wDead = { kill: () => { throw new Error('ESRCH'); } };
+  const workers = new Map([[1, wAlive], [2, wDead]]);
+  const exits = [];
+  const handler = buildClusterSupervisionHandler({
+    workers,
+    setShuttingDown: () => {},
+    exitFn: (code) => exits.push(code),
+    log: () => {},
+  });
+  // Must not throw — must still call exitFn.
+  expect(() => handler({ code: 9, expected: false })).not.toThrow();
+  expect(exits).toEqual([1]);
+});
+
+test('buildClusterSupervisionHandler wired through PostgresManager event surface', () => {
+  // End-to-end plumbing: synthesize a fake PostgresManager (EventEmitter),
+  // attach the handler, emit backendExited{expected:false}, observe exit.
+  const fakePgManager = new EventEmitter();
+  const workers = new Map([[1, { kill: () => {} }]]);
+  const exits = [];
+  fakePgManager.on('backendExited', buildClusterSupervisionHandler({
+    workers,
+    setShuttingDown: () => {},
+    exitFn: (code) => exits.push(code),
+    log: () => {},
+  }));
+  fakePgManager.emit('backendExited', { code: 0, expected: true });
+  expect(exits).toEqual([]);  // clean stop — silent
+  fakePgManager.emit('backendExited', { code: 137, expected: false });
+  expect(exits).toEqual([1]); // unexpected — exit
 });


### PR DESCRIPTION
## Summary

The supervision fix shipped in **v2.2.3** (#49 / `4d88982`) wired `backendExited → backendDiedUnexpectedly → process.exit(1)` only through the **single-process daemon path** (`PgserveDaemon` in `src/daemon.js`, subscribed by `bin/postgres-server.js:93-99`).

**Cluster mode** (auto-enabled on multi-core systems via `cpuCount > 1 && !isWindows` at `bin/postgres-server.js:459`) takes a different path through `startClusterServer` in `src/cluster.js`. The primary instantiates `PostgresManager` directly (line 414) and calls `pgManager.start()` — but **never subscribes to `pgManager.on('backendExited')`**. When the embedded postgres backend dies unexpectedly (SIGKILL, OOM, segfault, container cgroup memory cap), the primary keeps running with a zombie pgManager. Workers respawn happily and accept TCP connections that immediately fail with `Connection closed`. pm2 reports the wrapper as `online` (it is alive), so no operator sees the failure.

## Real-world incident

Proxmox LXC container, 80-worker cluster. postgres backend SIGKILL'd at `08:12:34`. Wrapper stayed up for **5.5 hours** emitting zero out-log lines after the initial WARN. **~840 MB of error log** accumulated in `pgserve-error.log` (~14 MB/min) before operator intervention. The fix in v2.2.3 was present but unreachable because cluster mode was active.

## Fix

| Change | Where | LOC |
|---|---|---|
| Extract supervision logic into pure exported function `buildClusterSupervisionHandler({workers, setShuttingDown, exitFn, log})` | `src/cluster.js` | +47 |
| Wire it via `pgManager.on('backendExited', …)` immediately after `pgManager.start()` | `src/cluster.js` | +14 |
| Hoist `let shuttingDown` and `const workers` so the handler can flip the flag and walk the registry | `src/cluster.js` | +/-5 |
| 4 new tests: silent on clean stop, exit+SIGTERM on unexpected, tolerates dead workers (kill throws), end-to-end via fake EventEmitter | `tests/wrapper-supervision.test.js` | +80 |

The handler mirrors the daemon path's contract: silent on `expected:true` (clean `stop()`); tears down workers + `process.exit(1)` on `expected:false`. Mirrors the same exit code (1) the single-process wrapper uses, so process supervisors (genie serve, pm2, systemd) treat it identically.

## Validation

```
$ bun test tests/wrapper-supervision.test.js
…
 8 pass
 0 fail
 22 expect() calls
Ran 8 tests across 1 file. [2.90s]
```

(4 existing single-process tests + 4 new cluster-mode tests, all deterministic and cross-platform — no spawned processes in the new tests.)

## Out of scope

- **What killed postgres in the original incident** (kernel/systemd-oomd/Proxmox cgroup) — orthogonal; supervision contract has to hold regardless of why postgres died.
- **Runaway error log throttling** when postgres is missing — should be addressed separately; once supervision exits properly the log spam window collapses to a single retry.
- **Watchdog dead-man's switch** for the case where the wrapper itself locks up before exit — covered by the genie-watchdog package; out of scope here.

## Test plan

- [x] `bun test tests/wrapper-supervision.test.js` clean
- [ ] CI green
- [ ] Reviewer sanity-check: simulate `pgManager.emit('backendExited', {code:137,expected:false})` against a running cluster and verify the wrapper exits within ~50ms

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved cluster stability: cluster mode now monitors backend process health, logs unexpected exits, and initiates coordinated worker shutdown to prevent resource leaks.

* **Tests**
  * Added comprehensive test coverage for cluster supervision, validating behavior during expected clean exits and unexpected failures with edge-case handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->