### PR TITLE
docs(wish): housekeep shipped statuses + v2.4 cohort relabel + park system-mode wish

### DIFF
--- a/.genie/wishes/autopg-console-dist/WISH.md
+++ b/.genie/wishes/autopg-console-dist/WISH.md
@@ -2,7 +2,7 @@
 
 | Field | Value |
 |-------|-------|
-| **Status** | DRAFT |
+| **Status** | SHIPPED (v2.2.2, 2026-05-04) |
 | **Slug** | `autopg-console-dist` |
 | **Date** | 2026-05-03 |
 | **Author** | Felipe Rosa (via genie-pgserve agent) |

--- a/.genie/wishes/autopg-console-settings/WISH.md
+++ b/.genie/wishes/autopg-console-settings/WISH.md
@@ -2,7 +2,7 @@
 
 | Field | Value |
 |-------|-------|
-| **Status** | DRAFT |
+| **Status** | SHIPPED (v2.2.0, 2026-05-03) |
 | **Slug** | `autopg-console-settings` |
 | **Date** | 2026-04-30 |
 | **Author** | felipe@namastex.ai |

--- a/.genie/wishes/autopg-service-install-system/WISH.md
+++ b/.genie/wishes/autopg-service-install-system/WISH.md
@@ -1,0 +1,104 @@
+# Wish: `autopg service install --system` — privileged system-wide systemd unit
+
+| Field | Value |
+|-------|-------|
+| **Status** | DRAFT (parked for post-v2.4 `/dream` queue) |
+| **Slug** | `autopg-service-install-system` |
+| **Date** | 2026-05-08 |
+| **Author** | Felipe Rosa (split out from `autopg-distribution-cutover` G11.6) |
+| **Appetite** | medium (~1 week, integration-test heavy) |
+| **Branch** | `wish/autopg-service-install-system` (separate branch + PR per Felipe directive 2026-05-08) |
+| **Repos touched** | `automagik/autopg` (post-rename) |
+| **Predecessor** | `autopg-distribution-cutover` G11.6 ships Tier B `--user` only in v2.4. This wish adds the `--system` mode in the next minor (v2.5 or v3.0 — TBD by Felipe). |
+| **Dream queue** | next-version |
+
+## Summary
+
+Extend `autopg service install` with a `--system` mode that writes a system-wide systemd unit at `/etc/systemd/system/autopg.service`, runs as a dedicated `autopg` UNIX user, and ships the hardening profile expected of a production service. Deferred from v2.4 because the privileged-install surface (sudo, dedicated user, mandatory access control) is materially larger than `--user` and would have blocked the v2.4 train.
+
+This wish exists ONLY to unblock the v2.4 ship. It is not a placeholder — when it lands, it ships the full privileged path that ops teams expect.
+
+## Scope
+
+### IN
+
+**Group 1 — Dedicated UNIX user provisioning**
+- `autopg service install --system` creates an `autopg` system user (no shell, no home in `/home`, primary group `autopg`) if absent. Idempotent.
+- Data dir, runtime dir, log dir all get `chown autopg:autopg` with mode `0700`.
+- Refuse to run if not invoked under sudo / as root.
+
+**Group 2 — System unit file**
+- Write `/etc/systemd/system/autopg.service`:
+  - `User=autopg`, `Group=autopg`
+  - `ProtectSystem=strict`, `ProtectHome=true`, `PrivateTmp=true`, `NoNewPrivileges=true`
+  - `ReadWritePaths=` for data + runtime + log dirs only
+  - `Restart=on-failure`, `RestartSec=5`
+  - `ExecStart=<install-dir>/autopg serve --data /var/lib/autopg --runtime /run/autopg`
+  - `RuntimeDirectory=autopg`, `RuntimeDirectoryMode=0700`
+- `systemctl daemon-reload && systemctl enable --now autopg.service`.
+
+**Group 3 — Migration from `--user` or pm2**
+- Same hard-MIGRATE contract as the v2.4 G11.6 `--user` path: must detect existing supervisor (pm2 / systemd-user / launchd), capture state, stop + delete cleanly, write new system unit, verify boot, update `admin.json`. No duplicates ever.
+- Specific edge case: migrating from `--user` to `--system` requires moving the data dir from `~/.autopg/data` to `/var/lib/autopg` with `chown autopg:autopg`. Provide `--keep-data-in-home` escape hatch for operators who want to leave the data where it is (only the unit changes scope).
+
+**Group 4 — SELinux / AppArmor profile**
+- Write a minimal AppArmor profile for the `autopg` binary (Ubuntu / Debian).
+- Write a minimal SELinux policy module (Fedora / RHEL).
+- `autopg service install --system` detects which MAC system is active and installs the matching profile.
+- `--no-mac-profile` flag for operators who manage profiles externally.
+
+**Group 5 — `autopg doctor --system` checks**
+- Verify dedicated user exists and owns expected paths.
+- Verify unit is enabled + active + running under correct user.
+- Verify MAC profile is loaded (when not `--no-mac-profile`).
+- Still passive reporting only — no auto-fix suggestions per Felipe's 2026-05-08 directive.
+
+**Group 6 — Documentation + migration guide**
+- New section in install guide: "Production install with system-wide systemd".
+- Migration runbook: `--user` → `--system` upgrade, with the data-dir-move step.
+- Rollback runbook: `autopg service uninstall --system`.
+
+**Group 7 — Tests + CI fixtures**
+- Linux fixture: fresh root container → `autopg service install --system` → assert dedicated user, unit active, MAC profile loaded, postgres responsive on UDS + TCP.
+- Migration fixtures: pm2 → `--system`, `--user` → `--system`, `--system` rollback.
+- All in CI on Linux Blacksmith runners with sudo enabled.
+
+### OUT
+
+- macOS `--system` (launchd `LaunchDaemons` requiring root) — separate future wish if demand emerges.
+- Multi-host / cluster systemd orchestration.
+- Custom MAC profile composition (operators bring their own profile generator).
+
+## Decisions
+
+| # | Decision | Rationale |
+|---|---|---|
+| 1 | Separate wish, separate branch, separate PR | Felipe directive 2026-05-08: "separate branches wishes and prs" + "that comes for next version". |
+| 2 | Dedicated `autopg` UNIX user, not `nobody` or postgres | Service hardening 101: principle of least privilege. `nobody` is overloaded; reusing system `postgres` user couples autopg to a specific PG package. |
+| 3 | MAC profile on by default | Production hosts running as root need defense in depth; profile is opt-out via `--no-mac-profile`. |
+| 4 | Migration is a one-way upgrade by default | `--system` is the production endpoint; downgrade to `--user` exists (`autopg service uninstall --system && autopg service install`) but is not a smooth flow. Operators rarely downgrade. |
+
+## Success Criteria
+
+- Fresh Linux host: `sudo autopg service install --system` produces a fully functional, MAC-profiled, dedicated-user-owned autopg in <60s.
+- Re-running `sudo autopg service install --system` is idempotent.
+- `autopg doctor` reports `supervisor: systemd-system, user: autopg, mac: apparmor (or selinux)` and all checks pass.
+- No duplicate-supervision states ever observable from the migration paths.
+- All seven groups land behind a single PR per Felipe's "separate PRs" directive.
+
+## Dependencies
+
+- v2.4 must ship first (Tier A pm2 + Tier B systemd-user) — this wish only adds `--system` on top.
+- `autopg-distribution-cutover` G11.6 contract for "no duplicate supervisors" must be already proven and tested.
+
+## QA Criteria
+
+- [ ] CI fixture: pm2 → `--system` migrates cleanly, no pm2 residue.
+- [ ] CI fixture: `--user` → `--system` migrates cleanly, data dir moved to `/var/lib/autopg`.
+- [ ] CI fixture: rollback path (`autopg service uninstall --system`) restores `--user` mode.
+- [ ] AppArmor / SELinux profile loads on Ubuntu 24.04 + Fedora 41 fixtures.
+- [ ] `autopg service install --system` invoked without sudo exits non-zero with clear remediation.
+
+## Notes
+
+This wish is parked. Do NOT execute via `/dream` until v2.4 has shipped and `autopg service install` (Tier B `--user`) is proven in production. Felipe's directive (2026-05-08): "separate dedicated wish, and dream queue too" — this lives on the next-version queue.

--- a/.genie/wishes/canonical-pgserve-pm2-supervision/WISH.md
+++ b/.genie/wishes/canonical-pgserve-pm2-supervision/WISH.md
@@ -91,7 +91,7 @@ Same session also revealed: **multiple pgserve instances running in parallel** (
 - **No port migration tooling for third-party consumers.** If someone else's app talks to omni's old pgserve port directly, they update on their own.
 - **No automatic uninstall of legacy embedded pgserve data dirs.** Migration copies forward; the old data stays on disk until operator removes it (avoids accidental data loss).
 - **No multi-host pgserve cluster.** Single host only. Multi-host pgserve is a separate, much larger wish.
-- **No systemd / launchd path.** pm2 is the single supervisor for this iteration. Aegis-runtime wish covers a future systemd-user variant.
+- **No systemd / launchd as the DEFAULT path.** pm2 is the rootless default supervisor that ships with `autopg install` (Tier A). Systemd / launchd ships in the same v2.4 release as `autopg service install` (Tier B, privileged opt-in) — see the singleton-no-proxy wish's two-tier supervisor model. This wish (when it lands) only specifies the pm2 tier.
 
 ## Decisions
 

--- a/.genie/wishes/pgserve-singleton-no-proxy/WISH.md
+++ b/.genie/wishes/pgserve-singleton-no-proxy/WISH.md
@@ -1,23 +1,32 @@
-# Wish: pgserve singleton — kill proxy, add cosign, new CLI verbs (v2.3)
+# Wish: pgserve singleton — kill proxy, add cosign, new CLI verbs (v2.4)
 
 | Field | Value |
 |-------|-------|
-| **Status** | DRAFT |
+| **Status** | DRAFT (one of three peer wishes that together ship v2.4; each gets its own branch + PR + `/dream` slot) |
 | **Slug** | `pgserve-singleton-no-proxy` |
-| **Date** | 2026-05-06 |
+| **Date** | 2026-05-06 (relabeled v2.3 → v2.4 on 2026-05-08; v2.3.0 already shipped as docs-only placeholder release) |
 | **Author** | Felipe Rosa <felipe@namastex.ai> |
 | **Appetite** | large (~3-4 weeks) |
 | **Branch** | `wish/pgserve-singleton-no-proxy` |
 | **Repos touched** | `automagik/pgserve` |
 | **Design** | [SHARED-DESIGN.md](./SHARED-DESIGN.md) |
+| **v2.4 cohort** | peer wishes, separate branches/PRs: `autopg-distribution-cutover`, `canonical-pgserve-pm2-supervision`, this wish |
 
 > **Companion wishes** (byte-identical SHARED-DESIGN.md): `automagik-dev/genie#pgserve-singleton-no-proxy`, `automagik/omni#pgserve-singleton-no-proxy`. All three ship in parallel against their respective integration branches.
 
 ## Summary
 
-Major bump to pgserve **2.3.0**. Kill the bun bridge from the data plane: postgres backend listens directly on Unix socket (`$XDG_RUNTIME_DIR/pgserve/.s.PGSQL.5432`) AND TCP 5432, no proxy. Replace the always-on bun daemon with on-demand CLI verbs (`pgserve provision`, `pgserve verify`, `pgserve gc`, `pgserve trust`, `pgserve doctor`). Add cosign-keyless-OIDC publisher attestation as Tier 2 on top of the existing host_signed identity (Tier 1) and path-based default (Tier 0). Bake a hardcoded blocklist of known-bad versions. Wire self-healing semantics into `pgserve update` (auto-migrate old layout, pm2 restart, doctor --fix tiered). See `SHARED-DESIGN.md` §1-§9 for full design context.
+Major bump to pgserve **2.4.0**. Kill the bun bridge from the data plane: postgres backend listens directly on Unix socket (`$XDG_RUNTIME_DIR/pgserve/.s.PGSQL.5432`) AND TCP 5432, no proxy. Replace the always-on bun daemon with on-demand CLI verbs (`pgserve provision`, `pgserve verify`, `pgserve gc`, `pgserve trust`, `pgserve doctor`). Add cosign-keyless-OIDC publisher attestation as Tier 2 on top of the existing host_signed identity (Tier 1) and path-based default (Tier 0). Bake a hardcoded blocklist of known-bad versions. Wire self-healing semantics into `pgserve update` (auto-migrate old layout, pm2 restart, doctor --fix tiered). See `SHARED-DESIGN.md` §1-§9 for full design context.
 
-> **⚠ BREAKING — accept-downtime contract**: TCP port `8432` dies in this release. Out-of-trio consumers that hardcode `localhost:8432` (brain, rlmx, hapvida-eugenia, email, any third-party app) **WILL break silently** when `pgserve update` runs. This is intentional: pgserve 2.3 is a major bump and the cutover is the right moment to take that hit once. CHANGELOG must warn explicitly. QA Criteria adds a consumer-fan-out test (verify all known consumers connect post-cutover). **No socat shim. No port-redirect. No backwards-compat layer.** Operators update connection strings to Unix socket (preferred) or TCP 5432.
+> **🛡 TWO-TIER SUPERVISOR MODEL (Felipe constraint, 2026-05-08)**: removing the bun bridge does NOT mean removing the supervisor.
+>
+> - **Tier A — `autopg install` (default, rootless)**: writes a pm2 ecosystem entry that supervises the postgres postmaster directly. Works for the majority of devs who have no root and cannot install systemd units. Keeps the existing `autopg-server` + `autopg-ui` two-process pm2 layout from the cutover wish.
+> - **Tier B — `autopg service install` (`--user` only in v2.4, privileged opt-in)**: dedicated subcommand that installs a systemd user-unit on Linux (or launchd plist on macOS) for operators who want OS-native supervision. **Hard contract**: `autopg service install` MUST migrate from pm2 (`pm2 delete autopg-server` BEFORE writing the unit) — never both supervisors active simultaneously. `autopg doctor` reports the active mode passively (no auto-swap prompts).
+> - **System-wide systemd (`--system` mode, dedicated `autopg` UNIX user, selinux/apparmor)** is **OUT OF SCOPE for v2.4** — separate dedicated wish on the next-version `/dream` queue (`autopg-service-install-system`).
+>
+> Postmaster is the long-running process under either tier; the new CLI verbs (`provision`/`verify`/`gc`/`trust`/`doctor`) are short-lived helpers, not replacements for supervision. `autopg doctor` reads `~/.autopg/admin.json` (records active supervisor: `pm2` | `systemd-user` | `launchd`) and reports it; nothing else.
+
+> **⚠ BREAKING — accept-downtime contract**: TCP port `8432` dies in this release. Out-of-trio consumers that hardcode `localhost:8432` (brain, rlmx, hapvida-eugenia, email, any third-party app) **WILL break silently** when `pgserve update` runs. This is intentional: pgserve 2.4 is a major bump and the cutover is the right moment to take that hit once. CHANGELOG must warn explicitly. QA Criteria adds a consumer-fan-out test (verify all known consumers connect post-cutover). **No socat shim. No port-redirect. No backwards-compat layer.** Operators update connection strings to Unix socket (preferred) or TCP 5432.
 
 ## Scope
 
@@ -76,7 +85,7 @@ Major bump to pgserve **2.3.0**. Kill the bun bridge from the data plane: postgr
 
 **Group 9 — Tests + docs + CHANGELOG**
 - Tests for every new CLI verb.
-- Migration test from synthetic v2.2.x state to v2.3.x.
+- Migration test from synthetic v2.2.x state to v2.4.x.
 - Cosign verify tests.
 - CHANGELOG entry naming the contracts.
 
@@ -124,7 +133,7 @@ See `SHARED-DESIGN.md` §6 for the cross-repo decision table. pgserve-specific:
 - [ ] Cross-DB grants: `pgserve grant` works only between cosign-verified publishers.
 - [ ] All existing pgserve tests pass byte-identically.
 - [ ] CHANGELOG entry naming: socket path canonical-ization, blocklist, tiered doctor, cosign tier.
-- [ ] Migration test: synthetic v2.2.x state → run `pgserve update` → assert v2.3.x state.
+- [ ] Migration test: synthetic v2.2.x state → run `pgserve update` → assert v2.4.x state.
 - [ ] `bun run lint` and `bun run typecheck` clean.
 
 ## Execution Strategy

--- a/.genie/wishes/pgserve-v2/WISH.md
+++ b/.genie/wishes/pgserve-v2/WISH.md
@@ -2,7 +2,7 @@
 
 | Field | Value |
 |-------|-------|
-| **Status** | DRAFT |
+| **Status** | SHIPPED (v2.0.0, 2026-04-29) |
 | **Slug** | `pgserve-v2` |
 | **Date** | 2026-04-26 |
 | **Author** | Felipe Rosa (via genie-pgserve agent) |


### PR DESCRIPTION
## Summary

Wish-file housekeeping pass triggered by Felipe's 2026-05-08 review ("road to v3" → corrected to "v2.4 cohort"). No code changes. All edits live under `.genie/wishes/`.

### Shipped statuses flipped

| Wish | Released as | New status |
|---|---|---|
| `pgserve-v2` | v2.0.0 (2026-04-29) | SHIPPED |
| `autopg-console-settings` | v2.2.0 (2026-05-03) | SHIPPED |
| `autopg-console-dist` | v2.2.2 (2026-05-04) | SHIPPED |

### `pgserve-singleton-no-proxy` rebased v2.3 → v2.4

v2.3.0 already shipped as a docs-only placeholder release. The actual breaking cut now ships as v2.4.0. Title, summary, breaking-contract section, and migration tests all rebased.

Header gains:
- **v2.4 cohort** field cross-linking the three peer wishes that ship v2.4 together with separate branches/PRs/dream slots.
- **Two-tier supervisor model** note replacing the prior single PM2-RETENTION block.

### Two-tier supervisor model (locked)

- **Tier A — `autopg install`** (default, rootless): pm2 ecosystem entry supervising postmaster directly. Works for the majority of devs without root.
- **Tier B — `autopg service install`** (privileged opt-in, `--user` only in v2.4): systemd user-unit on Linux / launchd plist on macOS. **Hard MIGRATE contract**: `pm2 delete autopg-server` BEFORE writing the unit; never both supervisors active simultaneously.
- `autopg doctor` reports active mode passively. No auto-swap, no migration prompts.

`--system` mode (sudo, dedicated UNIX user, selinux/apparmor) is parked in a new wish for the next-version `/dream` queue.

### Cohort sibling adjustments

- `canonical-pgserve-pm2-supervision` — "No systemd path" → "Tier A only; Tier B ships in same v2.4 release via cohort sibling".

### NEW: `autopg-service-install-system` (parked)

7-group wish covering the privileged `--system` path: dedicated `autopg` UNIX user, system-wide systemd unit, AppArmor / SELinux profile, migration from pm2/--user, doctor extensions, docs, CI fixtures. Status: DRAFT — do NOT execute via `/dream` until v2.4 ships.

## Felipe directives baked in (2026-05-08)

1. `/dream` the v2.4 cohort separately (peer wishes, not umbrella).
2. Separate branches / wishes / PRs per cohort member.
3. `--system` mode → next version with dedicated wish + dream queue.
4. `autopg doctor` reports passively + `service install` MUST migrate (no duplicates).

## Companion commit

The matching `autopg-distribution-cutover` G11.6 spec (Tier B `--user` with hard MIGRATE contract) lives on `wish/autopg-cutover-transport-absorb` (commit pushed separately, since that wish file only exists on the cutover branch).

## Test plan

- [ ] Reviewer confirms wish status accuracy against shipped tags (v2.0.0, v2.2.0, v2.2.2).
- [ ] Reviewer confirms v2.4 relabel covers all v2.3.x references in the singleton wish.
- [ ] Reviewer confirms two-tier supervisor note matches the cutover G11.6 contract on the sibling branch.
- [ ] No code changed — CI should pass docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Pre-bundled autopg console now available offline without external dependencies
  * Console settings interface is now functional

* **Releases**
  * pgserve v2.0.0 shipped with socket-based architecture
  * autopg console v2.2.2 released with offline-first capability
  * autopg console settings v2.2.0 released

<!-- end of auto-generated comment: release notes by coderabbit.ai -->