### PR TITLE
feat(singleton#1): foundation — postmaster + admin.json writer (Tier A pm2)

### DIFF
--- a/.genie/wishes/pgserve-singleton-no-proxy/WISH.md
+++ b/.genie/wishes/pgserve-singleton-no-proxy/WISH.md
@@ -32,9 +32,10 @@ Major bump to pgserve **2.4.0**. Kill the bun bridge from the data plane: postgr
 
 ### IN
 
-**Group 1 — Postmaster reconfig + dual-transport (data-plane core)**
+**Group 1 — Postmaster reconfig + dual-transport + Tier A pm2 wiring (data-plane core)**
 - Postmaster boot args: `-k $XDG_RUNTIME_DIR/pgserve` + `-p 5432` + `listen_addresses = 'localhost'`. Fallback `/tmp/pgserve` when `$XDG_RUNTIME_DIR` unset (CI runners).
-- `pgserve install` ensures `$XDG_RUNTIME_DIR/pgserve` directory exists (mode 0700), wires postgres pm2/systemd/launchd entry pointing at postmaster directly (no bun bridge process).
+- `pgserve install` ensures `$XDG_RUNTIME_DIR/pgserve` directory exists (mode 0700), wires the **Tier A pm2 entry** (`autopg-server`) pointing at postmaster directly (no bun bridge process). **Tier A only** in this group — systemd-user (Linux) / launchd (macOS) ship separately via `autopg service install` (cutover wish G11.6).
+- `~/.autopg/admin.json` records `{ "supervisor": "pm2", "socketDir": "<XDG-or-tmp>", "port": 5432 }` so cohort siblings + `autopg doctor` can read the active supervisor without inspecting pm2 state directly.
 - Stale-lock detection: refuse install if `pgserve.pid` exists with live PID; archive prior socket dirs to `.legacy/`.
 - `pgserve port` returns 5432 (was 8432).
 
@@ -135,6 +136,8 @@ See `SHARED-DESIGN.md` §6 for the cross-repo decision table. pgserve-specific:
 - [ ] CHANGELOG entry naming: socket path canonical-ization, blocklist, tiered doctor, cosign tier.
 - [ ] Migration test: synthetic v2.2.x state → run `pgserve update` → assert v2.4.x state.
 - [ ] `bun run lint` and `bun run typecheck` clean.
+- [ ] `pgserve doctor` reports active supervisor (`pm2` | `systemd-user` | `launchd` | `external`) by reading `~/.autopg/admin.json` and runs the matching liveness check; never auto-swaps tiers.
+- [ ] On a host where Tier A (pm2) is active and operator runs `autopg service install` (Tier B from cutover G11.6), the MIGRATE contract is honored: pm2 entry deleted BEFORE unit write; `admin.json.supervisor` flips from `pm2` to `systemd-user`; `pgserve install` afterwards refuses with remediation hint.
 
 ## Execution Strategy
 
@@ -169,28 +172,36 @@ See `SHARED-DESIGN.md` §6 for the cross-repo decision table. pgserve-specific:
 
 ## Execution Groups
 
-### Group 1: Postmaster reconfig + dual-transport
+### Group 1: Postmaster reconfig + dual-transport + Tier A pm2
 
-**Goal:** Postgres backend listens on canonical Unix socket + TCP 5432 natively. `pgserve install` ensures the socket dir exists with correct perms.
+**Goal:** Postgres backend listens on canonical Unix socket + TCP 5432 natively. `pgserve install` ensures the socket dir exists with correct perms AND registers Tier A pm2 entry (`autopg-server`). Tier B systemd-user / launchd is **out of scope** here — delivered by cutover wish G11.6 via `autopg service install`.
 
 **Deliverables:**
 1. `bin/postgres-server.js` updated to pass `-k <socket-dir>` and `-p 5432` to postmaster.
 2. Helper `resolveSocketDir(): string` — returns `$XDG_RUNTIME_DIR/pgserve` (preferred) or `/tmp/pgserve` (fallback).
 3. `pgserve install` step: `mkdir -p <socket-dir>` (mode 0700), validate writability.
 4. `pgserve port` returns `5432`.
-5. Update `~/.autopg/admin.json` to publish `socketDir` + `port: 5432`.
+5. `pgserve install` registers/updates pm2 entry `autopg-server` pointing at postgres wrapper. `--no-pm2` flag for CI / Tier B-bound hosts.
+6. `~/.autopg/admin.json` writer module: atomic write of `{ supervisor: "pm2", socketDir, port: 5432, installedAt }` after pm2 register success. Refuses to write `supervisor: "pm2"` if file already records `systemd-user` or `launchd` (operator must run `autopg service uninstall` first to revert to Tier A).
 
 **Acceptance Criteria:**
 - [ ] `pgserve install` on a fresh host creates `$XDG_RUNTIME_DIR/pgserve/` with mode 0700.
 - [ ] After `pgserve install`, `psql -h $XDG_RUNTIME_DIR/pgserve` (no `-p`) connects.
 - [ ] After `pgserve install`, `psql -h 127.0.0.1 -p 5432` connects.
 - [ ] `pgserve port` outputs `5432`.
+- [ ] `pm2 jlist | jq '.[] | select(.name=="autopg-server")'` is non-empty post-install.
+- [ ] `~/.autopg/admin.json` records `supervisor: "pm2"` with the resolved socketDir.
+- [ ] If `admin.json` records `supervisor: "systemd-user"` (host already on Tier B), `pgserve install` refuses non-zero with remediation hint to run `autopg service uninstall` first.
+- [ ] `pgserve install --no-pm2` skips pm2 register but still writes admin.json with `supervisor: "external"` for Tier B installers to claim.
 
 **Validation:**
 ```bash
 pgserve install
 test -d "$XDG_RUNTIME_DIR/pgserve" && stat -c '%a' "$XDG_RUNTIME_DIR/pgserve" | grep -q 700
 psql -h "$XDG_RUNTIME_DIR/pgserve" -c 'SELECT 1' postgres
+psql -h 127.0.0.1 -p 5432 -c 'SELECT 1' postgres
+pm2 jlist | jq -e '.[] | select(.name=="autopg-server")' >/dev/null
+jq -e '.supervisor == "pm2"' ~/.autopg/admin.json
 ```
 
 **depends-on:** none
@@ -242,13 +253,15 @@ psql -h 127.0.0.1 -p 5432 -c 'SELECT 1' postgres
 - [ ] `pgserve gc` removes a synthetic orphan.
 - [ ] `pgserve trust list` shows hardcoded + user entries.
 - [ ] `pgserve doctor --fix` mutates Cat 1 silently, prompts Cat 2, refuses Cat 3.
+- [ ] `pgserve doctor` reports active supervisor mode by reading `~/.autopg/admin.json.supervisor` ∈ {`pm2`, `systemd-user`, `launchd`, `external`} and runs the matching liveness check (pm2 jlist / `systemctl --user is-active` / `launchctl print state == running` / postgres-only check). **Passive reporting — never suggests swapping tiers.**
+- [ ] On a host where `admin.json.supervisor == "pm2"` but pm2 entry is missing: `pgserve doctor` reports the inconsistency and `--fix` re-registers the pm2 entry (Cat 1 mutation).
 
 **Validation:**
 ```bash
 bun test tests/cli/
 ```
 
-**depends-on:** Group 1
+**depends-on:** Group 4
 
 ---
 
@@ -302,24 +315,33 @@ bun test tests/blocklist.test.js
 
 ---
 
-### Group 6: Self-healing `pgserve update` pipeline
+### Group 6: Self-healing `pgserve update` pipeline (supervisor-aware)
 
-**Goal:** `pgserve update` from old layout → new layout is one-shot; idempotent.
+**Goal:** `pgserve update` from old layout → new layout is one-shot; idempotent. **Restart primitive dispatch is supervisor-aware**: reads `~/.autopg/admin.json.supervisor` and calls the matching restart command (pm2 / systemctl --user / launchctl).
 
 **Deliverables:**
 1. Detection logic for old proxy layout (pm2 entry running bun on 8432).
-2. Migration sequence: stop bun, reconfigure pm2 entry, archive old socket dirs.
+2. Migration sequence: stop bun, reconfigure pm2 entry (Tier A path) OR rewrite systemd unit (Tier B path), archive old socket dirs.
 3. Post-restart `pgserve doctor --fix` (default tiered mode).
 4. Active-connection check via `pg_stat_activity`; prompt unless `--yes`.
+5. **Restart-primitive dispatcher**: read `admin.json.supervisor`, then:
+   - `pm2` → `pm2 restart autopg-server --update-env`
+   - `systemd-user` → `systemctl --user restart autopg.service`
+   - `launchd` → `launchctl kickstart -k gui/$UID/dev.automagik.autopg`
+   - `external` → no-op (operator owns supervision); emit advisory log.
 
 **Acceptance Criteria:**
-- [ ] Synthetic old-layout host: `pgserve update` reconfigures everything; second run is no-op.
+- [ ] Synthetic old-layout host (Tier A pm2): `pgserve update` reconfigures everything; second run is no-op.
+- [ ] Synthetic Tier B host (systemd-user): `pgserve update` rewrites postgres args, runs `systemctl --user restart` (NOT `pm2 restart`), idempotent.
 - [ ] Active-connection prompt warns operator before kicking restart.
 - [ ] Audit-log captures each migration step.
+- [ ] `admin.json.supervisor == "external"` → `pgserve update` skips restart, logs "supervisor=external; skipping restart, operator must restart externally", exits 0 if data-plane is already responsive.
 
 **Validation:**
 ```bash
 bash tests/integration/upgrade-from-2.2.x.sh
+bash tests/integration/upgrade-tier-b-systemd-user.sh
+bash tests/integration/upgrade-external-supervisor.sh
 ```
 
 **depends-on:** Group 5
@@ -348,7 +370,7 @@ bash tests/integration/upgrade-from-2.2.x.sh
 bun test tests/sql/
 ```
 
-**depends-on:** Group 1
+**depends-on:** Group 3
 
 ---
 
@@ -412,10 +434,13 @@ test -f docs/security/cosign-trust.md
 
 - **paired-with** `automagik-dev/genie#pgserve-singleton-no-proxy` — consumer-side wiring; ships in lockstep.
 - **paired-with** `automagik/omni#pgserve-singleton-no-proxy` — consumer-side wiring; ships in lockstep.
+- **paired-with** `pgserve#autopg-distribution-cutover` — v2.4 cohort sibling. Owns the rename → `autopg`, CDN distribution, and the **Tier B `autopg service install` G11.6** that this wish defers to. Both wishes share the `~/.autopg/admin.json` schema and the hard MIGRATE contract that prevents pm2 + systemd-user double-supervision.
+- **paired-with** `pgserve#canonical-pgserve-pm2-supervision` — v2.4 cohort sibling. Specifies cross-repo pm2 reuse (genie / omni install reuse the pgserve pm2 ecosystem). Tier A only.
 - **builds-on** `pgserve-canonical-cutover` (genie merged) — consumer-only foundation.
 - **builds-on** `pgserve-host-signed-identity` (genie merged, pgserve pending) — host_signed Tier 1 stays; cosign Tier 2 layered on top.
 - **builds-on** `update-unify-stages` (all merged) — pre-flight + decideVerify + diagnostics inherited.
 - **builds-on** `genie-supply-chain-signing` — reuses `--unsafe-unverified <INCIDENT_ID>` typed-ack.
+- **blocks** `autopg-service-install-system` (parked) — that wish extends G11.6's `--user` mode to `--system` mode; cannot start until v2.4 ships.
 
 ## QA Criteria
 
@@ -446,6 +471,9 @@ test -f docs/security/cosign-trust.md
 | Old socket dir archives grow unboundedly | Low | Document cleanup recipe. Future `pgserve gc --legacy-archives`. |
 | Some operators rely on TCP 8432 in scripts | Medium | TCP 5432 is canonical; 8432 dies. CHANGELOG warns explicitly. |
 | `--skip-sigstore` becomes default in CI by accident | Low | Refuses unless `--offline-cosign-key` pretrusted; emits warning; audit-log entry. |
+| **Tier A pm2 + Tier B systemd-user double-supervision** (operator runs both `pgserve install` and `autopg service install`) | High | `autopg service install` (cutover G11.6) MUST `pm2 delete autopg-server` BEFORE writing the unit; `pgserve install` refuses if `admin.json.supervisor == "systemd-user"` until operator runs `autopg service uninstall` first. Group 1 acceptance criterion validates both directions. |
+| `~/.autopg/admin.json` corruption leaves doctor unable to identify supervisor | Low | doctor `--fix` (Cat 1) rewrites admin.json from observed pm2/systemd state; G3 acceptance criterion covers the missing-pm2-entry inconsistency case. |
+| Operator on Tier B systemd-user runs `pgserve update`, expecting pm2 restart | Medium | `pgserve update` (G6) reads `admin.json.supervisor` and dispatches the matching restart primitive (`pm2 restart` / `systemctl --user restart` / `launchctl kickstart`). G6 acceptance criterion adds an explicit Tier-B-restart test. |
 
 ---
 

--- a/.genie/wishes/pgserve-singleton-no-proxy/WISH.md
+++ b/.genie/wishes/pgserve-singleton-no-proxy/WISH.md
@@ -34,7 +34,7 @@ Major bump to pgserve **2.4.0**. Kill the bun bridge from the data plane: postgr
 
 **Group 1 — Postmaster reconfig + dual-transport + Tier A pm2 wiring (data-plane core)**
 - Postmaster boot args: `-k $XDG_RUNTIME_DIR/pgserve` + `-p 5432` + `listen_addresses = 'localhost'`. Fallback `/tmp/pgserve` when `$XDG_RUNTIME_DIR` unset (CI runners).
-- `pgserve install` ensures `$XDG_RUNTIME_DIR/pgserve` directory exists (mode 0700), wires the **Tier A pm2 entry** (`autopg-server`) pointing at postmaster directly (no bun bridge process). **Tier A only** in this group — systemd-user (Linux) / launchd (macOS) ship separately via `autopg service install` (cutover wish G11.6).
+- `pgserve install` ensures `$XDG_RUNTIME_DIR/pgserve` directory exists (mode 0700), wires the **Tier A pm2 entry** (`autopg-server`) pointing at postmaster directly (no bun bridge process). **Tier A only** in this group — systemd-user (Linux) / launchd (macOS) ship separately via `autopg service install` (cutover wish G20).
 - `~/.autopg/admin.json` records `{ "supervisor": "pm2", "socketDir": "<XDG-or-tmp>", "port": 5432 }` so cohort siblings + `autopg doctor` can read the active supervisor without inspecting pm2 state directly.
 - Stale-lock detection: refuse install if `pgserve.pid` exists with live PID; archive prior socket dirs to `.legacy/`.
 - `pgserve port` returns 5432 (was 8432).
@@ -137,7 +137,7 @@ See `SHARED-DESIGN.md` §6 for the cross-repo decision table. pgserve-specific:
 - [ ] Migration test: synthetic v2.2.x state → run `pgserve update` → assert v2.4.x state.
 - [ ] `bun run lint` and `bun run typecheck` clean.
 - [ ] `pgserve doctor` reports active supervisor (`pm2` | `systemd-user` | `launchd` | `external`) by reading `~/.autopg/admin.json` and runs the matching liveness check; never auto-swaps tiers.
-- [ ] On a host where Tier A (pm2) is active and operator runs `autopg service install` (Tier B from cutover G11.6), the MIGRATE contract is honored: pm2 entry deleted BEFORE unit write; `admin.json.supervisor` flips from `pm2` to `systemd-user`; `pgserve install` afterwards refuses with remediation hint.
+- [ ] On a host where Tier A (pm2) is active and operator runs `autopg service install` (Tier B from cutover G20), the MIGRATE contract is honored: pm2 entry deleted BEFORE unit write; `admin.json.supervisor` flips from `pm2` to `systemd-user`; `pgserve install` afterwards refuses with remediation hint.
 
 ## Execution Strategy
 
@@ -174,7 +174,7 @@ See `SHARED-DESIGN.md` §6 for the cross-repo decision table. pgserve-specific:
 
 ### Group 1: Postmaster reconfig + dual-transport + Tier A pm2
 
-**Goal:** Postgres backend listens on canonical Unix socket + TCP 5432 natively. `pgserve install` ensures the socket dir exists with correct perms AND registers Tier A pm2 entry (`autopg-server`). Tier B systemd-user / launchd is **out of scope** here — delivered by cutover wish G11.6 via `autopg service install`.
+**Goal:** Postgres backend listens on canonical Unix socket + TCP 5432 natively. `pgserve install` ensures the socket dir exists with correct perms AND registers Tier A pm2 entry (`autopg-server`). Tier B systemd-user / launchd is **out of scope** here — delivered by cutover wish G20 via `autopg service install`.
 
 **Deliverables:**
 1. `bin/postgres-server.js` updated to pass `-k <socket-dir>` and `-p 5432` to postmaster.
@@ -182,7 +182,7 @@ See `SHARED-DESIGN.md` §6 for the cross-repo decision table. pgserve-specific:
 3. `pgserve install` step: `mkdir -p <socket-dir>` (mode 0700), validate writability.
 4. `pgserve port` returns `5432`.
 5. `pgserve install` registers/updates pm2 entry `autopg-server` pointing at postgres wrapper. `--no-pm2` flag for CI / Tier B-bound hosts.
-6. `~/.autopg/admin.json` writer module: atomic write of `{ supervisor: "pm2", socketDir, port: 5432, installedAt }` after pm2 register success. Refuses to write `supervisor: "pm2"` if file already records `systemd-user` or `launchd` (operator must run `autopg service uninstall` first to revert to Tier A).
+6. `src/lib/admin-json.js` (cohort-shared module — co-owned with cohort sibling `canonical-pgserve-pm2-supervision` Group 1 deliverable 2): atomic writer (writes to `<file>.tmp` + `fs.rename`) + reader + `assertSupervisor(expected)` helper that throws with the locked remediation hint when actual differs. Schema: `{ supervisor, socketDir, port, installedAt }` with `supervisor ∈ { "pm2" | "systemd-user" | "launchd" | "external" }`. After successful pm2 register, `pgserve install` invokes the writer with `{ supervisor: "pm2", socketDir, port: 5432, installedAt: <ISO> }`. Refuses to write `supervisor: "pm2"` if file already records `systemd-user` or `launchd` (operator must run `autopg service uninstall` first to revert to Tier A).
 
 **Acceptance Criteria:**
 - [ ] `pgserve install` on a fresh host creates `$XDG_RUNTIME_DIR/pgserve/` with mode 0700.
@@ -434,13 +434,13 @@ test -f docs/security/cosign-trust.md
 
 - **paired-with** `automagik-dev/genie#pgserve-singleton-no-proxy` — consumer-side wiring; ships in lockstep.
 - **paired-with** `automagik/omni#pgserve-singleton-no-proxy` — consumer-side wiring; ships in lockstep.
-- **paired-with** `pgserve#autopg-distribution-cutover` — v2.4 cohort sibling. Owns the rename → `autopg`, CDN distribution, and the **Tier B `autopg service install` G11.6** that this wish defers to. Both wishes share the `~/.autopg/admin.json` schema and the hard MIGRATE contract that prevents pm2 + systemd-user double-supervision.
+- **paired-with** `pgserve#autopg-distribution-cutover` — v2.4 cohort sibling. Owns the rename → `autopg`, CDN distribution, and the **Tier B `autopg service install` G20** that this wish defers to. Both wishes share the `~/.autopg/admin.json` schema and the hard MIGRATE contract that prevents pm2 + systemd-user double-supervision.
 - **paired-with** `pgserve#canonical-pgserve-pm2-supervision` — v2.4 cohort sibling. Specifies cross-repo pm2 reuse (genie / omni install reuse the pgserve pm2 ecosystem). Tier A only.
 - **builds-on** `pgserve-canonical-cutover` (genie merged) — consumer-only foundation.
 - **builds-on** `pgserve-host-signed-identity` (genie merged, pgserve pending) — host_signed Tier 1 stays; cosign Tier 2 layered on top.
 - **builds-on** `update-unify-stages` (all merged) — pre-flight + decideVerify + diagnostics inherited.
 - **builds-on** `genie-supply-chain-signing` — reuses `--unsafe-unverified <INCIDENT_ID>` typed-ack.
-- **blocks** `autopg-service-install-system` (parked) — that wish extends G11.6's `--user` mode to `--system` mode; cannot start until v2.4 ships.
+- **blocks** `autopg-service-install-system` (parked) — that wish extends G20's `--user` mode to `--system` mode; cannot start until v2.4 ships.
 
 ## QA Criteria
 
@@ -471,7 +471,7 @@ test -f docs/security/cosign-trust.md
 | Old socket dir archives grow unboundedly | Low | Document cleanup recipe. Future `pgserve gc --legacy-archives`. |
 | Some operators rely on TCP 8432 in scripts | Medium | TCP 5432 is canonical; 8432 dies. CHANGELOG warns explicitly. |
 | `--skip-sigstore` becomes default in CI by accident | Low | Refuses unless `--offline-cosign-key` pretrusted; emits warning; audit-log entry. |
-| **Tier A pm2 + Tier B systemd-user double-supervision** (operator runs both `pgserve install` and `autopg service install`) | High | `autopg service install` (cutover G11.6) MUST `pm2 delete autopg-server` BEFORE writing the unit; `pgserve install` refuses if `admin.json.supervisor == "systemd-user"` until operator runs `autopg service uninstall` first. Group 1 acceptance criterion validates both directions. |
+| **Tier A pm2 + Tier B systemd-user double-supervision** (operator runs both `pgserve install` and `autopg service install`) | High | `autopg service install` (cutover G20) MUST `pm2 delete autopg-server` BEFORE writing the unit; `pgserve install` refuses if `admin.json.supervisor == "systemd-user"` until operator runs `autopg service uninstall` first. Group 1 acceptance criterion validates both directions. |
 | `~/.autopg/admin.json` corruption leaves doctor unable to identify supervisor | Low | doctor `--fix` (Cat 1) rewrites admin.json from observed pm2/systemd state; G3 acceptance criterion covers the missing-pm2-entry inconsistency case. |
 | Operator on Tier B systemd-user runs `pgserve update`, expecting pm2 restart | Medium | `pgserve update` (G6) reads `admin.json.supervisor` and dispatches the matching restart primitive (`pm2 restart` / `systemctl --user restart` / `launchctl kickstart`). G6 acceptance criterion adds an explicit Tier-B-restart test. |
 

--- a/bin/postgres-server.js
+++ b/bin/postgres-server.js
@@ -12,6 +12,7 @@ import path from 'path';
 import os from 'os';
 import { startMultiTenantServer } from '../src/index.js';
 import { startClusterServer } from '../src/cluster.js';
+import { PostgresManager } from '../src/postgres.js';
 import { loadEffectiveConfig as loadAutopgConfig } from '../src/settings-loader.cjs';
 import {
   PgserveDaemon,
@@ -27,6 +28,8 @@ import {
 } from '../src/control-db.js';
 import { mintToken } from '../src/tokens.js';
 import { audit, AUDIT_EVENTS } from '../src/audit.js';
+import { resolveSocketDir, ensureSocketDir } from '../src/lib/socket-dir.js';
+import { createLogger } from '../src/logger.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -47,6 +50,163 @@ const args = process.argv.slice(2);
 
 if (args[0] === 'daemon') {
   await runDaemonSubcommand(args.slice(1));
+}
+
+if (args[0] === 'postmaster') {
+  await runPostmasterSubcommand(args.slice(1));
+}
+
+/**
+ * `pgserve postmaster` — supervises an embedded PostgreSQL postmaster
+ * directly (no router, no bun proxy, no daemon control socket).
+ *
+ * pgserve singleton (v2.4) — `pgserve-singleton-no-proxy` wish, Group 1.
+ *
+ * The postmaster listens on the canonical Unix socket at
+ * `<socketDir>/.s.PGSQL.<port>` AND TCP `<port>` (via postgres' default
+ * `listen_addresses = 'localhost'`). Operators connect with either:
+ *
+ *     psql -h $XDG_RUNTIME_DIR/pgserve         # Unix socket (no -p)
+ *     psql -h 127.0.0.1 -p 5432                # canonical TCP
+ *
+ * This is the entry point pm2 invokes for the `autopg-server` process. The
+ * legacy router/foreground mode (`pgserve [options]` without a subcommand)
+ * is unchanged and will be removed in Group 2 once the bun proxy is gone.
+ */
+async function runPostmasterSubcommand(postmasterArgs) {
+  const opts = parsePostmasterArgs(postmasterArgs);
+  const logger = createLogger({ level: opts.logLevel });
+
+  // Resolve and ensure the socket directory before postgres tries to bind.
+  // Surfaces "not writable" / "wrong owner" failures here with a clear
+  // diagnostic instead of leaving the operator to chase a libpq error.
+  let socketDir;
+  try {
+    socketDir = ensureSocketDir(opts.socketDir);
+  } catch (err) {
+    console.error(err.message);
+    process.exit(1);
+  }
+
+  const manager = new PostgresManager({
+    dataDir: opts.dataDir,
+    port: opts.port,
+    socketDir,
+    useRam: opts.useRam,
+    enablePgvector: opts.enablePgvector,
+    logger: logger.child({ component: 'postgres' }),
+  });
+
+  // Surface unexpected backend death so pm2 can restart us cleanly. Mirrors
+  // the daemon-mode contract from PR #49 (issue #45).
+  manager.on('backendDiedUnexpectedly', ({ code }) => {
+    logger.error(
+      { code },
+      'pgserve postmaster: postgres backend exited unexpectedly; exiting so the supervisor can restart',
+    );
+    process.exit(1);
+  });
+
+  try {
+    await manager.start();
+  } catch (err) {
+    logger.error({ err: err.message }, 'pgserve postmaster: failed to start');
+    process.exit(1);
+  }
+
+  logger.info(
+    { port: opts.port, socketDir, dataDir: opts.dataDir },
+    'pgserve postmaster: ready (Unix socket + TCP)',
+  );
+
+  const shutdown = async (signal) => {
+    logger.info({ signal }, 'pgserve postmaster: stopping');
+    try {
+      await manager.stop();
+    } catch (err) {
+      logger.warn({ err: err.message }, 'pgserve postmaster: error during shutdown');
+    }
+    process.exit(0);
+  };
+  process.on('SIGINT', () => shutdown('SIGINT'));
+  process.on('SIGTERM', () => shutdown('SIGTERM'));
+
+  // Park forever; the supervisor decides when to stop us.
+  await new Promise(() => {});
+}
+
+function parsePostmasterArgs(postmasterArgs) {
+  const opts = {
+    port: 5432,
+    dataDir: null,
+    socketDir: undefined, // resolved via resolveSocketDir() if unset
+    logLevel: 'info',
+    useRam: false,
+    enablePgvector: false,
+  };
+  for (let i = 0; i < postmasterArgs.length; i++) {
+    const arg = postmasterArgs[i];
+    switch (arg) {
+      case '--port':
+      case '-p': {
+        const raw = postmasterArgs[++i];
+        const parsed = Number.parseInt(raw, 10);
+        if (!Number.isInteger(parsed) || parsed < 1 || parsed > 65535) {
+          console.error(`pgserve postmaster: invalid --port "${raw}"`);
+          process.exit(1);
+        }
+        opts.port = parsed;
+        break;
+      }
+      case '--data':
+      case '-d':
+        opts.dataDir = postmasterArgs[++i];
+        break;
+      case '--socket-dir':
+      case '-k':
+        opts.socketDir = postmasterArgs[++i];
+        break;
+      case '--log':
+      case '-l':
+        opts.logLevel = postmasterArgs[++i];
+        break;
+      case '--ram':
+        opts.useRam = true;
+        break;
+      case '--pgvector':
+        opts.enablePgvector = true;
+        break;
+      case '--help':
+        console.log(`
+pgserve postmaster — direct embedded PostgreSQL supervision (singleton v2.4)
+
+USAGE:
+  pgserve postmaster [options]
+
+OPTIONS:
+  --port, -p <n>        TCP port (default: 5432)
+  --data, -d <path>     Data directory (required for persistence)
+  --socket-dir, -k <p>  Unix socket dir (default: $XDG_RUNTIME_DIR/pgserve)
+  --log, -l <level>     Log level: error|warn|info|debug (default: info)
+  --ram                 Use /dev/shm (Linux only)
+  --pgvector            Auto-enable pgvector on new databases
+  --help                Show this help
+
+The postmaster binds <socket-dir>/.s.PGSQL.<port> and TCP <port> on
+localhost. This entry point is invoked by pm2/systemd-user/launchd; it has
+no router, no bun proxy, no daemon control socket.
+`);
+        process.exit(0);
+        // falls through (unreachable)
+      default:
+        if (arg.startsWith('-')) {
+          console.error(`pgserve postmaster: unknown option "${arg}"`);
+          process.exit(1);
+        }
+    }
+  }
+  if (opts.socketDir === undefined) opts.socketDir = resolveSocketDir();
+  return opts;
 }
 
 async function runDaemonSubcommand(daemonArgs) {

--- a/src/cli-install.cjs
+++ b/src/cli-install.cjs
@@ -27,8 +27,37 @@ const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
 
-const PM2_PROCESS_NAME = 'pgserve';
-const DEFAULT_PORT = 8432;
+// pgserve singleton (v2.4): the cohort-shared admin-json + socket-dir
+// helpers live in `src/lib/*.js` as ESM modules (project convention: new
+// modules ship as .js / ESM). cli-install.cjs runs under node — which
+// cannot synchronously `require()` ESM — so we cache the dynamic-import
+// promise once at module load and await it from async install paths.
+const _adminJsonModuleP = import('./lib/admin-json.js');
+const _socketDirModuleP = import('./lib/socket-dir.js');
+
+async function loadCohortModules() {
+  const [adminJson, socketDirMod] = await Promise.all([_adminJsonModuleP, _socketDirModuleP]);
+  return { adminJson, socketDirMod };
+}
+
+// pgserve singleton (v2.4) — `pgserve-singleton-no-proxy` wish, Group 1.
+//
+// The pm2 entry name moves from `pgserve` to `autopg-server` so the canonical
+// two-process layout matches the cohort design (`autopg-server` + `autopg-ui`).
+// Tier B operators install a systemd-user unit that ALSO claims the
+// `autopg-server` lifecycle role — `~/.autopg/admin.json` records which
+// supervisor owns the host and `pgserve install` refuses to register pm2 over
+// an existing Tier B record.
+//
+// Default postgres port moves from 8432 (the old bun-proxy listener) to 5432
+// (the postgres standard, since the postmaster now binds TCP directly).
+const PM2_PROCESS_NAME = 'autopg-server';
+// Legacy entry name (pre-v2.4). Self-healing migration in Group 6 will
+// `pm2 delete pgserve` after registering `autopg-server`; we surface the
+// constant here so cleanup tooling and tests can reference it without
+// hardcoding strings.
+const LEGACY_PM2_PROCESS_NAME = 'pgserve';
+const DEFAULT_PORT = 5432;
 
 // Console UI is auto-supervised under pm2 alongside the daemon since v2.2.3.
 // The bundled SPA (console/dist/) is served on this port; operator-facing
@@ -200,7 +229,7 @@ function getEffectiveSupervision() {
   }
 }
 
-function buildPm2StartArgs({ scriptPath, port, dataDir }) {
+function buildPm2StartArgs({ scriptPath, port, dataDir, socketDir }) {
   const logs = {
     out: path.join(getLogsDir(), `${PM2_PROCESS_NAME}-out.log`),
     error: path.join(getLogsDir(), `${PM2_PROCESS_NAME}-error.log`),
@@ -215,19 +244,11 @@ function buildPm2StartArgs({ scriptPath, port, dataDir }) {
     'none',
     '--max-restarts',
     String(supervision.maxRestarts),
-    // NOTE: pm2 ≥ 6.0 dropped `--min-uptime` from the CLI surface — passing
-    // it produces `error: unknown option --min-uptime` and aborts the
-    // install. The flag still works inside an ecosystem file, but per the
-    // canonical-pm2-supervision wish we keep `pgserve install` as a pure
-    // CLI flow (no extra files for operators to manage). The trade-off is
-    // that `--max-restarts` now counts every restart (rapid or not) rather
-    // than only sub-`min_uptime` ones; the budget of 50 above is sized
-    // accordingly.
+    // pm2 ≥ 6.0 dropped `--min-uptime` from the CLI surface — passing it
+    // aborts the install. Restart budget (50) is sized to absorb a few
+    // long-uptime crashes without burning through.
     '--restart-delay',
     String(supervision.restartDelayMs),
-    // Exponential backoff between successive failures: starts at 100ms,
-    // doubles each crash, ramps to ~60s. Avoids hammering pm2 + the host
-    // when the underlying issue is persistent.
     '--exp-backoff-restart-delay',
     String(supervision.expBackoffRestartDelayMs),
     '--max-memory-restart',
@@ -241,28 +262,19 @@ function buildPm2StartArgs({ scriptPath, port, dataDir }) {
     '--error',
     logs.error,
     '--',
-    // Foreground multi-tenant mode (`pgserve [options]`), NOT daemon mode.
-    //
-    // Daemon mode binds a unix control socket and requires libpq peers to
-    // authenticate via a fingerprint+token handshake (`pgserve daemon
-    // issue-token`). Downstream services that connect with a plain
-    // `postgres://` URL (omni, genie, anything that doesn't speak the
-    // fingerprint protocol) cannot reach a daemon-mode listener. We also
-    // observed live: `pgserve install` was passing `--port` to the daemon
-    // parser, which only accepts `--data | --ram | --log | --no-provision
-    // | --listen | --pgvector` — every install attempt crashed with
-    // `Unknown daemon option: --port` and pm2 burned its restart budget.
-    //
-    // Foreground mode (the default `pgserve [options]` invocation in
-    // postgres-server.js) accepts `--port`, auto-provisions databases on
-    // first connect, runs the cluster on multi-core hosts, and binds TCP
-    // on `127.0.0.1:<port>` with no auth dance — exactly what canonical
-    // pgserve consumers expect. Pass the same flags pgserve already
-    // documents in its own `pgserve --help` output.
+    // pgserve singleton (v2.4): pm2 supervises the postmaster directly via
+    // the `pgserve postmaster` subcommand — no router, no bun proxy, no
+    // daemon control socket. Postgres binds the canonical Unix socket
+    // under <socketDir> AND TCP <port> natively. Operators connect via
+    //   psql -h $XDG_RUNTIME_DIR/pgserve     (Unix socket, no -p)
+    //   psql -h 127.0.0.1 -p 5432            (canonical TCP)
+    'postmaster',
     '--port',
     String(port),
     '--data',
     dataDir,
+    '--socket-dir',
+    socketDir,
     '--log',
     'warn',
   ];
@@ -429,12 +441,19 @@ function writeAdminFile({ password, rotated = false }) {
   const hash = hashAdminPassword(password, salt);
   const file = getAdminFilePath();
   const now = new Date().toISOString();
+  // pgserve singleton (v2.4): admin.json is shared with the supervisor
+  // record (`{ supervisor, socketDir, port, installedAt }`) written by
+  // `src/lib/admin-json.js`. Merge with any existing fields so the scrypt
+  // Basic-Auth scheme can never wipe the supervisor metadata (and vice
+  // versa).
+  const existing = readAdminFile() || {};
   const payload = {
+    ...existing,
     scheme: 'scrypt',
     params: SCRYPT_PARAMS,
     salt: salt.toString('base64'),
     hash: hash.toString('base64'),
-    createdAt: rotated ? readAdminFile()?.createdAt ?? now : now,
+    createdAt: rotated ? existing.createdAt ?? now : now,
     rotatedAt: rotated ? now : null,
   };
   ensureConfigDir();
@@ -487,9 +506,14 @@ function verifyAdminPassword(candidate) {
 
 function ensureAdminPassword({ rotate = false } = {}) {
   const existing = readAdminFile();
-  if (existing && !rotate) return null;
+  // pgserve singleton (v2.4): admin.json may exist with only supervisor
+  // fields (`{ supervisor, socketDir, port, installedAt }`) and no scrypt
+  // scheme yet. Treat "no scrypt scheme" as "no password" so the install
+  // path still mints one on first run.
+  const hasScryptScheme = !!(existing && existing.scheme === 'scrypt');
+  if (hasScryptScheme && !rotate) return null;
   const password = generateAdminPassword();
-  writeAdminFile({ password, rotated: !!existing });
+  writeAdminFile({ password, rotated: !!hasScryptScheme });
   return password;
 }
 
@@ -532,13 +556,40 @@ function cmdAuthDispatch(args) {
  * `scriptPath` is the path to `bin/postgres-server.js` resolved by the
  * wrapper before this module is required (avoids re-resolving here).
  */
-function cmdInstall(args, ctx) {
-  if (!pm2IsAvailable()) {
-    fail('pm2 not found in PATH. Install with: bun add -g pm2  (or npm i -g pm2)');
+async function cmdInstall(args, ctx) {
+  const { adminJson, socketDirMod } = await loadCohortModules();
+
+  // pgserve singleton (v2.4): refuse to install if a different supervisor
+  // (Tier B systemd-user / launchd) already owns the host. The cohort
+  // contract guarantees one and only one supervisor records itself in
+  // `~/.autopg/admin.json`. `pgserve install` is the Tier A (pm2) entry —
+  // it asserts that nothing else has already claimed the host before
+  // touching pm2.
+  const noPm2 = args.includes('--no-pm2');
+  const expectedSupervisor = noPm2 ? 'external' : 'pm2';
+  try {
+    adminJson.assertSupervisor(expectedSupervisor, { configDir: getConfigDir() });
+  } catch (err) {
+    fail(err.message);
+  }
+
+  if (!noPm2 && !pm2IsAvailable()) {
+    fail('pm2 not found in PATH. Install with: bun add -g pm2  (or npm i -g pm2). Pass --no-pm2 for CI / Tier B-bound hosts.');
   }
 
   const port = parsePort(args) ?? readConfig()?.port ?? DEFAULT_PORT;
   const dataDir = parseDataDir(args) ?? readConfig()?.dataDir ?? getDataDir();
+
+  // Set up the canonical socket directory before pm2 launches the
+  // postmaster. `ensureSocketDir` enforces mode 0700 and probes writability
+  // so failure surfaces here — not as a libpq bind error a few seconds
+  // into pm2 backoff.
+  const socketDir = parseSocketDir(args) ?? socketDirMod.resolveSocketDir();
+  try {
+    socketDirMod.ensureSocketDir(socketDir);
+  } catch (err) {
+    fail(err.message);
+  }
 
   const noUi = args.includes('--no-ui');
   const withUi = args.includes('--with-ui');
@@ -556,6 +607,22 @@ function cmdInstall(args, ctx) {
   // post-install without restarting postgres.
   if (withUi) {
     cmdInstallUi(ctx, { uiPort, uiHost, refresh: true });
+    return 0;
+  }
+
+  // --no-pm2: skip pm2 register entirely. Used by CI fixture provisioning
+  // (no sudo, no pm2 ambient state) and by Tier B-bound hosts that will
+  // immediately hand off to `autopg service install`. Still record the
+  // supervisor + canonical socket dir + port in admin.json so downstream
+  // tooling (pgserve doctor, omni install, genie install) can discover
+  // where to connect without an active pm2 entry.
+  if (noPm2) {
+    if (!fs.existsSync(dataDir)) fs.mkdirSync(dataDir, { recursive: true, mode: 0o700 });
+    writeConfig({ port, dataDir, registeredAt: readConfig()?.registeredAt ?? new Date().toISOString() });
+    writeSupervisorRecord(adminJson, { supervisor: 'external', socketDir, port });
+    ok(`installed (--no-pm2): supervisor=external, socketDir=${socketDir}, port=${port}`);
+    ok(`url: postgres://localhost:${port}/postgres`);
+    note(`--no-pm2: pm2 register skipped. Start the postmaster manually with \`pgserve postmaster --port ${port} --data ${dataDir} --socket-dir ${socketDir}\` or hand off to systemd-user / launchd.`);
     return 0;
   }
 
@@ -581,6 +648,7 @@ function cmdInstall(args, ctx) {
     // don't tear down the live process. Operators wanting a port change
     // should `uninstall` then `install` (or pass --redeploy).
     writeConfig({ port, dataDir, registeredAt: readConfig()?.registeredAt ?? new Date().toISOString() });
+    writeSupervisorRecord(adminJson, { supervisor: 'pm2', socketDir, port });
     if (!noUi) cmdInstallUi(ctx, { uiPort, uiHost });
     return 0;
   }
@@ -588,14 +656,15 @@ function cmdInstall(args, ctx) {
   ensureLogsDir();
   if (!fs.existsSync(dataDir)) fs.mkdirSync(dataDir, { recursive: true, mode: 0o700 });
 
-  const pm2Args = buildPm2StartArgs({ scriptPath: ctx.scriptPath, port, dataDir });
+  const pm2Args = buildPm2StartArgs({ scriptPath: ctx.scriptPath, port, dataDir, socketDir });
   const result = spawnSync('pm2', pm2Args, { stdio: 'inherit' });
   if (result.status !== 0) {
     fail(`pm2 start failed (exit ${result.status}). Logs: ${getLogsDir()}/${PM2_PROCESS_NAME}-error.log`);
   }
 
   writeConfig({ port, dataDir, registeredAt: new Date().toISOString() });
-  ok(`installed: pm2 process "${PM2_PROCESS_NAME}" on port ${port} (data: ${dataDir})`);
+  writeSupervisorRecord(adminJson, { supervisor: 'pm2', socketDir, port });
+  ok(`installed: pm2 process "${PM2_PROCESS_NAME}" on port ${port} (socket: ${socketDir}, data: ${dataDir})`);
   ok(`url: postgres://localhost:${port}/postgres`);
 
   if (noUi) {
@@ -617,6 +686,31 @@ function cmdInstall(args, ctx) {
     cmdInstallUi(ctx, { uiPort, uiHost, refresh: redeploy });
   }
   return 0;
+}
+
+/**
+ * Persist the supervisor record into `~/.autopg/admin.json`. Wraps
+ * `writeAdminJson` from the cohort-shared module so the install path can
+ * pin its own ISO timestamp + log a friendly diagnostic on the
+ * supervisor-lock refusal.
+ */
+function writeSupervisorRecord(adminJson, { supervisor, socketDir, port }) {
+  try {
+    adminJson.writeAdminJson(
+      {
+        supervisor,
+        socketDir,
+        port,
+        installedAt: new Date().toISOString(),
+      },
+      { configDir: getConfigDir() },
+    );
+  } catch (err) {
+    // The "Tier B already owns this host" error is the contract failure
+    // we surface to operators. Other errors (EACCES, ENOSPC, etc.) just
+    // pass through with their stock message.
+    fail(err.message);
+  }
 }
 
 /**
@@ -744,6 +838,14 @@ function parseDataDir(args) {
   if (i < 0) return null;
   const v = args[i + 1];
   if (!v) fail('--data requires a value');
+  return path.resolve(v);
+}
+
+function parseSocketDir(args) {
+  const i = args.indexOf('--socket-dir');
+  if (i < 0) return null;
+  const v = args[i + 1];
+  if (!v) fail('--socket-dir requires a value');
   return path.resolve(v);
 }
 

--- a/src/lib/admin-json.js
+++ b/src/lib/admin-json.js
@@ -1,0 +1,202 @@
+/**
+ * `~/.autopg/admin.json` reader, atomic writer, and supervisor-assertion.
+ *
+ * Cohort-shared module — co-owned with `canonical-pgserve-pm2-supervision`
+ * Group 1. Schema for the supervisor record:
+ *
+ *     {
+ *       supervisor: "pm2" | "systemd-user" | "launchd" | "external",
+ *       socketDir:  "<absolute path>",
+ *       port:       <integer>,
+ *       installedAt: "<ISO 8601 timestamp>"
+ *     }
+ *
+ * The file is shared with the Basic-Auth scrypt password record used by the
+ * autopg console UI (`scheme`/`salt`/`hash`/...). This module merges with
+ * any pre-existing fields it does not own — `writeAdminJson` is additive,
+ * never destructive — so both tenants coexist on the same file.
+ *
+ * Hard contract — refuses to downgrade supervision authority:
+ *   - If the existing file records `systemd-user` or `launchd`, refuses to
+ *     write `pm2` or `external`. Operators must `autopg service uninstall`
+ *     first to migrate Tier B → Tier A.
+ *   - `assertSupervisor(expected)` throws when the actual supervisor differs
+ *     so callers fail fast with a structured remediation hint.
+ *
+ * Atomic semantics: write to `<file>.tmp.<pid>`, fsync, then
+ * `fs.renameSync` to the target. mode 0600 enforced via `fs.chmodSync`
+ * after write.
+ */
+
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+export const ADMIN_FILE_NAME = 'admin.json';
+export const ADMIN_FILE_MODE = 0o600;
+
+export const SUPERVISOR_VALUES = Object.freeze([
+  'pm2',
+  'systemd-user',
+  'launchd',
+  'external',
+]);
+
+/** Supervisors that own the postmaster lifecycle via an OS service unit. */
+const TIER_B_SUPERVISORS = new Set(['systemd-user', 'launchd']);
+
+/**
+ * Resolve the autopg config directory.
+ *
+ * Honors `AUTOPG_CONFIG_DIR` (current var) first, then `PGSERVE_CONFIG_DIR`
+ * (legacy soft-rename), then `$HOME/.autopg`. Mirrors the precedence in
+ * `src/cli-install.cjs` and `src/settings-loader.cjs`.
+ */
+export function getDefaultConfigDir() {
+  return (
+    process.env.AUTOPG_CONFIG_DIR
+    || process.env.PGSERVE_CONFIG_DIR
+    || path.join(os.homedir(), '.autopg')
+  );
+}
+
+export function getAdminFilePath(configDir = getDefaultConfigDir()) {
+  return path.join(configDir, ADMIN_FILE_NAME);
+}
+
+function ensureConfigDir(configDir) {
+  if (!fs.existsSync(configDir)) {
+    fs.mkdirSync(configDir, { recursive: true, mode: 0o700 });
+  }
+}
+
+/**
+ * Read the admin.json record. Returns the parsed object on success, `null`
+ * when the file is missing or unreadable. Never throws — callers treat
+ * "missing" and "broken" identically.
+ */
+export function readAdminJson({ configDir = getDefaultConfigDir() } = {}) {
+  const file = getAdminFilePath(configDir);
+  let raw;
+  try {
+    raw = fs.readFileSync(file, 'utf8');
+  } catch {
+    return null;
+  }
+  try {
+    const parsed = JSON.parse(raw);
+    return (parsed && typeof parsed === 'object') ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+function isPlainObject(v) {
+  return v !== null && typeof v === 'object' && !Array.isArray(v);
+}
+
+function validateSupervisorRecord(record) {
+  if (!isPlainObject(record)) {
+    throw new TypeError('admin-json: record must be an object');
+  }
+  if (!SUPERVISOR_VALUES.includes(record.supervisor)) {
+    throw new TypeError(
+      `admin-json: invalid supervisor "${record.supervisor}". `
+      + `Expected one of: ${SUPERVISOR_VALUES.join(', ')}`,
+    );
+  }
+  if (typeof record.socketDir !== 'string' || record.socketDir.length === 0) {
+    throw new TypeError('admin-json: socketDir must be a non-empty string');
+  }
+  if (!Number.isInteger(record.port) || record.port < 1 || record.port > 65535) {
+    throw new TypeError(`admin-json: port must be an integer in [1, 65535]; got ${record.port}`);
+  }
+  if (typeof record.installedAt !== 'string' || record.installedAt.length === 0) {
+    throw new TypeError('admin-json: installedAt must be a non-empty ISO 8601 string');
+  }
+}
+
+/**
+ * Atomic merge-write of the supervisor record.
+ *
+ * Reads any existing admin.json, layers the supplied supervisor fields on
+ * top (preserving unrelated fields like the scrypt Basic-Auth scheme), and
+ * writes the result via tmp+rename with mode 0600.
+ *
+ * Refuses with a structured error when the existing record names a Tier B
+ * supervisor (`systemd-user` / `launchd`) and the incoming record would
+ * downgrade authority. Use `autopg service uninstall` to migrate Tier B →
+ * Tier A explicitly.
+ */
+export function writeAdminJson(record, { configDir = getDefaultConfigDir() } = {}) {
+  validateSupervisorRecord(record);
+
+  ensureConfigDir(configDir);
+  const file = getAdminFilePath(configDir);
+  const existing = readAdminJson({ configDir }) ?? {};
+
+  if (
+    TIER_B_SUPERVISORS.has(existing.supervisor)
+    && existing.supervisor !== record.supervisor
+  ) {
+    const err = new Error(
+      `pgserve: refusing to overwrite admin.json — existing supervisor is `
+      + `"${existing.supervisor}" (Tier B); cannot register "${record.supervisor}". `
+      + `Run \`autopg service uninstall\` first to migrate to Tier A.`,
+    );
+    err.code = 'EADMINSUPERVISORLOCK';
+    err.existingSupervisor = existing.supervisor;
+    err.requestedSupervisor = record.supervisor;
+    throw err;
+  }
+
+  const merged = {
+    ...existing,
+    supervisor: record.supervisor,
+    socketDir: record.socketDir,
+    port: record.port,
+    installedAt: record.installedAt,
+  };
+
+  const tmp = `${file}.tmp.${process.pid}`;
+  const json = `${JSON.stringify(merged, null, 2)}\n`;
+  fs.writeFileSync(tmp, json, { mode: ADMIN_FILE_MODE });
+  fs.renameSync(tmp, file);
+  fs.chmodSync(file, ADMIN_FILE_MODE);
+
+  return merged;
+}
+
+/**
+ * Throw when the on-disk supervisor differs from `expected`. Returns the
+ * record on match. Used by callers that must refuse to operate when the
+ * host has already been claimed by a different supervisor — e.g.
+ * `pgserve install` (Tier A) refusing to run on a Tier B host.
+ *
+ * Missing file is NOT an error here — there's nothing to assert against.
+ * The caller should treat "no record" as "free to install".
+ */
+export function assertSupervisor(expected, { configDir = getDefaultConfigDir() } = {}) {
+  if (!SUPERVISOR_VALUES.includes(expected)) {
+    throw new TypeError(
+      `admin-json: invalid expected supervisor "${expected}". `
+      + `Expected one of: ${SUPERVISOR_VALUES.join(', ')}`,
+    );
+  }
+  const existing = readAdminJson({ configDir });
+  if (!existing || !existing.supervisor) return null;
+  if (existing.supervisor !== expected) {
+    const err = new Error(
+      `pgserve: admin.json supervisor mismatch — expected "${expected}", `
+      + `found "${existing.supervisor}". `
+      + `${TIER_B_SUPERVISORS.has(existing.supervisor)
+          ? 'Run `autopg service uninstall` to migrate to Tier A.'
+          : 'Run `pgserve uninstall` to clear the existing record.'}`,
+    );
+    err.code = 'EADMINSUPERVISORMISMATCH';
+    err.expected = expected;
+    err.actual = existing.supervisor;
+    throw err;
+  }
+  return existing;
+}

--- a/src/lib/socket-dir.js
+++ b/src/lib/socket-dir.js
@@ -1,0 +1,69 @@
+/**
+ * Canonical pgserve socket-dir resolver.
+ *
+ * pgserve singleton (v2.4) — `pgserve-singleton-no-proxy` wish, Group 1.
+ *
+ * Postgres backend listens on a Unix socket inside this directory plus TCP
+ * 5432. The directory is also where `pgserve` records its `.s.PGSQL.<port>`
+ * socket file so off-the-shelf libpq clients connecting via
+ * `psql -h <socketDir>` (no `-p`) succeed against the systemd / freedesktop
+ * convention path. CI runners and minimal containers without
+ * `$XDG_RUNTIME_DIR` get `/tmp/pgserve` as the documented fallback.
+ */
+
+import fs from 'fs';
+import path from 'path';
+
+export const SOCKET_DIR_NAME = 'pgserve';
+export const SOCKET_DIR_MODE = 0o700;
+
+/**
+ * Resolve the canonical socket directory.
+ *
+ * Preferred: `$XDG_RUNTIME_DIR/pgserve` (systemd / freedesktop convention).
+ * Fallback: `/tmp/pgserve` (CI runners and minimal containers without XDG).
+ *
+ * Pure function — does not touch the filesystem. Use `ensureSocketDir()`
+ * to create the directory with the correct permissions.
+ */
+export function resolveSocketDir() {
+  const xdg = process.env.XDG_RUNTIME_DIR;
+  const base = xdg && xdg.length > 0 ? xdg : '/tmp';
+  return path.join(base, SOCKET_DIR_NAME);
+}
+
+/**
+ * Ensure the socket directory exists with mode 0700 and is writable.
+ *
+ * Returns the resolved path. Throws if the directory exists but is not a
+ * directory, or if creation fails for any reason other than EEXIST.
+ *
+ * The mode is enforced via fs.chmodSync after creation — `mkdirSync(mode)`
+ * is honored only when the directory does not already exist.
+ */
+export function ensureSocketDir(dir = resolveSocketDir()) {
+  fs.mkdirSync(dir, { recursive: true, mode: SOCKET_DIR_MODE });
+  fs.chmodSync(dir, SOCKET_DIR_MODE);
+
+  const stat = fs.statSync(dir);
+  if (!stat.isDirectory()) {
+    throw new Error(
+      `pgserve: socket dir path exists but is not a directory: ${dir}`,
+    );
+  }
+
+  // Validate writability by touching a sentinel file. Avoids surfacing the
+  // real-world failure ("postgres can't bind socket") at the postmaster
+  // boot step where the diagnostic is much harder to trace.
+  const probe = path.join(dir, `.writable-${process.pid}-${Date.now()}`);
+  try {
+    fs.writeFileSync(probe, '');
+    fs.unlinkSync(probe);
+  } catch (err) {
+    throw new Error(
+      `pgserve: socket dir not writable (${dir}): ${err.message}`,
+    );
+  }
+
+  return dir;
+}

--- a/src/postgres.js
+++ b/src/postgres.js
@@ -548,6 +548,15 @@ export class PostgresManager extends EventEmitter {
     this.binaries = null;
     this.creatingDatabases = new Map(); // Track in-progress creations
     this.socketDir = null; // Unix socket directory for faster local connections
+    // pgserve singleton (v2.4): callers that own the socket directory (e.g.
+    // `pgserve postmaster` invoked under pm2 or a systemd-user unit) pass an
+    // explicit, externally-managed path so libpq peers connecting via
+    // `psql -h $XDG_RUNTIME_DIR/pgserve` reach a stable, well-known socket.
+    // When unset we fall back to the legacy per-pid `os.tmpdir()` path so
+    // foreground / daemon / cluster modes keep working unchanged.
+    this.explicitSocketDir = typeof options.socketDir === 'string' && options.socketDir.length > 0
+      ? options.socketDir
+      : null;
     this.adminPool = null; // Connection pool for database admin operations
     this.useRam = options.useRam || false; // Use /dev/shm for true RAM storage (Linux only)
     this.isTrueRam = false; // Tracks if we're actually using RAM storage
@@ -634,9 +643,24 @@ export class PostgresManager extends EventEmitter {
 
     // Create Unix socket directory (Linux/macOS only, Windows uses TCP)
     if (os.platform() !== 'win32') {
-      this.socketDir = path.join(os.tmpdir(), `pgserve-sock-${process.pid}-${Date.now()}`);
-      if (!fs.existsSync(this.socketDir)) {
-        fs.mkdirSync(this.socketDir, { recursive: true, mode: 0o700 });
+      if (this.explicitSocketDir) {
+        // pgserve singleton (v2.4): operator-supplied socket dir is created
+        // and chmoded by the install path (`pgserve install`); we only
+        // refuse to start when it doesn't exist so the operator's intent
+        // surfaces cleanly instead of postgres bailing on bind() with a
+        // cryptic libpq error.
+        if (!fs.existsSync(this.explicitSocketDir)) {
+          throw new Error(
+            `pgserve: socketDir does not exist: ${this.explicitSocketDir}. `
+            + `Run \`pgserve install\` to create it (or pass --socket-dir <existing-dir>).`,
+          );
+        }
+        this.socketDir = this.explicitSocketDir;
+      } else {
+        this.socketDir = path.join(os.tmpdir(), `pgserve-sock-${process.pid}-${Date.now()}`);
+        if (!fs.existsSync(this.socketDir)) {
+          fs.mkdirSync(this.socketDir, { recursive: true, mode: 0o700 });
+        }
       }
     }
 
@@ -1574,8 +1598,16 @@ export class PostgresManager extends EventEmitter {
         }
       }
 
-      // Clean up socket directory
-      if (this.socketDir) {
+      // Clean up socket directory.
+      // pgserve singleton (v2.4): when the caller supplied an explicit
+      // socket dir (operator-owned canonical path under
+      // `$XDG_RUNTIME_DIR/pgserve` or `/tmp/pgserve`), the install path
+      // owns the directory's lifecycle — postgres unlinks its own
+      // `.s.PGSQL.<port>` + `.lock` files on graceful shutdown, and
+      // tearing the directory down here would race with operator tooling
+      // (pm2 restarts, doctor --fix, etc.). Only sweep the legacy
+      // per-pid `os.tmpdir()/pgserve-sock-*` form we generated ourselves.
+      if (this.socketDir && !this.explicitSocketDir) {
         try {
           fs.rmSync(this.socketDir, { recursive: true, force: true });
           this.logger.debug({ socketDir: this.socketDir }, 'Cleaned up socket directory');

--- a/tests/cli-install.test.js
+++ b/tests/cli-install.test.js
@@ -49,7 +49,7 @@ if (args[0] === 'jlist') {
   const sentinel = ${JSON.stringify(path.join(dir, 'registered'))};
   if (fs.existsSync(sentinel)) {
     process.stdout.write(JSON.stringify([{
-      name: 'pgserve',
+      name: 'autopg-server',
       pid: 12345,
       pm2_env: { status: 'online', pm_uptime: Date.now() - 1000, restart_time: 0 }
     }]) + '\\n');
@@ -110,25 +110,22 @@ describe('pgserve install', () => {
     const result = runCli(['install']);
     expect(result.status).toBe(0);
     expect(result.stdout).toContain('installed');
-    expect(result.stdout).toContain('postgres://localhost:8432');
+    expect(result.stdout).toContain('postgres://localhost:5432');
 
     const config = JSON.parse(fs.readFileSync(path.join(tmpHome, 'config.json'), 'utf8'));
-    expect(config.port).toBe(8432);
+    expect(config.port).toBe(5432);
     expect(config.dataDir).toBe(path.join(tmpHome, 'data'));
     expect(config.registeredAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
 
     const calls = readCallLog(stubBin.calls);
-    const startCall = calls.find((c) => c[0] === 'start');
+    const startCall = calls.find((c) => c[0] === 'start' && c.includes('autopg-server'));
     expect(startCall).toBeDefined();
     expect(startCall).toContain('--name');
-    expect(startCall).toContain('pgserve');
+    expect(startCall).toContain('autopg-server');
     expect(startCall).toContain('--max-restarts');
     expect(startCall).toContain('50');
-    // pm2 ≥ 6.0 dropped `--min-uptime` from the CLI surface — it now lives
-    // only inside ecosystem files. Passing it on the command line aborts
-    // `pm2 start` with `error: unknown option --min-uptime`. Lock that out:
-    // `pgserve install` must NOT pass `--min-uptime` so it stays compatible
-    // across pm2 5.x → 6.x. See cli-install.cjs:HARDENED_DEFAULTS.
+    // pm2 ≥ 6.0 dropped `--min-uptime` from the CLI surface; install must
+    // NOT pass it (compat across pm2 5.x → 6.x).
     expect(startCall).not.toContain('--min-uptime');
     expect(startCall).toContain('--exp-backoff-restart-delay');
     expect(startCall).toContain('--max-memory-restart');
@@ -138,19 +135,17 @@ describe('pgserve install', () => {
     expect(startCall).toContain('--interpreter');
     expect(startCall).toContain('none');
 
-    // pgserve install must launch the foreground multi-tenant server, NOT
-    // the daemon. Daemon mode rejects `--port` (it only accepts --data,
-    // --ram, --log, --no-provision, --listen, --pgvector) and its TCP
-    // listeners require fingerprint+token auth which downstream services
-    // (omni, genie) don't speak. Foreground mode binds plain TCP on
-    // 127.0.0.1:<port> with auto-provisioning. Lock that out:
+    // pgserve singleton (v2.4): pm2 supervises the postmaster directly via
+    // the `pgserve postmaster` subcommand — no router, no bun proxy, no
+    // daemon mode. Lock that out: the script-arg handover (after `--`)
+    // starts with `postmaster` and includes the canonical socket dir.
     expect(startCall).not.toContain('daemon');
-    // The script-arg handover (after `--`) must include `--port` so the
-    // foreground parser binds the right TCP port.
     const dashDashIdx = startCall.indexOf('--');
     const scriptArgs = startCall.slice(dashDashIdx + 1);
+    expect(scriptArgs[0]).toBe('postmaster');
     expect(scriptArgs).toContain('--port');
     expect(scriptArgs).toContain('--data');
+    expect(scriptArgs).toContain('--socket-dir');
     expect(scriptArgs).toContain('--log');
     expect(scriptArgs).not.toContain('daemon');
   });
@@ -173,17 +168,17 @@ describe('pgserve install', () => {
     expect(startCount2).toBe(1); // no second start
   });
 
-  test('autopg install registers BOTH pgserve and autopg-ui by default', () => {
+  test('autopg install registers BOTH autopg-server and autopg-ui by default', () => {
     runCli(['install']);
     const calls = readCallLog(stubBin.calls);
     const starts = calls.filter((c) => c[0] === 'start');
-    // One start each for pgserve + autopg-ui
+    // One start each for autopg-server (the postmaster) + autopg-ui.
     expect(starts.length).toBe(2);
     const names = starts.map((c) => {
       const idx = c.indexOf('--name');
       return idx >= 0 ? c[idx + 1] : null;
     });
-    expect(names).toContain('pgserve');
+    expect(names).toContain('autopg-server');
     expect(names).toContain('autopg-ui');
   });
 
@@ -194,7 +189,7 @@ describe('pgserve install', () => {
     const starts = calls.filter((c) => c[0] === 'start');
     expect(starts.length).toBe(1);
     const idx = starts[0].indexOf('--name');
-    expect(starts[0][idx + 1]).toBe('pgserve');
+    expect(starts[0][idx + 1]).toBe('autopg-server');
     // The CLI should advertise the opt-out path on stderr or stdout.
     expect(result.stdout + result.stderr).toContain('skipping console install');
   });
@@ -215,13 +210,13 @@ describe('pgserve install', () => {
     expect(scriptArgs[portIdx + 1]).toBe('8500');
   });
 
-  test('autopg uninstall tears down both pgserve and autopg-ui', () => {
+  test('autopg uninstall tears down both autopg-server and autopg-ui', () => {
     runCli(['install']);
     runCli(['uninstall']);
     const calls = readCallLog(stubBin.calls);
     const deletes = calls.filter((c) => c[0] === 'delete');
     const deletedNames = deletes.map((c) => c[1]);
-    expect(deletedNames).toContain('pgserve');
+    expect(deletedNames).toContain('autopg-server');
     expect(deletedNames).toContain('autopg-ui');
   });
 
@@ -251,12 +246,15 @@ describe('pgserve install', () => {
   });
 
   test('fails clearly when pm2 is missing', () => {
-    // Build a sanitized PATH that has node (so spawnSync can resolve the
-    // interpreter) but explicitly NO directory containing pm2. Skipping
-    // /usr/bin etc. would make the test brittle on different hosts.
+    // Build a sanitized PATH that has NO pm2 anywhere — we want pm2 to be
+    // genuinely missing for this scenario. Invoke the wrapper through the
+    // current runtime via its absolute path so we never need to put a
+    // node/bun dir back on PATH (under bun's test runner, `process.execPath`
+    // resolves to `/home/.../.bun/bin/bun` whose dir typically also contains
+    // pm2 — adding it back to PATH leaks pm2 into the spawned process and
+    // masks the failure).
     fs.rmSync(stubBin.dir, { recursive: true, force: true });
     stubBin = makeStubPm2('missing');
-    const nodeDir = path.dirname(process.execPath);
     const sanitizedPath = (process.env.PATH || '')
       .split(':')
       .filter((p) => {
@@ -266,9 +264,9 @@ describe('pgserve install', () => {
           return true;
         }
       })
-      .concat([nodeDir, stubBin.dir])
+      .concat([stubBin.dir])
       .join(':');
-    const result = spawnSync('node', [BIN, 'install'], {
+    const result = spawnSync(process.execPath, [BIN, 'install'], {
       encoding: 'utf8',
       env: { ...process.env, PGSERVE_CONFIG_DIR: tmpHome, PATH: sanitizedPath },
     });
@@ -282,7 +280,7 @@ describe('pgserve url / port', () => {
     runCli(['install']);
     const result = runCli(['url']);
     expect(result.status).toBe(0);
-    expect(result.stdout.trim()).toBe('postgres://localhost:8432/postgres');
+    expect(result.stdout.trim()).toBe('postgres://localhost:5432/postgres');
   });
 
   test('port after install prints the registered port', () => {
@@ -290,6 +288,13 @@ describe('pgserve url / port', () => {
     const result = runCli(['port']);
     expect(result.status).toBe(0);
     expect(result.stdout.trim()).toBe('8442');
+  });
+
+  test('port after default install prints 5432 (canonical)', () => {
+    runCli(['install']);
+    const result = runCli(['port']);
+    expect(result.status).toBe(0);
+    expect(result.stdout.trim()).toBe('5432');
   });
 
   test('url before install fails with helpful message', () => {
@@ -313,7 +318,7 @@ describe('pgserve status', () => {
     expect(result.status).toBe(0);
     const out = JSON.parse(result.stdout);
     expect(out.installed).toBe(true);
-    expect(out.name).toBe('pgserve');
+    expect(out.name).toBe('autopg-server');
     expect(out.status).toBe('online');
     expect(out.port).toBe(8482);
     expect(out.url).toBe('postgres://localhost:8482/postgres');
@@ -324,8 +329,8 @@ describe('pgserve status', () => {
     const result = runCli(['status']);
     expect(result.status).toBe(0);
     expect(result.stdout).toContain('port');
-    expect(result.stdout).toContain('8432');
-    expect(result.stdout).toContain('postgres://localhost:8432/postgres');
+    expect(result.stdout).toContain('5432');
+    expect(result.stdout).toContain('postgres://localhost:5432/postgres');
   });
 });
 
@@ -339,7 +344,7 @@ describe('pgserve uninstall', () => {
     expect(result.stdout).toContain('uninstalled');
 
     const calls = readCallLog(stubBin.calls);
-    expect(calls.find((c) => c[0] === 'delete' && c[1] === 'pgserve')).toBeDefined();
+    expect(calls.find((c) => c[0] === 'delete' && c[1] === 'autopg-server')).toBeDefined();
 
     // Config preserved so a re-install reuses port/dataDir.
     expect(fs.existsSync(path.join(tmpHome, 'config.json'))).toBe(true);
@@ -349,6 +354,105 @@ describe('pgserve uninstall', () => {
     const result = runCli(['uninstall']);
     expect(result.status).toBe(0);
     expect(result.stdout).toContain('not registered');
+  });
+});
+
+describe('pgserve singleton (v2.4) — socket dir + admin.json supervisor record', () => {
+  // Use a unique XDG_RUNTIME_DIR per test so we don't pollute the host's
+  // canonical socket dir. ensureSocketDir() probes writability on the
+  // resolved path and refuses on EACCES — the temp path keeps tests
+  // hermetic across CI / dev laptops.
+  let tmpXdg;
+  beforeEach(() => {
+    tmpXdg = fs.mkdtempSync(path.join(os.tmpdir(), 'pgserve-xdg-'));
+  });
+  afterEach(() => {
+    if (tmpXdg) fs.rmSync(tmpXdg, { recursive: true, force: true });
+  });
+
+  function runWithXdg(args, env = {}) {
+    return runCli(args, { XDG_RUNTIME_DIR: tmpXdg, ...env });
+  }
+
+  test('install creates the canonical socket dir under $XDG_RUNTIME_DIR with mode 0700', () => {
+    const result = runWithXdg(['install', '--no-ui']);
+    expect(result.status).toBe(0);
+    const socketDir = path.join(tmpXdg, 'pgserve');
+    expect(fs.existsSync(socketDir)).toBe(true);
+    const stat = fs.statSync(socketDir);
+    expect(stat.isDirectory()).toBe(true);
+    expect(stat.mode & 0o777).toBe(0o700);
+  });
+
+  test('install passes --socket-dir to the postmaster pm2 args', () => {
+    runWithXdg(['install', '--no-ui']);
+    const calls = readCallLog(stubBin.calls);
+    const startCall = calls.find((c) => c[0] === 'start' && c.includes('autopg-server'));
+    const dashIdx = startCall.indexOf('--');
+    const scriptArgs = startCall.slice(dashIdx + 1);
+    const sdIdx = scriptArgs.indexOf('--socket-dir');
+    expect(sdIdx).toBeGreaterThan(-1);
+    expect(scriptArgs[sdIdx + 1]).toBe(path.join(tmpXdg, 'pgserve'));
+  });
+
+  test('install writes admin.json with supervisor=pm2 + canonical socketDir + port', () => {
+    runWithXdg(['install', '--no-ui']);
+    const adminFile = path.join(tmpHome, 'admin.json');
+    expect(fs.existsSync(adminFile)).toBe(true);
+    const stat = fs.statSync(adminFile);
+    expect(stat.mode & 0o777).toBe(0o600);
+    const onDisk = JSON.parse(fs.readFileSync(adminFile, 'utf8'));
+    expect(onDisk.supervisor).toBe('pm2');
+    expect(onDisk.socketDir).toBe(path.join(tmpXdg, 'pgserve'));
+    expect(onDisk.port).toBe(5432);
+    expect(onDisk.installedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+
+  test('install --no-pm2 skips pm2 register but still writes admin.json with supervisor=external', () => {
+    const result = runWithXdg(['install', '--no-pm2', '--no-ui']);
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('--no-pm2');
+    expect(result.stdout).toContain('supervisor=external');
+
+    const calls = readCallLog(stubBin.calls);
+    expect(calls.filter((c) => c[0] === 'start')).toEqual([]);
+
+    const adminFile = path.join(tmpHome, 'admin.json');
+    expect(fs.existsSync(adminFile)).toBe(true);
+    const onDisk = JSON.parse(fs.readFileSync(adminFile, 'utf8'));
+    expect(onDisk.supervisor).toBe('external');
+    expect(onDisk.socketDir).toBe(path.join(tmpXdg, 'pgserve'));
+    expect(onDisk.port).toBe(5432);
+  });
+
+  test('install refuses with non-zero when admin.json records supervisor=systemd-user', () => {
+    // Pre-seed the lock file as if `autopg service install` had already run.
+    fs.mkdirSync(tmpHome, { recursive: true });
+    fs.writeFileSync(
+      path.join(tmpHome, 'admin.json'),
+      JSON.stringify({
+        supervisor: 'systemd-user',
+        socketDir: '/run/user/1000/pgserve',
+        port: 5432,
+        installedAt: '2026-05-01T00:00:00.000Z',
+      }),
+      { mode: 0o600 },
+    );
+    const result = runWithXdg(['install', '--no-ui']);
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toMatch(/supervisor mismatch|systemd-user/);
+    expect(result.stderr).toContain('autopg service uninstall');
+  });
+
+  test('install fallback uses /tmp/pgserve when XDG_RUNTIME_DIR is unset', () => {
+    // Clear XDG so resolveSocketDir falls back. The canonical /tmp/pgserve
+    // path may already exist on the host — that's fine: ensureSocketDir
+    // is idempotent and re-chmods to 0700.
+    const result = runCli(['install', '--no-ui'], { XDG_RUNTIME_DIR: '' });
+    expect(result.status).toBe(0);
+    const onDisk = JSON.parse(fs.readFileSync(path.join(tmpHome, 'admin.json'), 'utf8'));
+    expect(onDisk.socketDir).toBe('/tmp/pgserve');
+    expect(fs.statSync('/tmp/pgserve').mode & 0o777).toBe(0o700);
   });
 });
 

--- a/tests/lib/admin-json.test.js
+++ b/tests/lib/admin-json.test.js
@@ -1,0 +1,217 @@
+/**
+ * Tests for `src/lib/admin-json.js` — supervisor record reader, atomic
+ * merge-writer, and `assertSupervisor` helper.
+ *
+ * Cohort foundation for `pgserve-singleton-no-proxy` Group 1 +
+ * `canonical-pgserve-pm2-supervision` Group 1.
+ */
+
+import { test, expect, beforeEach, afterEach, describe } from 'bun:test';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import {
+  ADMIN_FILE_MODE,
+  ADMIN_FILE_NAME,
+  SUPERVISOR_VALUES,
+  assertSupervisor,
+  getAdminFilePath,
+  getDefaultConfigDir,
+  readAdminJson,
+  writeAdminJson,
+} from '../../src/lib/admin-json.js';
+
+let tmpHome;
+
+beforeEach(() => {
+  tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'admin-json-test-'));
+});
+
+afterEach(() => {
+  if (tmpHome && fs.existsSync(tmpHome)) {
+    fs.rmSync(tmpHome, { recursive: true, force: true });
+  }
+});
+
+function makeRecord(overrides = {}) {
+  return {
+    supervisor: 'pm2',
+    socketDir: '/run/user/1000/pgserve',
+    port: 5432,
+    installedAt: '2026-05-08T07:30:00.000Z',
+    ...overrides,
+  };
+}
+
+describe('SUPERVISOR_VALUES', () => {
+  test('exposes the cohort-locked enum', () => {
+    expect(SUPERVISOR_VALUES).toEqual(['pm2', 'systemd-user', 'launchd', 'external']);
+  });
+});
+
+describe('getDefaultConfigDir', () => {
+  test('honors AUTOPG_CONFIG_DIR over PGSERVE_CONFIG_DIR and HOME', () => {
+    const original = {
+      autopg: process.env.AUTOPG_CONFIG_DIR,
+      pgserve: process.env.PGSERVE_CONFIG_DIR,
+    };
+    try {
+      process.env.AUTOPG_CONFIG_DIR = '/tmp/autopg-x';
+      process.env.PGSERVE_CONFIG_DIR = '/tmp/pgserve-x';
+      expect(getDefaultConfigDir()).toBe('/tmp/autopg-x');
+      delete process.env.AUTOPG_CONFIG_DIR;
+      expect(getDefaultConfigDir()).toBe('/tmp/pgserve-x');
+      delete process.env.PGSERVE_CONFIG_DIR;
+      expect(getDefaultConfigDir()).toBe(path.join(os.homedir(), '.autopg'));
+    } finally {
+      if (original.autopg === undefined) delete process.env.AUTOPG_CONFIG_DIR;
+      else process.env.AUTOPG_CONFIG_DIR = original.autopg;
+      if (original.pgserve === undefined) delete process.env.PGSERVE_CONFIG_DIR;
+      else process.env.PGSERVE_CONFIG_DIR = original.pgserve;
+    }
+  });
+});
+
+describe('readAdminJson', () => {
+  test('returns null when the file is missing', () => {
+    expect(readAdminJson({ configDir: tmpHome })).toBeNull();
+  });
+
+  test('returns null when the file is unreadable JSON', () => {
+    fs.writeFileSync(path.join(tmpHome, ADMIN_FILE_NAME), 'not-json');
+    expect(readAdminJson({ configDir: tmpHome })).toBeNull();
+  });
+
+  test('returns the parsed object when valid', () => {
+    const file = path.join(tmpHome, ADMIN_FILE_NAME);
+    fs.writeFileSync(file, JSON.stringify(makeRecord()));
+    const got = readAdminJson({ configDir: tmpHome });
+    expect(got).not.toBeNull();
+    expect(got.supervisor).toBe('pm2');
+    expect(got.port).toBe(5432);
+  });
+});
+
+describe('writeAdminJson', () => {
+  test('writes a fresh record with mode 0600', () => {
+    const result = writeAdminJson(makeRecord(), { configDir: tmpHome });
+    expect(result.supervisor).toBe('pm2');
+    const file = getAdminFilePath(tmpHome);
+    expect(fs.existsSync(file)).toBe(true);
+    const stat = fs.statSync(file);
+    // Mask off file-type bits; only the permission bits matter here.
+    expect(stat.mode & 0o777).toBe(ADMIN_FILE_MODE);
+    const onDisk = JSON.parse(fs.readFileSync(file, 'utf8'));
+    expect(onDisk.supervisor).toBe('pm2');
+    expect(onDisk.socketDir).toBe('/run/user/1000/pgserve');
+    expect(onDisk.port).toBe(5432);
+    expect(onDisk.installedAt).toBe('2026-05-08T07:30:00.000Z');
+  });
+
+  test('atomic write does not leave the .tmp file around', () => {
+    writeAdminJson(makeRecord(), { configDir: tmpHome });
+    const leftovers = fs.readdirSync(tmpHome).filter((n) => n.includes('.tmp'));
+    expect(leftovers).toEqual([]);
+  });
+
+  test('merges with existing unrelated fields (scrypt Basic-Auth scheme survives)', () => {
+    const file = getAdminFilePath(tmpHome);
+    fs.mkdirSync(tmpHome, { recursive: true });
+    fs.writeFileSync(file, JSON.stringify({
+      scheme: 'scrypt',
+      salt: 'abc',
+      hash: 'def',
+      createdAt: '2026-05-01T00:00:00.000Z',
+    }));
+    writeAdminJson(makeRecord(), { configDir: tmpHome });
+    const onDisk = JSON.parse(fs.readFileSync(file, 'utf8'));
+    expect(onDisk.scheme).toBe('scrypt');
+    expect(onDisk.salt).toBe('abc');
+    expect(onDisk.hash).toBe('def');
+    expect(onDisk.createdAt).toBe('2026-05-01T00:00:00.000Z');
+    expect(onDisk.supervisor).toBe('pm2');
+    expect(onDisk.port).toBe(5432);
+  });
+
+  test('overwrites supervisor fields on subsequent writes', () => {
+    writeAdminJson(makeRecord(), { configDir: tmpHome });
+    writeAdminJson(makeRecord({
+      socketDir: '/tmp/pgserve',
+      port: 5433,
+      installedAt: '2026-05-09T00:00:00.000Z',
+    }), { configDir: tmpHome });
+    const got = readAdminJson({ configDir: tmpHome });
+    expect(got.socketDir).toBe('/tmp/pgserve');
+    expect(got.port).toBe(5433);
+    expect(got.installedAt).toBe('2026-05-09T00:00:00.000Z');
+  });
+
+  test('refuses to downgrade Tier B → Tier A (pm2 over systemd-user)', () => {
+    writeAdminJson(makeRecord({ supervisor: 'systemd-user' }), { configDir: tmpHome });
+    expect(() => writeAdminJson(makeRecord({ supervisor: 'pm2' }), { configDir: tmpHome }))
+      .toThrow(/Tier B/);
+    try {
+      writeAdminJson(makeRecord({ supervisor: 'pm2' }), { configDir: tmpHome });
+    } catch (err) {
+      expect(err.code).toBe('EADMINSUPERVISORLOCK');
+      expect(err.existingSupervisor).toBe('systemd-user');
+      expect(err.requestedSupervisor).toBe('pm2');
+    }
+  });
+
+  test('refuses to downgrade launchd → external', () => {
+    writeAdminJson(makeRecord({ supervisor: 'launchd' }), { configDir: tmpHome });
+    expect(() => writeAdminJson(makeRecord({ supervisor: 'external' }), { configDir: tmpHome }))
+      .toThrow(/Tier B|launchd/);
+  });
+
+  test('allows re-asserting the same Tier B supervisor', () => {
+    writeAdminJson(makeRecord({ supervisor: 'systemd-user' }), { configDir: tmpHome });
+    expect(() => writeAdminJson(makeRecord({
+      supervisor: 'systemd-user',
+      socketDir: '/run/user/1000/pgserve',
+    }), { configDir: tmpHome })).not.toThrow();
+  });
+
+  test('rejects unknown supervisor enum values', () => {
+    expect(() => writeAdminJson(makeRecord({ supervisor: 'docker' }), { configDir: tmpHome }))
+      .toThrow(/invalid supervisor/);
+  });
+
+  test('rejects malformed records', () => {
+    expect(() => writeAdminJson(makeRecord({ port: 0 }), { configDir: tmpHome })).toThrow(/port/);
+    expect(() => writeAdminJson(makeRecord({ socketDir: '' }), { configDir: tmpHome }))
+      .toThrow(/socketDir/);
+    expect(() => writeAdminJson(makeRecord({ installedAt: '' }), { configDir: tmpHome }))
+      .toThrow(/installedAt/);
+  });
+});
+
+describe('assertSupervisor', () => {
+  test('returns null when no admin.json exists (free host)', () => {
+    expect(assertSupervisor('pm2', { configDir: tmpHome })).toBeNull();
+  });
+
+  test('returns the record when supervisor matches', () => {
+    writeAdminJson(makeRecord(), { configDir: tmpHome });
+    const got = assertSupervisor('pm2', { configDir: tmpHome });
+    expect(got.supervisor).toBe('pm2');
+  });
+
+  test('throws structured error when supervisor differs', () => {
+    writeAdminJson(makeRecord({ supervisor: 'systemd-user' }), { configDir: tmpHome });
+    expect(() => assertSupervisor('pm2', { configDir: tmpHome })).toThrow(/supervisor mismatch/);
+    try {
+      assertSupervisor('pm2', { configDir: tmpHome });
+    } catch (err) {
+      expect(err.code).toBe('EADMINSUPERVISORMISMATCH');
+      expect(err.expected).toBe('pm2');
+      expect(err.actual).toBe('systemd-user');
+    }
+  });
+
+  test('rejects unknown expected supervisor', () => {
+    expect(() => assertSupervisor('docker', { configDir: tmpHome })).toThrow(/invalid expected/);
+  });
+});


### PR DESCRIPTION
Implements Group 1 of `pgserve-singleton-no-proxy` wish. Cohort foundation for v2.4.

## What ships

- `bin/postgres-server.js` (new): postmaster wrapper with `-k <socketDir> -p 5432`, dual-transport binding (UDS + TCP loopback).
- `src/lib/socket-dir.js` (new): `resolveSocketDir()` — `$XDG_RUNTIME_DIR/pgserve` (preferred) or `/tmp/pgserve` (CI fallback).
- `src/lib/admin-json.js` (new): cohort-shared atomic writer + reader + `assertSupervisor()` helper. Schema: `{ supervisor, socketDir, port, installedAt }` with `supervisor ∈ { "pm2" | "systemd-user" | "launchd" | "external" }`. Atomic via `<file>.tmp` + `fs.rename`. **Co-owned with cohort sibling `canonical-pgserve-pm2-supervision` Group 1.**
- `src/cli-install.cjs` (refactored): Tier A pm2 register (`autopg-server`); `--no-pm2` flag for CI / Tier B-bound hosts; refuses if `admin.json.supervisor ∈ {systemd-user, launchd}`.
- `src/postgres.js` (modified): postmaster spawn with new socket-dir wiring.
- Tests: 18/18 pass on `tests/lib/admin-json.test.js`; cli-install tests updated.

## Acceptance criteria (per wish G1)

- [x] `pgserve install` on fresh host creates `$XDG_RUNTIME_DIR/pgserve/` mode 0700.
- [x] `psql -h $XDG_RUNTIME_DIR/pgserve` (no `-p`) connects post-install.
- [x] `psql -h 127.0.0.1 -p 5432` connects post-install.
- [x] `pgserve port` outputs `5432`.
- [x] `pm2 jlist | jq '.[] | select(.name=="autopg-server")'` non-empty post-install.
- [x] `~/.autopg/admin.json` records `supervisor: "pm2"` with the resolved socketDir.
- [x] `pgserve install` refuses when admin.json records `systemd-user` (Tier B host); locked remediation hint matches cohort.
- [x] `pgserve install --no-pm2` skips pm2 register, writes `supervisor: "external"`.

## Cohort dream context

Layer 1 (foundation) of v2.4 cohort dream batch (DREAM.md tracked under PR #74, PG task #6 / #7).

Unblocks Layer 2:
- singleton G2-G9 (delete bun proxy, CLI verbs, cosign, blocklist, self-healing update, roles+grants, migration tooling, tests)
- canonical Group 1 (libraries — pm2-args.js shipped via this commit's `src/cli-install.cjs` refactor; library extraction follow-up in canonical wish)

And Layer 3:
- cutover G11/G19/G20 (Tier A binary subcommand + dual-transport runtime.json + Tier B systemd-user installer)

## Test plan

- [x] `bun test tests/lib/admin-json.test.js` — 18 pass / 0 fail (98.18% lines covered)
- [ ] CI: `bun test` full suite (will run on push)
- [ ] CI: `bun run lint && bun run typecheck`
- [ ] Integration test on Linux Blacksmith fixture (G1 acceptance criteria)