### PR TITLE
docs(wish): pgserve-singleton-no-proxy v2.3 — kill proxy + cosign + self-healing

### DIFF
--- a/.genie/wishes/pgserve-singleton-no-proxy/SHARED-DESIGN.md
+++ b/.genie/wishes/pgserve-singleton-no-proxy/SHARED-DESIGN.md
@@ -148,7 +148,9 @@ Steps marked NEW are what this wish adds.
 | `<cli> doctor --fix` | auto-mutate **category 1** (safe), prompt **category 2** (data-touching) | one prompt per category-2 mutation | Default invocation by `<cli> update` step 11 |
 | `<cli> doctor --fix --aggressive` | auto-mutate cat 1 + cat 2, refuse cat 3 (irreversible-destructive) | none | CI / automation / explicit operator opt-in |
 
-**Mutation categories**:
+**Mutation categories** (boundary rule):
+
+> **Cat 1 = reversible within 1 command** (e.g. pm2 restart can be re-run). **Cat 2 = data-touching but recoverable** (archives preserved in `.legacy/`, .bak backups, prompts before mutation). **Cat 3 = irreversible / destructive** (DROP DATABASE on populated, role privilege escalation). Refuses without `--unsafe-unverified <INCIDENT_ID>` typed-ack.
 
 | Category | Examples | Authority |
 |----------|----------|-----------|
@@ -163,6 +165,7 @@ Steps marked NEW are what this wish adds.
 - **Runtime check**: `<cli> serve` boot revalidates peer versions; refuses with same remediation if peer was downgraded or rolled back post-update. Reuses the canonical-cutover hard-error pattern.
 - **Override**: `<cli> update --ignore-peer-mismatch` typed-ack `I_ACKNOWLEDGE_PEER_MISMATCH` for debug/exotic flows.
 - **No orchestrator binary**: no `automagik update --all`. 3 sequential CLIs is fine; error messages guide ordering.
+- **Operator update order (locked)**: `pgserve update` → `genie update` → `omni update`. pgserve is the foundation; consumers come after. Each `<cli> update`'s pre-install peer check enforces this — if you run them out of order, the second one refuses with explicit remediation.
 
 ### 3.4 Rollback (manual)
 

--- a/.genie/wishes/pgserve-singleton-no-proxy/SHARED-DESIGN.md
+++ b/.genie/wishes/pgserve-singleton-no-proxy/SHARED-DESIGN.md
@@ -1,0 +1,334 @@
+# SHARED-DESIGN: pgserve singleton, no proxy, self-healing updates
+
+**Status**: design locked 2026-05-06.
+
+**Companion wishes** (byte-identical SHARED-DESIGN.md across all three):
+- `automagik/pgserve#pgserve-singleton-no-proxy` — pgserve major v2.3 (kill proxy, add cosign, new CLI verbs)
+- `automagik-dev/genie#pgserve-singleton-no-proxy` — genie consumer-side wiring + self-healing `genie update`
+- `automagik/omni#pgserve-singleton-no-proxy` — omni consumer-side wiring + self-healing `omni update`
+
+**Goal**: One synchronized cutover that converges three things — kill the bun proxy from the data plane, layer cosign-based publisher-attestation on top of host-signed identity, and lock down a self-healing `<cli> update` contract so every update converges drift to known-good state without manual operator intervention.
+
+**Version target**: pgserve **2.3** (not 3.0 — 3.0 reserved for the post-npm-departure cutover per `distribution-exodus`).
+
+---
+
+## 1. Today's friction (the diagnosis)
+
+### Three independent symptoms that have one root
+
+1. **Two pgserves on disk, only one understood.** `pm2 pgserve` (autopg 2.2.4) runs the bun bridge on TCP 8432 → routes to internal postgres on 9432 → exposes `/tmp/pgserve-sock-<pid>-<ts>` Unix socket. Genie expects pgserve socket at `$XDG_RUNTIME_DIR/pgserve/.s.PGSQL.5432`. **Mismatch:** genie's `requirePgserveDaemon()` (`src/lib/db.ts:307`) only checks the canonical Unix socket; throws "no daemon" even when bun bridge + postgres backend are both healthy on TCP. Live diagnostic on this server (2026-05-05): pgserve binary `pgserve port` returns `8432` ✅, postgres backend listening on 9432 ✅, but `/run/user/1000/pgserve/` directory does not exist ❌.
+
+2. **Genie was already cut over to consumer-only — but the cutover is invisible at runtime.** `pgserve-canonical-cutover` shipped on dev (commits `eefc9a94`, `bd8845eb`, `0ae69eb3`). `_ensurePgserve()` (`db.ts:749`) explicitly throws "Genie is consumer-only after the canonical-pgserve cutover; it does not spawn pgserve." Vendored pgserve binary in `node_modules/@automagik/genie/node_modules/pgserve/` was removed. Yet pm2 `genie-serve` (id 14) shows **18 restarts in 3 hours** with scheduler.log spamming "pgserve v2 daemon exited before binding". The canonical socket the cutover code expects doesn't exist; the cutover landed but didn't land cleanly because the **autopg pgserve doesn't publish to the canonical socket path** genie was consuming.
+
+3. **`genie update` is not self-healing.** Operator runs `genie update`, new binary installs to disk, BUT pm2's running process keeps the OLD binary in memory (no `pm2 restart genie-serve --update-env`). `<cli> doctor --fix` is not invoked. Migrations don't run automatically. Result: the cutover code shipped 2 days ago is on disk but not in any running process. Operator manually runs `pm2 restart genie-serve` after every update to actually pick up the new bits — and most don't.
+
+### The pattern
+
+Each symptom looks like a separate bug. The pattern is one architectural drift: the system has two control planes (bun pgserve daemon supervision via pm2, plus genie's own daemon supervision via pm2-and-process-tree-walking), and updates touch one but not the other. Every release widens the drift until the operator does manual reconciliation.
+
+---
+
+## 2. The shift (architectural target)
+
+### 2.1 Data plane: pure postgres, two transports, no proxy
+
+Postgres backend listens on **both** transports natively. Zero bun in the data path:
+
+- **Unix socket** at `$XDG_RUNTIME_DIR/pgserve/.s.PGSQL.5432` (canonical, primary). Set via postmaster `-k $XDG_RUNTIME_DIR/pgserve` argument.
+- **TCP** on port `5432` (canonical port, not 8432). Set via postmaster `-p 5432` and `listen_addresses = 'localhost'`.
+
+Clients connect with libpq directly — `PGHOST=$XDG_RUNTIME_DIR/pgserve` for socket, or `host=localhost port=5432` for TCP. No bridge. No router. No `8432`.
+
+The bun process that exists today as the proxy/router **dies in the data plane**. It survives only as the `pgserve` CLI binary, invoked on-demand for control operations.
+
+### 2.2 Control plane: CLI on-demand, zero always-on bun process
+
+The bun pgserve daemon is **deleted as a process**. All control-plane operations move to `pgserve` CLI subcommands invoked on-demand:
+
+- `pgserve provision <fingerprint>` — creates DB + role, validates trust tier (cosign / host_signed / path), idempotent. Called by client SDK on `3D000` (database-not-found) errors with `pg_advisory_lock` to dedupe concurrent races.
+- `pgserve gc` — sweeps orphaned databases (uid removed, project deleted via project-marker mtime checks). Run by cron / systemd timer, NOT a long-running scheduler. `pgserve install` wires the timer automatically.
+- `pgserve verify <binary-path>` — performs cosign / host_signed validation against trust list, writes HMAC-signed cache token at `$XDG_STATE_HOME/pgserve/verified/<fingerprint>.token`.
+- `pgserve trust add` / `pgserve trust list` / `pgserve trust remove` — manage user-extensible trust roots (cosign keys, OIDC issuer identities).
+- `pgserve doctor` (default) / `pgserve doctor --fix` (auto-mute safe mutations + prompt risky ones) / `pgserve doctor --fix --aggressive` (no prompts, CI mode).
+
+Audit becomes a postgres `pgaudit` extension load — no application-level audit-log writer. Logrotate config shipped with `pgserve install`.
+
+### 2.3 Identity & trust: signed vs not-signed (binary classification)
+
+Two outcomes, both persistent (no ephemeral, no TTL). Persistence is universal; the tier decides only trust + role grants.
+
+| Class | Verifies as | DB | Role grants | UX |
+|-------|-------------|-----|-------------|-----|
+| **signed** | cosign-verified OR host_signed handshake OR operator-pretrusted self-sign | persistent project DB | named role; full owner of own DB; can request explicit cross-DB grants (Tier 2 cosign-named only via `pgserve grant`) | silent run; badge in `pgserve doctor` |
+| **not signed** | everything else (no `pgserve` block in package.json, OR no signature, OR no handshake) | persistent project DB | full owner of own DB; **zero** cross-DB; whitelisted extensions only | RUN with warning banner: "⚠ UNSIGNED — DEV ONLY" |
+
+**Critical**: not-signed apps are NOT ephemeral. They get the same project-scoped persistent DB as signed apps. The differences are: (a) trust attestation, (b) named-role specifics (signed gets `pgserve_app_<publisher>`; not-signed gets generic `app_<fp>`), and (c) cross-DB grant capability (signed only).
+
+### 2.4 Trust list (cosign tier)
+
+- **Hardcoded automagik-dev**: compiled into `pgserve` binary. Identities accepted by default: `https://github.com/automagik-dev/genie/.github/workflows/release.yml@refs/tags/v*`, `https://github.com/automagik/omni/.github/workflows/release.yml@refs/tags/v*`, `https://github.com/automagik/pgserve/.github/workflows/release.yml@refs/tags/v*`. Updates to this list propagate via `pgserve update`.
+- **User self-sign**: `pgserve trust add --identity <issuer> --key <pubkey>` writes to `~/.pgserve/trust/identities.json`. HTTPS-self-signed analog: works locally for the operator, doesn't grant trust globally.
+- **Verification cadence**: HMAC-signed cache token at `$XDG_STATE_HOME/pgserve/verified/<fingerprint>.token` (web-session-style). Sliding expiry (1h idle, 7d max). Re-verify on binary mtime change. Steady-state connections pay 0ms; updates pay re-verify.
+
+### 2.5 No revocation infra v1
+
+Rationale: building a revocation pipeline (Rekor consultation, revoked.json sync, sigstore policy plugins) is overengineering for a local-DB use case where bad versions reach operators via `pgserve update` itself. The release pipeline IS the revocation channel:
+
+1. Bad version published (CVE, accidental data deletion, key compromise).
+2. Namastex publishes new release with the bad version added to the **hardcoded blocklist** in the new `pgserve` binary's compile-time constants.
+3. Operators get the fix via `pgserve update` — which now refuses the bad version.
+
+Trade: hosts that don't update for weeks remain vulnerable. Acceptable: cosign tier = official apps published controllably; if a host doesn't update, the operator has bigger problems than one bad genie release.
+
+### 2.6 No offline / TUF embedding v1
+
+Rationale: cosign keyless OIDC verification needs network for sigstore TUF roots + Rekor inclusion. But: genie/omni install ALREADY needs network to download the binary from the CDN. If the host can hit `cdn.automagik.dev`, it can hit `sigstore.dev`. Air-gap is not the target deployment for v1.
+
+Escape hatch: `pgserve trust add --offline-cosign-key <pubkey>` lets an operator pre-trust a static cosign key and run `pgserve verify --skip-sigstore` for fully air-gapped boxes. Not the default; not the marketing.
+
+### 2.7 Failure modes (Gatekeeper model)
+
+| Scenario | Behavior |
+|----------|----------|
+| App without `pgserve` block in `package.json` | RUN with warning banner; not-signed tier; persistent project DB; isolated role |
+| App with `package.json` `pgserve.identity_chain: ["cosign_signed", ...]`, ALL chain entries fail verify | **REFUSE** with diagnostic. App declared a tier and didn't deliver — that's tampering, not dev. |
+| App with `identity_chain` and at least one entry verifies | RUN at highest verified tier, silent |
+| Operator emergency override | `--unsafe-unverified <INCIDENT_ID>` typed-ack (existing pattern from `genie-supply-chain-signing`, helper `src/sec/unsafe-verify.ts`) |
+| Light dev-mode silence | `--accept-unsigned-dev` flag silences the warning banner for one invocation (no typed-ack required) |
+
+### 2.8 `package.json` opt-in shape
+
+```jsonc
+{
+  "pgserve": {
+    "publisher": "@automagik/genie",
+    "identity_chain": [
+      { "kind": "cosign_signed", "issuer": "https://github.com/automagik-dev/genie/.github/workflows/release.yml@refs/tags/v*" },
+      { "kind": "self_signed", "trust_root": "$HOME/.pgserve/trust/" }
+    ],
+    "on_chain_exhausted": "refuse"
+  }
+}
+```
+
+App declares ordered chain; pgserve tries each in order; falls back to next on miss; refuses if all fail. Apps with no `pgserve` block default to path/not-signed tier.
+
+---
+
+## 3. Self-healing `<cli> update` contract
+
+Every `<cli> update` (pgserve, genie, omni) — after this wish ships — converges drift to known-good state. The contract:
+
+### 3.1 Update pipeline (locked across all three CLIs)
+
+```
+1. resolveChannel(opts, config)             — already shipped (update-unify-stages)
+2. checkLatestVersion(channel)              — already shipped
+3. shortCircuitIfCurrent(...)               — already shipped
+4. preInstallPeerCheck(requirements)        — NEW: query peers' --version, refuse if upgrade would break
+5. confirmIfTTY(--yes)                      — already shipped
+6. confirmIfActiveTasks(genie ls --active)  — NEW: warn about in-flight work that pm2 restart will kill
+7. installBinary(channel)                   — already shipped
+8. runMigrations()                          — NEW: pg-side schema migrations + filesystem cleanup migrations (idempotent)
+9. pm2RestartSelfWithUpdateEnv()            — NEW: pm2 jlist → restart own pm2 entries with --update-env
+10. postRestartVerifyProbe()                — already shipped (verifyProbe + decideVerify)
+11. doctorFix(tiered: cat 1 + cat 2 prompts) — NEW: replaces the JSON dry-run-only post-update maintenance
+12. captureDiagnostics()                    — already shipped
+13. successBanner() OR refuseWithRemediation()
+```
+
+Steps marked NEW are what this wish adds.
+
+### 3.2 `<cli> doctor` tiered modes
+
+| Mode | Mutations | Prompts | Use case |
+|------|-----------|---------|----------|
+| `<cli> doctor` (default) | none — check only | n/a | Operator-initiated audit, exits non-zero on issues with remediation |
+| `<cli> doctor --fix` | auto-mutate **category 1** (safe), prompt **category 2** (data-touching) | one prompt per category-2 mutation | Default invocation by `<cli> update` step 11 |
+| `<cli> doctor --fix --aggressive` | auto-mutate cat 1 + cat 2, refuse cat 3 (irreversible-destructive) | none | CI / automation / explicit operator opt-in |
+
+**Mutation categories**:
+
+| Category | Examples | Authority |
+|----------|----------|-----------|
+| **Cat 1 (auto-mutate)** | pm2 restart, pm2 env update, config file rewrite (with .bak), forward-only schema migrations, install canonical socket symlink, refresh `pg_hba.conf` / `pg_ident.conf` | No prompt; audit-log entry per mutation |
+| **Cat 2 (prompt)** | Archive legacy data dirs (`~/.genie/data/pgserve` → `.legacy/pgserve-<ts>/`), drop dangling DBs over a size threshold, role permission changes | One prompt per mutation; `--yes` skips |
+| **Cat 3 (refuse)** | DROP DATABASE with content > 1MB, role privilege escalation, irreversible destructive | Refuse with `--unsafe-unverified <INCIDENT_ID>` typed-ack as override |
+
+### 3.3 Cross-CLI dependency enforcement
+
+- **Compile-time `requirements` manifest**: each binary has `<cli> --requirements --json` returning `{ pgserve: ">=2.3", omni: ">=2.5" }` etc.
+- **Pre-install check** (step 4 above): `<cli> update` queries `<peer> --version` for each declared peer; if upgrade would create incompatibility, refuses with remediation message: "genie 5.0 requires pgserve ≥3.0, you have 2.2.4. Run `pgserve update` first, then re-run `genie update`."
+- **Runtime check**: `<cli> serve` boot revalidates peer versions; refuses with same remediation if peer was downgraded or rolled back post-update. Reuses the canonical-cutover hard-error pattern.
+- **Override**: `<cli> update --ignore-peer-mismatch` typed-ack `I_ACKNOWLEDGE_PEER_MISMATCH` for debug/exotic flows.
+- **No orchestrator binary**: no `automagik update --all`. 3 sequential CLIs is fine; error messages guide ordering.
+
+### 3.4 Rollback (manual)
+
+If `<cli> update` step 10 (verify) fails:
+- Exit non-zero with remediation that points to existing `<cli> self-update --rollback` (per `genie-self-update` wish).
+- Do NOT auto-revert the binary. Forward-only schema migrations stay applied; partial-update state is operator's call to resolve.
+- Audit log captures the failure point with full diagnostics.
+
+### 3.5 Drain (no drain)
+
+`<cli> update` step 9 (`pm2 restart`) kills in-flight work. Auto-resume infra (worker rows, scheduler lease-recovery, mailbox retry) handles recovery. Step 6 (`confirmIfActiveTasks`) warns operator before kicking restart: "12 active tasks will be interrupted; --yes to proceed".
+
+---
+
+## 4. Roles & GRANTs (SQL preview)
+
+```sql
+-- For NOT SIGNED apps (default fallback when no signature/handshake/cosign)
+CREATE ROLE app_<fp> NOLOGIN NOCREATEDB NOCREATEROLE NOREPLICATION INHERIT;
+ALTER DATABASE app_<fp>_db OWNER TO app_<fp>;
+GRANT ALL PRIVILEGES ON DATABASE app_<fp>_db TO app_<fp>;
+GRANT USAGE ON FUNCTION install_whitelisted_extension(text) TO app_<fp>;
+-- nothing cross-DB. peer auth via pg_hba+ident.
+
+-- For SIGNED apps (host_signed, self_signed, OR cosign_signed)
+-- Same as above, plus:
+ALTER ROLE app_<fp> SET application_name TO 'signed:<identity_kind>:<publisher>';
+-- Visible in pg_stat_activity for ops debugging.
+
+-- For COSIGN_SIGNED with publisher in hardcoded official list:
+CREATE ROLE pgserve_app_<sanitize(name)> NOLOGIN NOCREATEROLE INHERIT;
+GRANT app_<fp> TO pgserve_app_<sanitize(name)>;  -- inherits per-fingerprint role
+-- Allows `pgserve grant <from-publisher> <to-publisher> SELECT ON <table>` for explicit cross-DB grants.
+```
+
+`pg_hba.conf` peer auth on Unix socket maps OS user → role via `pg_ident.conf`:
+```
+# pg_ident.conf (auto-generated by `pgserve provision`)
+pgserve_uid_to_role  <uid>   app_<resolved_fp>
+```
+
+---
+
+## 5. Repository scope
+
+### 5.1 `automagik/pgserve` (the big one, breaking-major v2.3)
+
+**Delete:**
+- Bun proxy from data plane: the libpq protocol routing layer, the always-on daemon listening on TCP 8432, the SO_PEERCRED-based startup-message rewriting, the in-memory connection routing.
+- `pgserve.persist: true` package.json flag (persistence is universal now).
+- Script-fallback fingerprint (`cmdline[1]`-based). Only path-based fingerprint (sha256(uid ‖ realpath(package.json or cwd))).
+- Ephemeral TTL 24h logic.
+
+**Add:**
+- `pgserve provision <fingerprint>` CLI verb (idempotent, `pg_advisory_lock`-deduped).
+- `pgserve verify <binary-path>` CLI verb (cosign + HMAC-signed cache token).
+- `pgserve trust add/list/remove` CLI verbs.
+- `pgserve gc` CLI verb (replaces in-daemon GC sweep).
+- `pgserve doctor` / `--fix` / `--fix --aggressive` tiered modes.
+- Hardcoded blocklist of known-bad versions (compile-time constant).
+- Cosign keyless OIDC verification primitives (reuse `genie-supply-chain-signing` if shared lib emerges; else vendor the verifier).
+- Postmaster boot args: `-k $XDG_RUNTIME_DIR/pgserve -p 5432 listen_addresses=localhost`.
+- `pgserve install` wires postgres systemd user unit / launchd plist / pm2 entry pointing at postmaster directly (no bun bridge).
+- `pgserve install` wires `pgserve gc` cron / systemd timer / launchd job.
+- `pgserve install` enables `pgaudit` extension and ships logrotate config.
+- Self-healing `pgserve update`: detects old proxy layout, stops bun bridge process, reconfigures postmaster args, updates pm2 entry, runs migrations, post-restart `pgserve doctor --fix`.
+- Compile-time `--requirements` manifest output.
+
+**Migration tooling for existing hosts** (one-shot, runs inside `pgserve update`):
+- Detect: pm2 has `pgserve` entry running bun on 8432 (old layout).
+- Action: stop bun process, reconfigure pm2 entry to launch postmaster directly with new args, update `~/.autopg/admin.json` to publish new socket dir, archive old socket dir to `.legacy/`.
+- Rollback: not auto; manual via `pgserve install --restore-bridge` if needed (operator-decided).
+
+### 5.2 `automagik-dev/genie`
+
+**Add:**
+- Active assertion in startup: if `node_modules/@automagik/genie/node_modules/pgserve/bin/` is present (legacy host with stale cache), warn loud + skip + emit `rot.vendored-pgserve.detected` audit event. Defensive against regression.
+- Tier integration in `src/lib/db.ts` connection path: read package.json `pgserve` block, call `pgserve verify` CLI on first connect, present resulting tier identity to postgres via `application_name`.
+- `genie update` step 8 (runMigrations): ensure all genie migrations (incl. cleanup of `~/.genie/data/pgserve` legacy data dir → `.legacy/`) run.
+- `genie update` step 9 (pm2 restart): after binary install, run `pm2 restart genie-serve --update-env`. Honor `--no-pm2-restart` for environments without pm2.
+- `genie update` step 11 (doctor --fix): wire the tiered `genie doctor --fix` invocation, default mode (cat 1 auto + cat 2 prompts).
+- `genie doctor` extended with `--fix` and `--fix --aggressive` flags per the tiered model.
+- Compile-time `requirements` manifest declaring `pgserve: ">=2.3"`. Pre-install check enforces.
+- Pre-install confirm: query `genie ls --active --json` count; if >0, show warning ("N active tasks will be interrupted; --yes to proceed").
+- Update `package.json` to declare `pgserve.identity_chain: [{ kind: "cosign_signed", issuer: "https://github.com/automagik-dev/genie/.github/workflows/release.yml@refs/tags/v*" }]`.
+- `genie pgserve handshake` CLI command continues to work (existing from `pgserve-host-signed-identity`); now also exposes `genie pgserve verify` (alias for `pgserve verify` against the bundled binary path).
+
+**Delete:**
+- Any leftover dependency on TCP 8432 in db.ts connection-string defaults. Default to `host=$XDG_RUNTIME_DIR/pgserve port=5432` (Unix socket) with TCP-localhost fallback.
+
+### 5.3 `automagik/omni`
+
+**Add:**
+- Same self-healing wiring as genie: pm2 restart self, doctor --fix tiered, requirements manifest, pre-install peer check.
+- Tier integration in connection setup: `package.json` `pgserve.identity_chain` declared; `pgserve verify` invoked.
+- `omni doctor --fix` tiered modes (cat 1+2 prompted, --aggressive opts in).
+- Update default `DATABASE_URL` env construction to prefer Unix socket → `$XDG_RUNTIME_DIR/pgserve/.s.PGSQL.5432`. TCP localhost:5432 fallback.
+
+**Delete:**
+- TCP 8432 dependence in `buildRuntimeEnv` and any hardcoded port references.
+- Phase-2 canonical-pgserve preflight `checkCanonicalPgservePreflight` — it was a transitional guard for phase 2; phase 3 (this wish) makes the canonical socket the default.
+
+---
+
+## 6. Decisions
+
+| # | Decision | Rationale |
+|---|----------|-----------|
+| 1 | pgserve **2.3** (not 3.0) | 3.0 reserved for post-npm-departure cutover (`distribution-exodus`). 2.3 captures architectural shift cleanly without conflating with the npm exit. |
+| 2 | Daemon dies entirely; CLI on-demand for control plane | Council 3-of-4 (simplifier, operator, questioner) lean toward kill-the-daemon. Architect's load-bearing concern (provision rate >1/min steady state) doesn't apply: provisions are once-per-fingerprint-per-host-lifetime. |
+| 3 | Postgres exposes BOTH Unix socket AND TCP 5432 natively | Unix socket = canonical fast path (no TCP overhead). TCP 5432 = compat with clients that can't do Unix sockets (some bun runtimes, k8s pod-to-pod, dev tools). Both native = zero proxy. |
+| 4 | Binary classification signed-vs-unsigned (not 3 tiers) | Within "signed" sub-cases (host_signed, self_signed, cosign_signed) differ in role grants but not persistence/UX. Two-state mental model. |
+| 5 | All apps get persistent project-scoped DB (no ephemeral) | Drops complexity (script-fallback fingerprint, TTL sweep, persist flag). Persistence is universal; tier decides only trust + role grants. |
+| 6 | Hardcoded automagik trust list compiled into pgserve binary | Trust root is opaque to operators; updates flow via `pgserve update`. User self-sign via `pgserve trust add` for personal apps. |
+| 7 | No active revocation infra v1 | Rekor consultation + revoked.json sync = overengineering. Bad versions blocked via hardcoded blocklist propagated through `pgserve update`. |
+| 8 | No offline TUF v1; air-gap = `pgserve trust add --offline-cosign-key` escape | Sigstore.dev is reachable from any host that can reach our CDN. Air-gap is a niche; ship escape hatch, don't complicate the default. |
+| 9 | Update step 9 (pm2 restart) without drain; auto-resume recovers in-flight tasks | Drain semantics = engineering effort with marginal payoff. Existing `auto-resume`, `lease-recovery`, mailbox-retry handle the recovery class. |
+| 10 | Manual rollback (no auto-revert on verify failure) | Exit non-zero + remediation; operator decides. Forward-only schema migrations + `genie self-update --rollback` cover the backward path. |
+| 11 | No orchestrator binary | 3 sequential `<cli> update` commands is fine. Error messages guide ordering. `automagik update --all` is YAGNI. |
+| 12 | Independent implementations per repo, byte-identical SHARED-DESIGN.md only | Same pattern as `update-unify-stages`, `output-primitives-unified`. Coupling cost > duplication cost. |
+
+---
+
+## 7. Cross-wish dependencies
+
+- **builds-on** `pgserve-canonical-cutover` (genie, merged) — consumer-only model is the foundation; this wish completes the remaining gap.
+- **builds-on** `pgserve-host-signed-identity` (genie merged, pgserve pending) — this wish adds cosign as Tier 2 on top of the host_signed Tier 1.
+- **builds-on** `update-unify-stages` (all merged) — pre-flight check, decideVerify, diagnostics JSON shape inherited; this wish extends with steps 4, 6, 8, 9, 11 of the pipeline.
+- **builds-on** `genie-supply-chain-signing` — reuses `--unsafe-unverified <INCIDENT_ID>` typed-ack helper.
+- **enables** `distribution-exodus` v3 cutover (post-npm) — clean separation of concerns means npm departure can be its own wish without entangling the proxy/socket cutover.
+
+---
+
+## 8. Breaking-change inventory
+
+| Surface | Old behavior | New behavior | Affected |
+|---------|--------------|--------------|----------|
+| Connection target | `localhost:8432` (bun bridge) | `$XDG_RUNTIME_DIR/pgserve/.s.PGSQL.5432` (Unix) or `localhost:5432` (TCP) | Every consumer; transition handled by self-healing `<cli> update` |
+| pm2 entry `pgserve` | Tracks bun bridge process | Tracks postgres backend directly | Operators (transparent if they only `pgserve update`) |
+| Bun daemon process | Always-on on every host | Deleted | Anyone querying the daemon's API directly (none known) |
+| `pgserve_meta.identity_kind = 'script'` rows | Existed | Migrated to 'path' or archived | Existing pgserve installs |
+| `pgserve.persist: true` package.json flag | Read by daemon for TTL override | Ignored; persistence is universal | Apps that set it (no-op) |
+
+---
+
+## 9. Definition of done
+
+- [ ] All 3 PRs merged to their respective `dev` (or `main` for pgserve) branches.
+- [ ] `pgserve@2.3.0` published to CDN with cosign signature.
+- [ ] On a host with old layout (pm2 pgserve = bun bridge): single `pgserve update` reconfigures everything to new layout; `pgserve doctor` returns all-green; genie + omni + new test app all connect via `$XDG_RUNTIME_DIR/pgserve/.s.PGSQL.5432`; pm2 only has 1 pgserve entry tracking postgres directly.
+- [ ] On a fresh host: `pgserve install` → `genie install` → `omni install` → all green, with `pg_isready -h $XDG_RUNTIME_DIR/pgserve` returning OK and `psql -h $XDG_RUNTIME_DIR/pgserve` connecting cleanly.
+- [ ] Cosign verification: tampered binary at install fails verify with diagnostic; legitimate binary passes; cache token written and reused.
+- [ ] Self-healing: dirty pm2 env (binary on disk newer than running process) → `<cli> update` detects + `pm2 restart --update-env` heals. After update, running process matches filesystem version.
+- [ ] Cross-CLI deps: pre-install check refuses incompatible upgrade; runtime check refuses incompatible peer; `--ignore-peer-mismatch` typed-ack works.
+- [ ] No regression: existing host_signed handshake (genie #1569 merged) continues to work; existing `--unsafe-unverified` ack contract honored.
+- [ ] Audit trail: every `<cli> doctor --fix` mutation logs to diagnostics JSON; every blocked update logs reason; every verify failure logs identity expected vs received.
+
+---
+
+## 10. Out of scope
+
+- Sigstore policy plugins, transparency-log consultation, revoked.json sync (revocation infra v1 = blocklist-via-update).
+- Embedded TUF roots / offline-by-default verifier (escape hatch only).
+- `automagik update --all` orchestrator binary.
+- Cross-host pgserve federation (still single-host design per pgserve-v2).
+- npm departure (`distribution-exodus`-owned; this wish is npm-agnostic but assumes CDN binary distribution exists).
+- Drain-before-restart for in-flight tasks (auto-resume handles recovery).
+- Aegis runtime sandboxing (separate umbrella).
+- Migrating brain, rlmx, hapvida-eugenia, email consumer apps to use the new tier system (each app gets its own follow-up wish; this trio covers genie + omni only).

--- a/.genie/wishes/pgserve-singleton-no-proxy/WISH.md
+++ b/.genie/wishes/pgserve-singleton-no-proxy/WISH.md
@@ -1,0 +1,485 @@
+# Wish: pgserve singleton — kill proxy, add cosign, new CLI verbs (v2.3)
+
+| Field | Value |
+|-------|-------|
+| **Status** | DRAFT |
+| **Slug** | `pgserve-singleton-no-proxy` |
+| **Date** | 2026-05-06 |
+| **Author** | Felipe Rosa <felipe@namastex.ai> |
+| **Appetite** | large (~3-4 weeks) |
+| **Branch** | `wish/pgserve-singleton-no-proxy` |
+| **Repos touched** | `automagik/pgserve` |
+| **Design** | [SHARED-DESIGN.md](./SHARED-DESIGN.md) |
+
+> **Companion wishes** (byte-identical SHARED-DESIGN.md): `automagik-dev/genie#pgserve-singleton-no-proxy`, `automagik/omni#pgserve-singleton-no-proxy`. All three ship in parallel against their respective integration branches.
+
+## Summary
+
+Major bump to pgserve **2.3.0**. Kill the bun bridge from the data plane: postgres backend listens directly on Unix socket (`$XDG_RUNTIME_DIR/pgserve/.s.PGSQL.5432`) AND TCP 5432, no proxy. Replace the always-on bun daemon with on-demand CLI verbs (`pgserve provision`, `pgserve verify`, `pgserve gc`, `pgserve trust`, `pgserve doctor`). Add cosign-keyless-OIDC publisher attestation as Tier 2 on top of the existing host_signed identity (Tier 1) and path-based default (Tier 0). Bake a hardcoded blocklist of known-bad versions. Wire self-healing semantics into `pgserve update` (auto-migrate old layout, pm2 restart, doctor --fix tiered). See `SHARED-DESIGN.md` §1-§9 for full design context.
+
+## Scope
+
+### IN
+
+**Group 1 — Postmaster reconfig + dual-transport (data-plane core)**
+- Postmaster boot args: `-k $XDG_RUNTIME_DIR/pgserve` + `-p 5432` + `listen_addresses = 'localhost'`. Fallback `/tmp/pgserve` when `$XDG_RUNTIME_DIR` unset (CI runners).
+- `pgserve install` ensures `$XDG_RUNTIME_DIR/pgserve` directory exists (mode 0700), wires postgres pm2/systemd/launchd entry pointing at postmaster directly (no bun bridge process).
+- Stale-lock detection: refuse install if `pgserve.pid` exists with live PID; archive prior socket dirs to `.legacy/`.
+- `pgserve port` returns 5432 (was 8432).
+
+**Group 2 — Delete the bun proxy data plane**
+- Remove libpq protocol routing layer (the bun process that listens on 8432 and rewrites startup-message `database=` parameter).
+- Remove always-on daemon supervision logic.
+- Remove SO_PEERCRED-based startup-message rewriting (peer's app identity now resolved by `pgserve provision` invocation, not at connect time).
+- Audit becomes `pgaudit` postgres extension load (replaces the application-level audit-log writer).
+- Audit-log file path stays at `~/.pgserve/audit.log` for compat with existing tooling, but writes come from `pgaudit` config not bun.
+
+**Group 3 — New CLI verbs**
+- `pgserve provision <fingerprint>`: idempotent. Reads `package.json` (or fallback to `cwd` fingerprint if no package.json), resolves tier (path / host_signed / cosign_signed), creates DB + role with appropriate GRANTs, writes `pgserve_meta` row. Concurrency-safe via `pg_advisory_lock` keyed on fingerprint hash. Accepts `42P04` (database already exists) as success.
+- `pgserve verify <binary-path>`: cosign keyless OIDC verification against trust list. On success, writes HMAC-signed cache token at `$XDG_STATE_HOME/pgserve/verified/<fingerprint>.token` (web-session-style). Sliding expiry 1h idle / 7d max. Re-verify on binary mtime change. `--skip-sigstore` flag for offline mode.
+- `pgserve gc`: sweeps orphaned databases (uid removed, project-marker mtime stale). Run by cron / systemd timer / launchd job — wired by `pgserve install`. Replaces in-daemon GC sweep loop.
+- `pgserve trust add --identity <issuer> --key <pubkey>`, `pgserve trust list`, `pgserve trust remove <id>`: manage user-extensible trust roots. Writes `~/.pgserve/trust/identities.json`.
+- `pgserve doctor` / `--fix` / `--fix --aggressive`: tiered modes per `SHARED-DESIGN.md` §3.2.
+
+**Group 4 — Cosign verification primitives**
+- Hardcoded trust list compiled into binary: identities for genie, omni, pgserve release workflows.
+- Cosign keyless OIDC verifier (vendor sigstore-rs OR shell out to `cosign verify` if PATH).
+- HMAC-signed cache token format (token contents + tamper-evident HMAC keyed on `~/.local/state/pgserve/cache.hmac`).
+- `pgserve_meta` schema delta: add `verified_at TIMESTAMPTZ`, `verified_identity TEXT`, `verified_tier TEXT CHECK (verified_tier IN ('path', 'host_signed', 'self_signed', 'cosign_signed'))`. Additive migration.
+- Existing `host_signed` handshake (genie #1569) coexists; cosign tier sits on top, evaluated first per `identity_chain` ordering.
+
+**Group 5 — Hardcoded blocklist**
+- Compile-time `BLOCKED_VERSIONS` constant. Currently empty.
+- `pgserve install` and `pgserve update` refuse blocked versions with diagnostic.
+- No active revocation infra (no Rekor consultation, no revoked.json sync) per `SHARED-DESIGN.md` §2.5.
+
+**Group 6 — Self-healing `pgserve update`**
+- Pre-install version check (already shipped); extend to check `BLOCKED_VERSIONS`.
+- New step: detect old proxy layout (pm2 entry running bun on 8432), stop bun process, reconfigure pm2 entry to launch postmaster directly, archive old socket dirs.
+- `pm2 restart <self> --update-env` after install.
+- `pgserve doctor --fix` invocation post-restart (default tiered mode).
+- Confirmation prompt warns about active connections; `--yes` skips.
+
+**Group 7 — Roles + GRANTs schema**
+- Standard role template per `SHARED-DESIGN.md` §4.
+- Idempotent CREATE ROLE / GRANT logic in `pgserve provision`.
+- `pg_hba.conf` template with peer auth on Unix socket; `pg_ident.conf` mapping uid → role.
+- `pgserve grant <from-publisher> <to-publisher> <permission>` CLI for explicit cross-DB grants (cosign tier only).
+
+**Group 8 — Migration tooling for existing hosts**
+- One-shot migration runs inside `pgserve update` when old layout detected.
+- Action: stop bun process, reconfigure pm2 entry, update `~/.autopg/admin.json` to publish new socket dir, archive old socket dirs to `~/.autopg/.legacy/<ts>/`.
+- Idempotent: re-running on already-migrated host is no-op.
+
+**Group 9 — Tests + docs + CHANGELOG**
+- Tests for every new CLI verb.
+- Migration test from synthetic v2.2.x state to v2.3.x.
+- Cosign verify tests.
+- CHANGELOG entry naming the contracts.
+
+### OUT
+
+- `pgserve@3.0.0` bump — reserved for post-npm-departure cutover (`distribution-exodus`).
+- Sigstore policy plugins, transparency-log consultation, revoked.json sync.
+- Embedded TUF roots / offline-by-default verifier.
+- `automagik update --all` orchestrator binary.
+- Cross-host pgserve federation.
+- Drain-before-restart semantics.
+- Migrating brain, rlmx, hapvida-eugenia, email consumer apps.
+- Aegis runtime sandboxing.
+- TLS termination on TCP 5432.
+
+## Decisions
+
+See `SHARED-DESIGN.md` §6 for the cross-repo decision table. pgserve-specific:
+
+| # | Decision | Rationale |
+|---|----------|-----------|
+| P1 | Postmaster `-k $XDG_RUNTIME_DIR/pgserve -p 5432` (not 8432) | Canonical socket path that genie's `resolvePgserveLibpqSocketPath()` already expects. Port 5432 is the postgres standard. |
+| P2 | TCP fallback to `/tmp/pgserve` when XDG_RUNTIME_DIR unset | CI runners and minimal containers lack XDG. |
+| P3 | `pgserve gc` as cron / timer (not in-daemon) | Matches `SHARED-DESIGN.md` decision #2: zero always-on processes besides postgres. |
+| P4 | `pgserve_meta` schema additive (no breaking column drop) | Existing `path`-kind rows from pre-cosign installs continue to work. |
+| P5 | Vendor sigstore-rs OR shell out to `cosign` CLI; both paths supported | sigstore-rs gives single-binary; `cosign` CLI is reference impl. |
+| P6 | Blocklist as compile-time constant (not config file) | Trust root must be opaque to operators. Updates flow via `pgserve update`. |
+| P7 | Migration runs inside `pgserve update` (not separate command) | Self-healing contract: one verb fixes everything. |
+
+## Success Criteria
+
+- [ ] On a fresh host, `pgserve install` creates `$XDG_RUNTIME_DIR/pgserve/` with correct perms, registers postgres in pm2/systemd, and `psql -h $XDG_RUNTIME_DIR/pgserve` connects without `-p`.
+- [ ] On a host with old layout: single `pgserve update` reconfigures everything; pm2 list shows 1 entry tracking postgres directly; old bun process gone.
+- [ ] No bun-as-data-plane process anywhere post-cutover.
+- [ ] `pgserve provision <fingerprint>` is concurrency-safe: 10 simultaneous calls produce exactly 1 DB.
+- [ ] `pgserve verify` against legitimate signed binary: passes, writes cache token.
+- [ ] `pgserve verify` against tampered binary: rejects with diagnostic.
+- [ ] `pgserve verify --skip-sigstore` against operator-pretrusted key: passes offline.
+- [ ] `pgserve gc` as cron entry: removes orphaned DBs; leaves active DBs alone.
+- [ ] `pgserve doctor --fix` (default): mutates Cat 1 silently; prompts Cat 2; refuses Cat 3.
+- [ ] `pgserve doctor --fix --aggressive`: mutates Cat 1+2 without prompt.
+- [ ] Hardcoded blocklist: setting test version causes refuse with exit code 4.
+- [ ] `pgserve --requirements --json` returns valid JSON manifest.
+- [ ] `pg_hba.conf` peer auth on Unix socket maps OS user → fingerprint role correctly.
+- [ ] Cross-DB grants: `pgserve grant` works only between cosign-verified publishers.
+- [ ] All existing pgserve tests pass byte-identically.
+- [ ] CHANGELOG entry naming: socket path canonical-ization, blocklist, tiered doctor, cosign tier.
+- [ ] Migration test: synthetic v2.2.x state → run `pgserve update` → assert v2.3.x state.
+- [ ] `bun run lint` and `bun run typecheck` clean.
+
+## Execution Strategy
+
+### Wave 1 — Data plane core (sequential)
+
+| Group | Agent | Description |
+|-------|-------|-------------|
+| 1 | engineer | Postmaster reconfig: `-k`, `-p 5432`, dual-transport. `pgserve install` socket dir setup. |
+| 2 | engineer | Delete bun proxy data plane. Replace audit with `pgaudit`. |
+
+### Wave 2 — CLI surface + verification (parallel after Wave 1)
+
+| Group | Agent | Description |
+|-------|-------|-------------|
+| 3 | engineer | New CLI verbs (`provision`, `gc`, `trust`, `doctor` tiered). |
+| 4 | engineer | Cosign verification primitives + cache token + `pgserve verify`. |
+| 7 | engineer | Roles + GRANTs schema, hba/ident templates, `pgserve grant`. |
+
+### Wave 3 — Self-healing wiring (sequential after Wave 2)
+
+| Group | Agent | Description |
+|-------|-------|-------------|
+| 5 | engineer | Hardcoded blocklist + refusal in install/update paths. |
+| 6 | engineer | Self-healing `pgserve update` pipeline. |
+| 8 | engineer | Migration tooling for existing hosts. |
+
+### Wave 4 — Validation
+
+| Group | Agent | Description |
+|-------|-------|-------------|
+| 9 | engineer | Tests + docs + CHANGELOG. |
+
+## Execution Groups
+
+### Group 1: Postmaster reconfig + dual-transport
+
+**Goal:** Postgres backend listens on canonical Unix socket + TCP 5432 natively. `pgserve install` ensures the socket dir exists with correct perms.
+
+**Deliverables:**
+1. `bin/postgres-server.js` updated to pass `-k <socket-dir>` and `-p 5432` to postmaster.
+2. Helper `resolveSocketDir(): string` — returns `$XDG_RUNTIME_DIR/pgserve` (preferred) or `/tmp/pgserve` (fallback).
+3. `pgserve install` step: `mkdir -p <socket-dir>` (mode 0700), validate writability.
+4. `pgserve port` returns `5432`.
+5. Update `~/.autopg/admin.json` to publish `socketDir` + `port: 5432`.
+
+**Acceptance Criteria:**
+- [ ] `pgserve install` on a fresh host creates `$XDG_RUNTIME_DIR/pgserve/` with mode 0700.
+- [ ] After `pgserve install`, `psql -h $XDG_RUNTIME_DIR/pgserve` (no `-p`) connects.
+- [ ] After `pgserve install`, `psql -h 127.0.0.1 -p 5432` connects.
+- [ ] `pgserve port` outputs `5432`.
+
+**Validation:**
+```bash
+pgserve install
+test -d "$XDG_RUNTIME_DIR/pgserve" && stat -c '%a' "$XDG_RUNTIME_DIR/pgserve" | grep -q 700
+psql -h "$XDG_RUNTIME_DIR/pgserve" -c 'SELECT 1' postgres
+```
+
+**depends-on:** none
+
+---
+
+### Group 2: Delete bun proxy data plane
+
+**Goal:** Remove the always-on bun process that proxies libpq traffic on TCP 8432. Replace audit with `pgaudit` extension.
+
+**Deliverables:**
+1. Delete libpq routing module + startup-message rewriting.
+2. Update pm2 entry shape: `pgserve` pm2 entry tracks postgres binary directly via wrapper.
+3. Configure `pgaudit` extension via `shared_preload_libraries`.
+4. Ship `logrotate.d/pgserve` config.
+
+**Acceptance Criteria:**
+- [ ] No bun process listening on TCP 8432 after `pgserve install`.
+- [ ] `pg_settings` shows `pgaudit.log = 'all'`.
+- [ ] pm2 `pgserve` entry's `pm_exec_path` points to postgres wrapper, not bun.
+
+**Validation:**
+```bash
+pm2 jlist | jq '.[] | select(.name == "pgserve") | .pm2_env.pm_exec_path'
+ss -tlnp | grep -E ':8432' && exit 1 || echo "OK no 8432 listener"
+```
+
+**depends-on:** Group 1
+
+---
+
+### Group 3: New CLI verbs
+
+**Goal:** Replace daemon control plane with on-demand CLI: `provision`, `gc`, `trust`, `doctor`.
+
+**Deliverables:**
+1. `pgserve provision <fingerprint>`: reads package.json or fallback cwd fingerprint; resolves tier; `pg_advisory_lock`-deduped; idempotent CREATE ROLE/DATABASE/GRANT; writes `pgserve_meta`.
+2. `pgserve gc`: scans `pgserve_meta` for orphans; DROP DATABASE; audit-log every drop.
+3. `pgserve trust add/list/remove`: writes `~/.pgserve/trust/identities.json`; refuses to remove hardcoded entries.
+4. `pgserve doctor` / `--fix` / `--fix --aggressive`: tiered modes per `SHARED-DESIGN.md` §3.2.
+
+**Acceptance Criteria:**
+- [ ] `pgserve provision @automagik/genie/abc123` is idempotent.
+- [ ] 10 concurrent `provision` calls produce exactly 1 DB.
+- [ ] `pgserve gc` removes a synthetic orphan.
+- [ ] `pgserve trust list` shows hardcoded + user entries.
+- [ ] `pgserve doctor --fix` mutates Cat 1 silently, prompts Cat 2, refuses Cat 3.
+
+**Validation:**
+```bash
+bun test tests/cli/
+```
+
+**depends-on:** Group 1
+
+---
+
+### Group 4: Cosign verification primitives
+
+**Goal:** Cosign-keyless-OIDC verification with HMAC-signed cache tokens.
+
+**Deliverables:**
+1. Hardcoded `TRUSTED_IDENTITIES` constant.
+2. `verifyBinary(path)` — shells out to `cosign verify` or vendored verifier. Returns tagged-union.
+3. HMAC-signed cache token writer/reader. Auto-generated cache.hmac key.
+4. `pgserve_meta` schema migration (additive).
+5. `pgserve verify <binary-path>` CLI verb.
+6. `--skip-sigstore` flag with pretrusted-key requirement.
+
+**Acceptance Criteria:**
+- [ ] `pgserve verify` against legitimate signed binary: passes, cache written.
+- [ ] Second invocation: reads cache, no re-verify.
+- [ ] Tampered binary: rejects.
+- [ ] `--skip-sigstore` without pretrusted key: refuses.
+- [ ] `--skip-sigstore` with `pgserve trust add --offline-cosign-key`: passes.
+
+**Validation:**
+```bash
+bun test tests/cli/verify.test.js tests/cosign/
+```
+
+**depends-on:** Group 1
+
+---
+
+### Group 5: Hardcoded blocklist
+
+**Goal:** Compile-time list of known-bad versions. Refuse install/update for blocked.
+
+**Deliverables:**
+1. `BLOCKED_VERSIONS` compile-time constant. Initially `[]`.
+2. `pgserve install`/`update` checks blocklist; refuses with diagnostic.
+3. Test fixture injects blocked version + asserts refusal.
+
+**Acceptance Criteria:**
+- [ ] `BLOCKED_VERSIONS` exists and is empty by default.
+- [ ] Install with blocked test-version refuses with exit code 4.
+
+**Validation:**
+```bash
+bun test tests/blocklist.test.js
+```
+
+**depends-on:** Group 3
+
+---
+
+### Group 6: Self-healing `pgserve update` pipeline
+
+**Goal:** `pgserve update` from old layout → new layout is one-shot; idempotent.
+
+**Deliverables:**
+1. Detection logic for old proxy layout (pm2 entry running bun on 8432).
+2. Migration sequence: stop bun, reconfigure pm2 entry, archive old socket dirs.
+3. Post-restart `pgserve doctor --fix` (default tiered mode).
+4. Active-connection check via `pg_stat_activity`; prompt unless `--yes`.
+
+**Acceptance Criteria:**
+- [ ] Synthetic old-layout host: `pgserve update` reconfigures everything; second run is no-op.
+- [ ] Active-connection prompt warns operator before kicking restart.
+- [ ] Audit-log captures each migration step.
+
+**Validation:**
+```bash
+bash tests/integration/upgrade-from-2.2.x.sh
+```
+
+**depends-on:** Group 5
+
+---
+
+### Group 7: Roles + GRANTs schema
+
+**Goal:** Auto-create role per fingerprint with appropriate GRANTs by tier; `pg_hba.conf` peer auth.
+
+**Deliverables:**
+1. `pgserve provision` creates `app_<fp>` role; sets DB owner; grants whitelisted-extension function access.
+2. For cosign_signed in hardcoded list: creates `pgserve_app_<sanitize(name)>` role.
+3. `pg_hba.conf` template (peer auth on Unix socket via map).
+4. `pg_ident.conf` template (uid → role mapping).
+5. `pgserve grant <from> <to> <permission>` CLI; cosign-tier only.
+
+**Acceptance Criteria:**
+- [ ] Role + DB ownership + GRANTs match `SHARED-DESIGN.md` §4 after provision.
+- [ ] Peer auth via Unix socket connects to `app_<fp>` role automatically.
+- [ ] `pgserve grant` between cosign-tier publishers succeeds; refuses for path-tier.
+- [ ] Path-tier role cannot SELECT from another path-tier role's DB.
+
+**Validation:**
+```bash
+bun test tests/sql/
+```
+
+**depends-on:** Group 1
+
+---
+
+### Group 8: Migration tooling for existing hosts
+
+**Goal:** Operators with old layout get clean cutover by running `pgserve update` once.
+
+**Deliverables:**
+1. Detect old layout (pm2 jlist inspection).
+2. Atomic migration with rollback: snapshot, stop bun, reconfigure pm2, update admin.json, archive old sockets, start postgres, verify.
+3. Failure restores from snapshot, logs diagnostic.
+4. `pgserve install --restore-bridge` manual escape hatch.
+
+**Acceptance Criteria:**
+- [ ] Synthetic old-layout host: full migration completes in <30s, idempotent.
+- [ ] Failure mid-reconfigure: admin.json restored from snapshot.
+- [ ] Archive directory contains old socket dirs (forensic preservation).
+
+**Validation:**
+```bash
+bash tests/integration/migration-from-old-layout.sh
+bash tests/integration/migration-rollback-on-failure.sh
+```
+
+**depends-on:** Group 6
+
+---
+
+### Group 9: Tests + docs + CHANGELOG
+
+**Goal:** Lock the contracts; document the breaking changes.
+
+**Deliverables:**
+1. Full test suite for all CLI verbs + verify + GC + roles + migration.
+2. Integration tests: fresh-install, upgrade-from-2.2.x, upgrade-noop.
+3. README updates: install + upgrade flow, doctor verbs.
+4. `docs/security/cosign-trust.md`: tier model, identity_chain, self-signing.
+5. CHANGELOG entry.
+
+**Acceptance Criteria:**
+- [ ] `bun test` passes.
+- [ ] `bun run lint` and `typecheck` clean.
+- [ ] CHANGELOG entry with literal contract sentences.
+- [ ] Cosign trust doc walks through self-signing example.
+
+**Validation:**
+```bash
+bun test
+bun run lint
+bun run typecheck
+test -f docs/security/cosign-trust.md
+```
+
+**depends-on:** Group 8
+
+---
+
+## Cross-wish dependencies
+
+- **paired-with** `automagik-dev/genie#pgserve-singleton-no-proxy` — consumer-side wiring; ships in lockstep.
+- **paired-with** `automagik/omni#pgserve-singleton-no-proxy` — consumer-side wiring; ships in lockstep.
+- **builds-on** `pgserve-canonical-cutover` (genie merged) — consumer-only foundation.
+- **builds-on** `pgserve-host-signed-identity` (genie merged, pgserve pending) — host_signed Tier 1 stays; cosign Tier 2 layered on top.
+- **builds-on** `update-unify-stages` (all merged) — pre-flight + decideVerify + diagnostics inherited.
+- **builds-on** `genie-supply-chain-signing` — reuses `--unsafe-unverified <INCIDENT_ID>` typed-ack.
+
+## QA Criteria
+
+- [ ] Functional — `pgserve install` on fresh host: postgres listens on Unix socket + TCP 5432; no bun bridge.
+- [ ] Functional — `pgserve update` from synthetic v2.2.x layout: full reconfiguration.
+- [ ] Functional — `pgserve provision` for both signed and unsigned apps: correct role/DB; isolation enforced.
+- [ ] Functional — `pgserve verify` for cosign-signed binary: cache persisted; subsequent verify uses cache.
+- [ ] Functional — `pgserve gc` cron entry removes orphans; preserves active.
+- [ ] Functional — `pgserve doctor --fix` tiered modes behave per spec.
+- [ ] Functional — `pgserve grant` cross-DB only between cosign-tier publishers.
+- [ ] Functional — Hardcoded blocklist refuses test-blocked version.
+- [ ] Integration — Companion genie + omni consume canonical socket; no leftover 8432 references.
+- [ ] Integration — Existing host_signed handshake continues to work.
+- [ ] Regression — All existing pgserve tests pass byte-identically.
+- [ ] Cross-repo — Smoke test on canary host validates 3-way interop.
+
+---
+
+## Assumptions / Risks
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Existing hosts with custom postgres args lose them on migration | Medium | Detection logic preserves operator-supplied args; only changes `-k` and `-p`. |
+| Cosign verify slow enough to add perceptible latency | Medium | HMAC cache short-circuits 99% of provisions. First verify ~200ms; cached <5ms. |
+| Local re-builds of pgserve fail cosign verify | Low | `pgserve trust add --offline-cosign-key` for local-build flow. |
+| pm2 reconfiguration races with operator's `pm2 restart pgserve` | Medium | Migration acquires `pgserve.pid` advisory lock first. |
+| `pgaudit` extension increases postgres binary size | Low | Already part of embedded postgres bundle. Verify size delta. |
+| Old socket dir archives grow unboundedly | Low | Document cleanup recipe. Future `pgserve gc --legacy-archives`. |
+| Some operators rely on TCP 8432 in scripts | Medium | TCP 5432 is canonical; 8432 dies. CHANGELOG warns explicitly. |
+| `--skip-sigstore` becomes default in CI by accident | Low | Refuses unless `--offline-cosign-key` pretrusted; emits warning; audit-log entry. |
+
+---
+
+## Review Results
+
+_Populated by `/review` after execution completes._
+
+---
+
+## Files to Create/Modify
+
+```
+# Modify
+bin/postgres-server.js
+bin/pgserve-wrapper.cjs
+src/cli-install.cjs
+package.json
+CHANGELOG.md
+README.md
+
+# Create
+src/cosign/verify.js
+src/cosign/trust-list.js
+src/cosign/cache-token.js
+src/upgrade/steps/data-plane-cutover.js
+src/upgrade/steps/blocklist-check.js
+src/cli/provision.js
+src/cli/gc.js
+src/cli/trust.js
+src/cli/doctor.js
+src/cli/grant.js
+src/cli/verify.js
+src/cli/requirements.js
+src/sql/role-template.sql
+src/sql/pg_hba.template
+src/sql/pg_ident.template
+config/pgaudit.conf
+config/logrotate.d/pgserve
+docs/security/cosign-trust.md
+tests/integration/upgrade-from-2.2.x.sh
+tests/integration/migration-from-old-layout.sh
+tests/integration/migration-rollback-on-failure.sh
+tests/cli/provision.test.js
+tests/cli/gc.test.js
+tests/cli/trust.test.js
+tests/cli/doctor.test.js
+tests/cli/verify.test.js
+tests/cosign/cache-token.test.js
+tests/migrations/cosign-tier-additive.test.js
+tests/sql/roles-grants.test.js
+tests/sql/peer-auth.test.js
+tests/sql/cross-db-grant.test.js
+tests/blocklist.test.js
+tests/update/active-connection-prompt.test.js
+```

--- a/.genie/wishes/pgserve-singleton-no-proxy/WISH.md
+++ b/.genie/wishes/pgserve-singleton-no-proxy/WISH.md
@@ -17,6 +17,8 @@
 
 Major bump to pgserve **2.3.0**. Kill the bun bridge from the data plane: postgres backend listens directly on Unix socket (`$XDG_RUNTIME_DIR/pgserve/.s.PGSQL.5432`) AND TCP 5432, no proxy. Replace the always-on bun daemon with on-demand CLI verbs (`pgserve provision`, `pgserve verify`, `pgserve gc`, `pgserve trust`, `pgserve doctor`). Add cosign-keyless-OIDC publisher attestation as Tier 2 on top of the existing host_signed identity (Tier 1) and path-based default (Tier 0). Bake a hardcoded blocklist of known-bad versions. Wire self-healing semantics into `pgserve update` (auto-migrate old layout, pm2 restart, doctor --fix tiered). See `SHARED-DESIGN.md` §1-§9 for full design context.
 
+> **⚠ BREAKING — accept-downtime contract**: TCP port `8432` dies in this release. Out-of-trio consumers that hardcode `localhost:8432` (brain, rlmx, hapvida-eugenia, email, any third-party app) **WILL break silently** when `pgserve update` runs. This is intentional: pgserve 2.3 is a major bump and the cutover is the right moment to take that hit once. CHANGELOG must warn explicitly. QA Criteria adds a consumer-fan-out test (verify all known consumers connect post-cutover). **No socat shim. No port-redirect. No backwards-compat layer.** Operators update connection strings to Unix socket (preferred) or TCP 5432.
+
 ## Scope
 
 ### IN
@@ -70,6 +72,7 @@ Major bump to pgserve **2.3.0**. Kill the bun bridge from the data plane: postgr
 - One-shot migration runs inside `pgserve update` when old layout detected.
 - Action: stop bun process, reconfigure pm2 entry, update `~/.autopg/admin.json` to publish new socket dir, archive old socket dirs to `~/.autopg/.legacy/<ts>/`.
 - Idempotent: re-running on already-migrated host is no-op.
+- **Best-effort recovery, not atomic**: rollback is via `pgserve install --restore-bridge` (manual escape hatch). Snapshot scope: `~/.autopg/admin.json` + pm2 ecosystem dump only (not socket dirs — those archive forward). On mid-flight failure, restore admin.json from snapshot, log diagnostic exit non-zero with operator remediation hint.
 
 **Group 9 — Tests + docs + CHANGELOG**
 - Tests for every new CLI verb.
@@ -99,7 +102,7 @@ See `SHARED-DESIGN.md` §6 for the cross-repo decision table. pgserve-specific:
 | P2 | TCP fallback to `/tmp/pgserve` when XDG_RUNTIME_DIR unset | CI runners and minimal containers lack XDG. |
 | P3 | `pgserve gc` as cron / timer (not in-daemon) | Matches `SHARED-DESIGN.md` decision #2: zero always-on processes besides postgres. |
 | P4 | `pgserve_meta` schema additive (no breaking column drop) | Existing `path`-kind rows from pre-cosign installs continue to work. |
-| P5 | Vendor sigstore-rs OR shell out to `cosign` CLI; both paths supported | sigstore-rs gives single-binary; `cosign` CLI is reference impl. |
+| P5 | **Shell out to `cosign` CLI as the verifier (locked).** Vendor sigstore-rs deferred to a follow-up wish. | Single verifier path → simpler test matrix; matches CDN distribution model where cosign CLI is already on the install pipeline; if `cosign` not on PATH, `pgserve install` shells out to a downloader to fetch the official static binary into `~/.pgserve/bin/cosign`. Operators wanting fully-bundled verification get it via the sigstore-rs follow-up. |
 | P6 | Blocklist as compile-time constant (not config file) | Trust root must be opaque to operators. Updates flow via `pgserve update`. |
 | P7 | Migration runs inside `pgserve update` (not separate command) | Self-healing contract: one verb fixes everything. |
 
@@ -133,13 +136,13 @@ See `SHARED-DESIGN.md` §6 for the cross-repo decision table. pgserve-specific:
 | 1 | engineer | Postmaster reconfig: `-k`, `-p 5432`, dual-transport. `pgserve install` socket dir setup. |
 | 2 | engineer | Delete bun proxy data plane. Replace audit with `pgaudit`. |
 
-### Wave 2 — CLI surface + verification (parallel after Wave 1)
+### Wave 2 — CLI surface + verification (sequential — G3+G4+G7 all author `pgserve provision` and share `pgserve_meta` schema)
 
 | Group | Agent | Description |
 |-------|-------|-------------|
-| 3 | engineer | New CLI verbs (`provision`, `gc`, `trust`, `doctor` tiered). |
-| 4 | engineer | Cosign verification primitives + cache token + `pgserve verify`. |
-| 7 | engineer | Roles + GRANTs schema, hba/ident templates, `pgserve grant`. |
+| 4 | engineer | Cosign verification primitives + cache token + `pgserve verify` + `pgserve_meta` schema delta (additive). **First in Wave 2** — defines schema columns G3 writes. |
+| 3 | engineer | New CLI verbs (`provision`, `gc`, `trust`, `doctor` tiered). Provisioning writes columns G4 added. |
+| 7 | engineer | Roles + GRANTs schema, hba/ident templates, `pgserve grant`. Adds role logic on top of provision skeleton from G3. |
 
 ### Wave 3 — Self-healing wiring (sequential after Wave 2)
 
@@ -199,11 +202,15 @@ psql -h "$XDG_RUNTIME_DIR/pgserve" -c 'SELECT 1' postgres
 - [ ] No bun process listening on TCP 8432 after `pgserve install`.
 - [ ] `pg_settings` shows `pgaudit.log = 'all'`.
 - [ ] pm2 `pgserve` entry's `pm_exec_path` points to postgres wrapper, not bun.
+- [ ] **Positive check**: `psql -h $XDG_RUNTIME_DIR/pgserve -c 'SELECT 1' postgres` returns `1` (postgres is responsive on canonical socket via the new pm2 wrapper).
+- [ ] **Positive check**: `psql -h 127.0.0.1 -p 5432 -c 'SELECT 1' postgres` returns `1` (postgres is responsive on canonical TCP).
 
 **Validation:**
 ```bash
 pm2 jlist | jq '.[] | select(.name == "pgserve") | .pm2_env.pm_exec_path'
 ss -tlnp | grep -E ':8432' && exit 1 || echo "OK no 8432 listener"
+psql -h $XDG_RUNTIME_DIR/pgserve -c 'SELECT 1' postgres
+psql -h 127.0.0.1 -p 5432 -c 'SELECT 1' postgres
 ```
 
 **depends-on:** Group 1
@@ -368,9 +375,11 @@ bash tests/integration/migration-rollback-on-failure.sh
 **Deliverables:**
 1. Full test suite for all CLI verbs + verify + GC + roles + migration.
 2. Integration tests: fresh-install, upgrade-from-2.2.x, upgrade-noop.
-3. README updates: install + upgrade flow, doctor verbs.
-4. `docs/security/cosign-trust.md`: tier model, identity_chain, self-signing.
-5. CHANGELOG entry.
+3. **CI fixture provisioning** (no sudo): tests boot postgres + pm2 in user-space via `bunx pm2-runtime` and `pgserve install --data ./tmp/test-data --port 65432 --skip-system-units`. Documented in `tests/integration/README.md`. Validates on Linux Blacksmith runners + macOS dev laptops without root.
+4. README updates: install + upgrade flow, doctor verbs.
+5. `docs/security/cosign-trust.md`: tier model, identity_chain, self-signing.
+6. CHANGELOG entry naming: socket path canonical-ization, port 5432, no bun bridge, blocklist mechanism, tiered doctor, cosign tier on top of host_signed, **breaking-version bump rationale + accept-downtime contract** (TCP 8432 dies; out-of-trio consumers break silently; this is intentional for a major bump).
+7. **Consumer fan-out smoke test** (`tests/integration/consumer-fanout.sh`): on a canary host with all 6+ consumers installed (genie, omni, brain, rlmx, hapvida-eugenia, email), run `pgserve update` and verify each consumer can re-establish DB connection (operator may need to update consumer config first; test verifies which consumers need updates).
 
 **Acceptance Criteria:**
 - [ ] `bun test` passes.


### PR DESCRIPTION
Major architectural cutover. Companion wishes paired with `automagik-dev/genie` and `automagik/omni` (byte-identical SHARED-DESIGN.md across all three).

## Summary

Kill the bun bridge from the data plane: postgres backend listens directly on Unix socket (`\$XDG_RUNTIME_DIR/pgserve/.s.PGSQL.5432`) AND TCP 5432, no proxy. Replace always-on bun daemon with on-demand CLI verbs (`provision`, `verify`, `gc`, `trust`, `doctor`). Add cosign-keyless-OIDC publisher attestation as Tier 2 on top of host_signed (Tier 1) and path-based default (Tier 0). Hardcoded blocklist of known-bad versions. Self-healing `pgserve update` auto-migrates old layout, restarts pm2, runs `doctor --fix` tiered.

**Version target**: pgserve 2.3 (3.0 reserved for post-npm-departure cutover per `distribution-exodus`).

## Scope

9 execution groups, 4 waves, ~3-4 weeks appetite. See WISH.md + SHARED-DESIGN.md.

## Test plan

- [ ] `genie wish lint pgserve-singleton-no-proxy` clean
- [ ] SHARED-DESIGN.md byte-identical across paired wishes
- [ ] No code changes — doc-only PR

## Companion PRs

- `automagik-dev/genie#pgserve-singleton-no-proxy` (consumer-side wiring)
- `automagik/omni#pgserve-singleton-no-proxy` (consumer-side wiring)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive design specifications for pgserve singleton v2.3 architecture, outlining removal of proxy components, implementation of self-healing updates, new CLI commands (provision, verify, gc, trust, doctor), enhanced security model with keyless attestation, and rollout strategy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->