### PR TITLE
feat(canonical#1): pm2-args library + autopg uninstall (Tier A surfaces)

### DIFF
--- a/.genie/wishes/canonical-pgserve-pm2-supervision/WISH.md
+++ b/.genie/wishes/canonical-pgserve-pm2-supervision/WISH.md
@@ -280,6 +280,8 @@ nohup genie install &  # close shell; bridge stays alive
 
 **depends-on:** Group 1
 
+**cross-wish depends-on:** `pgserve#autopg-distribution-cutover` Group 11 (autopg install Tier A — provides the binary subcommand this wish's `genie install` shells out to before registering `genie-serve`). Also Group 20 for the Tier-B-refusal acceptance criterion (line 272 — must read `admin.json.supervisor` set by Group 20's MIGRATE flow).
+
 ---
 
 ### Group 3: omni install reconfig + migration (Wave 3)
@@ -309,6 +311,8 @@ omni doctor | grep -q "canonical-connection-string: ok"
 ```
 
 **depends-on:** Group 1
+
+**cross-wish depends-on:** `pgserve#autopg-distribution-cutover` Group 11 (autopg install Tier A — `omni install` shells out to it before registering `omni-api` + `omni-nats`). Also Group 20 for the Tier-B-refusal acceptance criterion (line 302).
 
 ---
 

--- a/.genie/wishes/canonical-pgserve-pm2-supervision/WISH.md
+++ b/.genie/wishes/canonical-pgserve-pm2-supervision/WISH.md
@@ -2,32 +2,39 @@
 
 | Field | Value |
 |-------|-------|
-| **Status** | DRAFT |
+| **Status** | DRAFT (one of three peer wishes that together ship v2.4; each gets its own branch + PR + `/dream` slot) |
 | **Slug** | `canonical-pgserve-pm2-supervision` |
-| **Date** | 2026-04-30 |
+| **Date** | 2026-04-30 (refined 2026-05-08 for v2.4 cohort + autopg rename) |
 | **Author** | genie-configure |
 | **Appetite** | medium-large |
-| **Repos touched** | `namastexlabs/pgserve`, `automagik-dev/omni`, `automagik-dev/genie`, `namastexlabs/genie-configure` (brain only) |
+| **Branch** | `wish/canonical-pgserve-pm2-supervision` |
+| **Repos touched** | `automagik/autopg` (renamed from `namastexlabs/pgserve` in cohort sibling), `automagik-dev/omni`, `automagik-dev/genie`, `namastexlabs/genie-configure` (brain only) |
 | **Design** | _No brainstorm — direct wish from operational pain (live debugging session 2026-04-30)_ |
+| **v2.4 cohort** | peer wishes, separate branches/PRs: `autopg-distribution-cutover` (rename + CDN + Tier B G11.6), `pgserve-singleton-no-proxy` (data plane + admin.json), this wish (cross-repo pm2 reuse — Tier A only) |
+
+> **🛡 TWO-TIER SUPERVISOR MODEL (Felipe constraint, 2026-05-08)**: this wish **specifies Tier A only** (rootless pm2). Tier B systemd-user / launchd is delivered by the cohort sibling `autopg-distribution-cutover` G11.6 via `autopg service install`. The hard MIGRATE contract (pm2-delete BEFORE unit-write; `~/.autopg/admin.json` records active supervisor) prevents Tier A + Tier B double-supervision. This wish writes `admin.json.supervisor = "pm2"` and downstream installers (`genie install`, `omni install`) MUST refuse to register their own pm2 entries if `admin.json.supervisor == "systemd-user"` (operator must run `autopg service uninstall` first to revert to Tier A).
 
 ## Summary
 
 Canonicalize **pgserve as the single, central, pm2-supervised database server** that every service in the stack connects to. Make `genie serve` and `omni-api`/`omni-nats` peer-equal pm2 services that boot under the same hardening, register via their own `*-install` commands, and consume pgserve through its CLI.
 
-**End-state pm2 list:**
+**End-state pm2 list (v2.4, Tier A — rootless default):**
 
 ```
-┌──────────────────────────────────────────┐
-│  pm2 supervisor                          │
-├──────────────────────────────────────────┤
-│  1. pgserve         ← NEW (canonical PG) │
-│  2. omni-api        ← existing, reconfig │
-│  3. omni-nats       ← existing            │
-│  4. genie-serve     ← NEW                 │
-│                                           │
-│  + pm2-logrotate (module, already there) │
-└──────────────────────────────────────────┘
+┌──────────────────────────────────────────────┐
+│  pm2 supervisor (Tier A)                     │
+├──────────────────────────────────────────────┤
+│  1. autopg-server    ← NEW (canonical PG)    │
+│  2. autopg-ui        ← NEW (console, opt.)   │
+│  3. omni-api         ← existing, reconfig    │
+│  4. omni-nats        ← existing               │
+│  5. genie-serve      ← NEW                    │
+│                                               │
+│  + pm2-logrotate (module, already there)     │
+└──────────────────────────────────────────────┘
 ```
+
+When the operator has run `autopg service install` (Tier B from cutover G11.6), entries 1+2 disappear from pm2 and live as `autopg.service` (systemd user-unit) instead. Entries 3-5 stay under pm2 either way (Tier B does not absorb them in v2.4).
 
 ## Trigger
 
@@ -46,11 +53,11 @@ Same session also revealed: **multiple pgserve instances running in parallel** (
 
 ### IN
 
-1. **pgserve gets `install` + `serve` commands.** New subcommands in the pgserve CLI:
-   - `pgserve install` — idempotent pm2 registration with hardened defaults (mirror omni's `PM2_HARDENED_DEFAULTS`); creates `~/.pgserve/config.json` with canonical port + data dir.
-   - `pgserve serve` — long-lived process pm2 invokes (currently `bin/pgserve-wrapper.cjs daemon`, just renamed for clarity).
-   - `pgserve status` / `pgserve url` / `pgserve port` — discovery API for downstream installers.
-   - `pgserve uninstall` — `pm2 delete pgserve` + leave data dir intact.
+1. **autopg gets `install` + `serve` commands** (CLI binary renamed from pgserve in cohort sibling `autopg-distribution-cutover`):
+   - `autopg install` — idempotent pm2 registration of `autopg-server` + `autopg-ui` with hardened defaults (mirror omni's `PM2_HARDENED_DEFAULTS`); writes `~/.autopg/admin.json` with `{ supervisor: "pm2", socketDir, port: 5432, installedAt }`. Refuses if `admin.json.supervisor == "systemd-user"` (operator on Tier B).
+   - `autopg serve` — long-lived postmaster wrapper pm2 invokes. Defined in cohort sibling `pgserve-singleton-no-proxy` G1.
+   - `autopg status` / `autopg url` / `autopg port` — discovery API for downstream installers. `port` returns 5432 (Unix socket preferred via `autopg url`).
+   - `autopg uninstall` — `pm2 delete autopg-server autopg-ui` + leave data dir intact + clear `admin.json.supervisor`.
 
 2. **Hardened pm2 defaults shared.** Extract `PM2_HARDENED_DEFAULTS` and `buildPm2StartArgs` from `omni/packages/cli/src/pm2.ts` into a small shared shape every installer copies. Constants stay duplicated across repos (avoids a new shared package), but the values are pinned in this wish:
    ```
@@ -63,22 +70,23 @@ Same session also revealed: **multiple pgserve instances running in parallel** (
    ```
 
 3. **`genie install` (NEW).** Mirror of `omni install`:
-   - Calls `pgserve install` first (no-op when already registered).
-   - Reads `pgserve url` to get the canonical connection string.
-   - Registers `genie-serve` under pm2 with hardened defaults.
-   - Writes `~/.genie/config.json` with `databaseUrl: <pgserve url>`.
+   - Calls `autopg install` first (no-op when already registered).
+   - Reads `autopg url` to get the canonical connection string (Unix socket via `host=$XDG_RUNTIME_DIR/pgserve` or TCP `localhost:5432`).
+   - Registers `genie-serve` under pm2 with hardened defaults — refuses if `admin.json.supervisor == "external"` (operator owns supervision; emits remediation).
+   - Writes `~/.genie/config.json` with `databaseUrl: <autopg url>`.
    - Idempotent; safe to re-run.
    - Adds `--non-interactive` for CI/install.sh.
 
 4. **`omni install` reconfigured.** Stops embedding pgserve inside `omni-api`'s lifecycle:
-   - Calls `pgserve install` first.
-   - Migration: pg_dump from current `~/.omni/data/pgserve/` → restore into canonical pgserve. Stop and pm2-delete the embedded pgserve.
-   - Update `omni-api`'s `DATABASE_URL` env to point at canonical pgserve.
-   - Existing `omni doctor` already audits this; extend it to check connection-string-points-at-canonical-pgserve.
+   - Calls `autopg install` first.
+   - Migration: pg_dump from current `~/.omni/data/pgserve/` → restore into canonical autopg → stop and pm2-delete the embedded pgserve.
+   - Update `omni-api`'s `DATABASE_URL` env to point at canonical autopg (Unix socket preferred).
+   - Existing `omni doctor` already audits this; extend it to check connection-string-points-at-canonical-autopg.
+   - Refuses if `admin.json.supervisor == "external"` (same guardrail as genie install).
 
 5. **`install.sh` updates.** Both repos' bootstrap scripts route through the new pattern:
-   - `omni/install.sh`: install pgserve@latest globally → `pgserve install` → `omni install`.
-   - `genie/install.sh`: install pgserve@latest globally → `pgserve install` → `genie install`.
+   - `omni/install.sh`: install autopg@latest → `autopg install` → `omni install`.
+   - `genie/install.sh`: install autopg@latest → `autopg install` → `genie install`.
 
 6. **Brain documentation.** Add to genie-configure's brain:
    - `Configuration & Routing/canonical-pgserve-pm2.md` — architecture map: 4 pm2 services, pgserve as central PG, install ordering.
@@ -97,27 +105,30 @@ Same session also revealed: **multiple pgserve instances running in parallel** (
 
 | # | Decision | Rationale |
 |---|---|---|
-| 1 | pgserve owns the install + serve subcommands | Other services should NOT know how to register pgserve under pm2 — that's pgserve's responsibility. Same pattern as omni owning omni-api/nats. |
-| 2 | Idempotent `*-install` everywhere | Every installer can be re-run without harm. Re-running `pgserve install` after it's already registered exits 0 with "already installed." Same for `omni install` and `genie install`. |
-| 3 | Cross-repo install dependency: pgserve → omni & genie | omni and genie shell out to `pgserve install` first. They DON'T re-implement pgserve registration. Tighter coupling, but simpler than a shared package, and avoids "two installers disagree on hardening defaults." |
+| 1 | autopg owns the install + serve subcommands | Other services should NOT know how to register autopg under pm2 — that's autopg's responsibility. Same pattern as omni owning omni-api/nats. |
+| 2 | Idempotent `*-install` everywhere | Every installer can be re-run without harm. Re-running `autopg install` after it's already registered exits 0 with "already installed." Same for `omni install` and `genie install`. |
+| 3 | Cross-repo install dependency: autopg → omni & genie | omni and genie shell out to `autopg install` first. They DON'T re-implement autopg registration. Tighter coupling, but simpler than a shared package, and avoids "two installers disagree on hardening defaults." |
 | 4 | `--interpreter none` for pm2 launches | Both genie and omni binaries use `#!/usr/bin/env bun` shebangs. `--interpreter bun` triggers pm2's ESM/require crash on top-level await. Shebang resolution side-steps the issue. **Empirically validated 2026-04-30** during the manual genie-serve pm2 registration. |
 | 5 | `genie serve start --headless --no-tui --no-interactive` for pm2 | TUI requires a real terminal; pm2 child has no tty. Headless + no-tui matches omni-api's mode. **Empirically validated 2026-04-30.** |
-| 6 | Migration via pg_dump + restore (not file-level copy) | Data file format is sensitive to PG version; pg_dump is portable. Even with same pgserve version, dump+restore is the safe path. |
-| 7 | Single config file per service, no shared "canonical config" file | `pgserve install` writes `~/.pgserve/config.json`; consumers read it via `pgserve url`. We don't introduce a `~/.canonical/` directory or similar. The CLI is the contract. |
-| 8 | pm2-logrotate stays as a module, not a pm2 service | It's a pm2 module by design; `omni install` already configures it. `pgserve install` reuses the same pm2-logrotate (no duplicate setup). |
+| 6 | Migration via pg_dump + restore (not file-level copy) | Data file format is sensitive to PG version; pg_dump is portable. Even with same autopg version, dump+restore is the safe path. |
+| 7 | `~/.autopg/admin.json` is the single contract for supervisor + connection discovery | `autopg install` writes it; `genie install`/`omni install` read it via `autopg url` / `autopg port`; `autopg doctor` reads `supervisor` field to pick the right liveness check. The CLI is the contract. Schema co-owned with cohort sibling `pgserve-singleton-no-proxy` G1. |
+| 8 | pm2-logrotate stays as a module, not a pm2 service | It's a pm2 module by design; `omni install` already configures it. `autopg install` reuses the same pm2-logrotate (no duplicate setup). |
+| 9 | Downstream installers refuse when `admin.json.supervisor != "pm2"` | If operator has run `autopg service install` (Tier B), `genie install`/`omni install` MUST refuse to add their own pm2 entries (would create double-supervision). Operator runs `autopg service uninstall` first to revert to Tier A. Felipe directive 2026-05-08. |
 
 ## Success Criteria
 
-- [ ] `pgserve install` registers `pgserve` as a pm2 service with hardened defaults; idempotent on second invocation.
-- [ ] `pgserve url` returns a valid connection string that other tools can use without pgserve being CLI-imported.
-- [ ] `omni install` on a clean machine results in: `pgserve` + `omni-api` + `omni-nats` all under pm2 with green status.
-- [ ] `genie install` on a clean machine results in: `pgserve` + `genie-serve` all under pm2 with green status.
-- [ ] On a machine where both omni and genie are installed, exactly **4 pm2 services** are present (pgserve, omni-api, omni-nats, genie-serve), pgserve is shared, and both `omni doctor` and `genie doctor` are green.
-- [ ] On reboot, `pm2 resurrect` brings all 4 services back online with correct env.
+- [ ] `autopg install` registers `autopg-server` + `autopg-ui` as pm2 services with hardened defaults; idempotent on second invocation; writes `~/.autopg/admin.json` with `supervisor: "pm2"`.
+- [ ] `autopg url` returns a valid connection string (Unix socket preferred, TCP 5432 fallback) that other tools can use without autopg being CLI-imported.
+- [ ] `omni install` on a clean machine results in: `autopg-server` + `autopg-ui` + `omni-api` + `omni-nats` all under pm2 with green status.
+- [ ] `genie install` on a clean machine results in: `autopg-server` + `autopg-ui` + `genie-serve` all under pm2 with green status.
+- [ ] On a machine where both omni and genie are installed, exactly **5 pm2 services** are present (`autopg-server`, `autopg-ui`, `omni-api`, `omni-nats`, `genie-serve`), autopg is shared, and both `omni doctor` and `genie doctor` are green.
+- [ ] On reboot, `pm2 resurrect` brings all 5 services back online with correct env.
 - [ ] Existing omni installs migrate without data loss: pre-migration `omni events list` content matches post-migration content.
 - [ ] `genie serve` running under pm2 survives shell closure (the bug that triggered this wish stays fixed forever).
-- [ ] `omni doctor` and `genie doctor` both gain a check: "process is registered under pm2 with hardened defaults" (yes/no with one-line remediation if no).
+- [ ] `omni doctor` and `genie doctor` both gain a check: "process is registered under pm2 with hardened defaults AND `admin.json.supervisor` matches host expectation" (yes/no with one-line remediation if no).
 - [ ] Brain entries (architecture map, runbook, ADR) merged in genie-configure.
+- [ ] **Tier B refusal**: on a host where operator has run `autopg service install` (admin.json.supervisor == "systemd-user"), running `genie install` or `omni install` exits non-zero with remediation hint `"autopg is on Tier B (systemd-user); run autopg service uninstall to revert to Tier A before installing genie/omni under pm2"`.
+- [ ] **Tier B coexistence**: with autopg on Tier B (systemd-user) and omni-api/omni-nats/genie-serve on pm2, `omni doctor` and `genie doctor` both pass when their connection-string check resolves against the systemd-managed autopg.
 
 ## Execution Strategy
 
@@ -133,14 +144,16 @@ Wave-based; each wave can ship independently. Three repos, four PRs total.
 
 **Validation:**
 ```bash
-bunx pgserve install              # green; pm2 list shows `pgserve`
-bunx pgserve install              # exits 0, "already installed"
-bunx pgserve url                  # postgres://localhost:8432/postgres
-bunx pgserve status --json        # { name: "pgserve", status: "online", port: 8432, dataDir: "..." }
-pm2 list | grep pgserve           # online, max-restarts=10, etc.
+autopg install                    # green; pm2 list shows `autopg-server` + `autopg-ui`
+autopg install                    # exits 0, "already installed"
+autopg url                        # postgres://localhost:5432/postgres or unix:$XDG_RUNTIME_DIR/pgserve
+autopg port                       # 5432
+autopg status --json              # { name: "autopg-server", status: "online", port: 5432, supervisor: "pm2", socketDir: "..." }
+pm2 list | grep -E '(autopg-server|autopg-ui)'   # both online, max-restarts=10
+jq -e '.supervisor == "pm2"' ~/.autopg/admin.json
 ```
 
-**PR:** `namastexlabs/pgserve#???` — `feat(cli): pgserve install + pm2 supervision`.
+**PR:** `automagik/autopg#???` — `feat(cli): autopg install + pm2 supervision (Tier A)`.
 
 ### Wave 2 — `genie install` (depends on Wave 1)
 
@@ -155,9 +168,11 @@ pm2 list | grep pgserve           # online, max-restarts=10, etc.
 **Validation:**
 ```bash
 genie install                                            # green
-pm2 list                                                 # includes pgserve + genie-serve
-genie doctor                                             # all green
+pm2 list                                                 # includes autopg-server + autopg-ui + genie-serve
+genie doctor                                             # all green; canonical-autopg=ok
 genie serve stop && genie install                        # idempotent
+# Tier B refusal: autopg service install (sets admin.json.supervisor=systemd-user), then re-run:
+genie install                                            # refuses: "autopg is on Tier B; revert with autopg service uninstall first"
 # kill the shell that ran install — bridge stays alive (the original incident's reproduction)
 ```
 
@@ -177,16 +192,16 @@ genie serve stop && genie install                        # idempotent
 ```bash
 # Fresh machine
 omni install
-pm2 list                            # pgserve + omni-api + omni-nats
+pm2 list                            # autopg-server + autopg-ui + omni-api + omni-nats
 omni doctor                         # all green; connection-string-canonical=ok
 
 # Existing machine (with embedded pgserve)
 omni install                        # detects legacy, runs migration
 omni events list --limit 100        # data preserved post-migration
-pm2 list                            # pgserve + omni-api + omni-nats (no embedded pgserve)
+pm2 list                            # autopg-server + autopg-ui + omni-api + omni-nats (no embedded pgserve)
 ```
 
-**PR:** `automagik-dev/omni#???` — `feat(install): canonical pgserve + migration from embedded`.
+**PR:** `automagik-dev/omni#???` — `feat(install): canonical autopg + migration from embedded pgserve`.
 
 ### Wave 4 — Brain ingestion (depends on Waves 1–3 merging)
 
@@ -196,17 +211,140 @@ pm2 list                            # pgserve + omni-api + omni-nats (no embedde
 - Group 4.2 — `brain/Runbooks/recover-pm2-stack.md`: diagnose/restart any of the 4 services; `pm2 resurrect` after reboot; rollback to embedded pgserve (if migration goes wrong).
 - Group 4.3 — `brain/_decisions/2026-04-30-canonical-pgserve.md`: ADR; alternatives considered (vanilla postgres, systemd-user, embedded-everywhere); consequences.
 
-**PR:** `namastexlabs/genie-configure#???` — `chore(brain): canonical pgserve + pm2 supervision`.
+**PR:** `namastexlabs/genie-configure#???` — `chore(brain): canonical autopg + pm2 supervision`.
+
+## Execution Groups
+
+### Group 1: autopg pm2 lifecycle (Wave 1)
+
+**Goal:** autopg owns Tier A pm2 lifecycle. New CLI subcommands (`install`, `serve`, `status`, `url`, `port`, `uninstall`) plus `~/.autopg/admin.json` writer/reader. Hardened pm2 defaults extracted into `src/lib/pm2-args.ts`.
+
+**Deliverables:**
+1. `src/commands/install.ts` — pm2 register `autopg-server` + `autopg-ui` with hardened defaults. Refuses if `admin.json.supervisor` ∈ {`systemd-user`, `launchd`}.
+2. `src/commands/serve.ts` — wrapper postmaster invocation (postmaster details in `pgserve-singleton-no-proxy` G1).
+3. `src/commands/status.ts` / `url.ts` / `port.ts` — JSON-shape discovery API.
+4. `src/commands/uninstall.ts` — pm2 delete + clear admin.json.
+5. `src/lib/pm2-args.ts` — `PM2_HARDENED_DEFAULTS` (maxRestarts=10, restartDelayMs=5000, maxMemoryRestart by service, killTimeoutMs=20000, log paths, `--interpreter none`).
+6. `src/lib/admin-json.ts` — atomic writer + reader; supervisor-refusal helper.
+7. `__tests__/install.test.ts`, `__tests__/url.test.ts`, `__tests__/admin-json.test.ts`.
+
+**Acceptance Criteria:**
+- [ ] `autopg install` is idempotent; second run exits 0 with "already installed".
+- [ ] `pm2 list` shows `autopg-server` + `autopg-ui` post-install.
+- [ ] `~/.autopg/admin.json` contains `{ supervisor: "pm2", socketDir, port: 5432, installedAt }`.
+- [ ] `autopg url` / `autopg port` / `autopg status --json` return canonical values.
+- [ ] `autopg install` refuses with non-zero exit when `admin.json.supervisor == "systemd-user"`.
+
+**Validation:**
+```bash
+autopg install && autopg install
+pm2 jlist | jq -e '.[] | select(.name=="autopg-server")' >/dev/null
+jq -e '.supervisor == "pm2"' ~/.autopg/admin.json
+autopg port | grep -q 5432
+```
+
+**depends-on:** none (cross-wish dependency on `pgserve#pgserve-singleton-no-proxy` Group 1 declared in Cross-wish dependencies section)
+
+---
+
+### Group 2: genie install + pm2 supervision (Wave 2)
+
+**Goal:** `genie install` is the rootless symmetric installer for `genie-serve`. Calls `autopg install` first; registers `genie-serve` under pm2; updates `~/.genie/config.json`. `genie doctor` adds `pm2-supervision` + `canonical-autopg` checks.
+
+**Deliverables:**
+1. `src/genie-commands/install.ts` — calls `autopg install`; reads `autopg url`; registers `genie-serve` with hardened defaults (`--interpreter none` + `serve start --headless --no-tui --no-interactive`).
+2. `src/genie-commands/doctor.ts` — adds `pm2-supervision` and `canonical-autopg` checks.
+3. `src/term-commands/serve.ts` — detects pm2 supervision and defers to `pm2 restart genie-serve`.
+4. `src/lib/pm2-args.ts` — copy from autopg's spec (Decision 3: constants duplicated, no shared package).
+5. `install.sh` — route through `autopg install` → `genie install`.
+6. Refusal path: `genie install` refuses non-zero when `admin.json.supervisor == "external"` (operator owns supervision).
+
+**Acceptance Criteria:**
+- [ ] On a fresh host, `genie install` produces `pm2 list` containing `autopg-server`, `autopg-ui`, `genie-serve`.
+- [ ] `genie doctor` is green; `pm2-supervision` and `canonical-autopg` checks pass.
+- [ ] `genie serve` running under pm2 survives shell closure (regression test for original incident).
+- [ ] `genie install` refuses when `admin.json.supervisor == "external"` with remediation hint.
+- [ ] `genie install` succeeds when `admin.json.supervisor == "systemd-user"` (autopg on Tier B; genie still under pm2 — hybrid is allowed).
+
+**Validation:**
+```bash
+genie install && genie doctor
+pm2 list | grep -q genie-serve
+nohup genie install &  # close shell; bridge stays alive
+```
+
+**depends-on:** Group 1
+
+---
+
+### Group 3: omni install reconfig + migration (Wave 3)
+
+**Goal:** Omni installer routes through canonical autopg. Migration handler dumps embedded pgserve → restores into autopg → updates omni-api `DATABASE_URL`.
+
+**Deliverables:**
+1. `packages/cli/src/commands/install.ts` — calls `autopg install`; removes embedded pgserve registration.
+2. `packages/cli/src/lib/migrate-from-embedded-pgserve.ts` — pg_dump from `~/.omni/data/pgserve/` → restore into canonical autopg → pm2-delete embedded pgserve.
+3. `packages/cli/src/commands/doctor.ts` — adds `canonical-connection-string` check.
+4. `install.sh` — `autopg install` → `omni install`.
+5. `--dry-run` migration mode + filesystem snapshot recommendation in docs.
+
+**Acceptance Criteria:**
+- [ ] Fresh machine: `omni install` produces `pm2 list` with `autopg-server`, `autopg-ui`, `omni-api`, `omni-nats`.
+- [ ] Existing-embedded machine: `omni install` migrates without data loss (`omni events list` content preserved).
+- [ ] Post-migration: no embedded pgserve in pm2 list.
+- [ ] `omni doctor` `canonical-connection-string` passes; `DATABASE_URL` points at autopg.
+- [ ] `omni install` refuses when `admin.json.supervisor == "external"`.
+
+**Validation:**
+```bash
+bash tests/integration/omni-fresh-install.sh
+bash tests/integration/omni-migrate-from-embedded.sh
+omni doctor | grep -q "canonical-connection-string: ok"
+```
+
+**depends-on:** Group 1
+
+---
+
+### Group 4: Brain ingestion + ADR (Wave 4)
+
+**Goal:** Document the canonical 5-service layout so future agents inheriting these servers know the pattern from a single file.
+
+**Deliverables:**
+1. `brain/Configuration & Routing/canonical-autopg-pm2.md` — architecture map; 5-service ascii diagram; autopg discovery via `autopg url`; install ordering; Tier A vs Tier B switching.
+2. `brain/Runbooks/recover-pm2-stack.md` — diagnose/restart any of the 5 services; `pm2 resurrect` after reboot; rollback to embedded pgserve (if migration goes wrong); switch from Tier A → Tier B (run `autopg service install`).
+3. `brain/_decisions/2026-04-30-canonical-autopg.md` — ADR; alternatives considered (vanilla postgres, systemd-only, embedded-everywhere); consequences.
+
+**Acceptance Criteria:**
+- [ ] All three files merged in `namastexlabs/genie-configure`.
+- [ ] Architecture map matches the actual end-state pm2 list on a host with all three repos installed.
+
+**Validation:**
+```bash
+test -f brain/Configuration\ \&\ Routing/canonical-autopg-pm2.md
+test -f brain/Runbooks/recover-pm2-stack.md
+test -f brain/_decisions/2026-04-30-canonical-autopg.md
+```
+
+**depends-on:** Group 1, Group 2, Group 3
+
+---
 
 ## Dependencies
 
 ```
-Wave 1 (pgserve)  ──┬──→ Wave 2 (genie)
-                     ├──→ Wave 3 (omni)
-                     └──→ Wave 4 (brain — also depends on Wave 2 & 3)
+Wave 1 (autopg)  ──┬──→ Wave 2 (genie)
+                    ├──→ Wave 3 (omni)
+                    └──→ Wave 4 (brain — also depends on Wave 2 & 3)
 ```
 
-Cross-wish: closes the operator-lockout footgun the canonical-genie-omni-wiring + omni-host-fingerprint-trust wishes paved over with workarounds. Doesn't conflict with `aegis-runtime` (separate daemon, separate supervisor).
+## Cross-wish dependencies
+
+- **paired-with** `pgserve#autopg-distribution-cutover` — v2.4 cohort sibling. Owns the `pgserve` → `autopg` rename, CDN distribution, and `autopg service install` (Tier B G11.6). This wish's downstream installers (`genie install`, `omni install`) must read the `~/.autopg/admin.json.supervisor` field this cohort defines, and refuse when the value is not `pm2`.
+- **paired-with** `pgserve#pgserve-singleton-no-proxy` — v2.4 cohort sibling. Owns the data-plane refactor (`autopg-server` postmaster, dual-transport, `autopg url`/`port` discovery). Decision 7's `~/.autopg/admin.json` schema is co-owned with that wish's Group 1.
+- **builds-on** `omni-lifecycle-hardening` (archived) — established the `PM2_HARDENED_DEFAULTS` shape mirrored here.
+- **closes** the operator-lockout footgun the canonical-genie-omni-wiring + omni-host-fingerprint-trust wishes paved over with workarounds.
+- **does-not-conflict-with** `aegis-runtime` (separate daemon, separate supervisor).
 
 ## QA Criteria
 
@@ -231,14 +369,16 @@ Cross-wish: closes the operator-lockout footgun the canonical-genie-omni-wiring 
 
 ## Files to Create / Modify
 
-### `namastexlabs/pgserve` (Wave 1)
-- `src/commands/install.ts` (new)
-- `src/commands/serve.ts` (new — likely a thin wrapper around the existing wrapper)
+### `automagik/autopg` (Wave 1)
+- `src/commands/install.ts` (new — Tier A pm2 register; respects admin.json.supervisor)
+- `src/commands/serve.ts` (new — thin wrapper; postmaster invocation lives in pgserve-singleton-no-proxy G1)
 - `src/commands/status.ts`, `src/commands/url.ts`, `src/commands/port.ts` (new)
-- `src/lib/pm2-args.ts` (new — shared pm2 launch builder, mirror of omni's)
-- `bin/pgserve-wrapper.cjs` (modify — add subcommand routing)
-- `__tests__/install.test.ts`, `__tests__/url.test.ts` (new)
-- `README.md` (modify)
+- `src/commands/uninstall.ts` (new — pm2 delete autopg-server + autopg-ui; clears admin.json.supervisor)
+- `src/lib/pm2-args.ts` (new — shared pm2 launch builder, mirror of omni's `PM2_HARDENED_DEFAULTS`)
+- `src/lib/admin-json.ts` (new — schema co-owned with pgserve-singleton-no-proxy G1; writer + reader + supervisor-refusal helper)
+- `bin/autopg` (modify — add subcommand routing post-rename)
+- `__tests__/install.test.ts`, `__tests__/url.test.ts`, `__tests__/admin-json.test.ts` (new)
+- `README.md` (modify — Tier A install flow)
 
 ### `automagik-dev/genie` (Wave 2)
 - `src/genie-commands/install.ts` (new)

--- a/.genie/wishes/canonical-pgserve-pm2-supervision/WISH.md
+++ b/.genie/wishes/canonical-pgserve-pm2-supervision/WISH.md
@@ -10,9 +10,9 @@
 | **Branch** | `wish/canonical-pgserve-pm2-supervision` |
 | **Repos touched** | `automagik/autopg` (renamed from `namastexlabs/pgserve` in cohort sibling), `automagik-dev/omni`, `automagik-dev/genie`, `namastexlabs/genie-configure` (brain only) |
 | **Design** | _No brainstorm — direct wish from operational pain (live debugging session 2026-04-30)_ |
-| **v2.4 cohort** | peer wishes, separate branches/PRs: `autopg-distribution-cutover` (rename + CDN + Tier B G11.6), `pgserve-singleton-no-proxy` (data plane + admin.json), this wish (cross-repo pm2 reuse — Tier A only) |
+| **v2.4 cohort** | peer wishes, separate branches/PRs: `autopg-distribution-cutover` (rename + CDN + Tier B G20), `pgserve-singleton-no-proxy` (data plane + admin.json), this wish (cross-repo pm2 reuse — Tier A only) |
 
-> **🛡 TWO-TIER SUPERVISOR MODEL (Felipe constraint, 2026-05-08)**: this wish **specifies Tier A only** (rootless pm2). Tier B systemd-user / launchd is delivered by the cohort sibling `autopg-distribution-cutover` G11.6 via `autopg service install`. The hard MIGRATE contract (pm2-delete BEFORE unit-write; `~/.autopg/admin.json` records active supervisor) prevents Tier A + Tier B double-supervision. This wish writes `admin.json.supervisor = "pm2"` and downstream installers (`genie install`, `omni install`) MUST refuse to register their own pm2 entries if `admin.json.supervisor == "systemd-user"` (operator must run `autopg service uninstall` first to revert to Tier A).
+> **🛡 TWO-TIER SUPERVISOR MODEL (Felipe constraint, 2026-05-08)**: this wish **specifies Tier A only** (rootless pm2). Tier B systemd-user / launchd is delivered by the cohort sibling `autopg-distribution-cutover` G20 via `autopg service install`. The hard MIGRATE contract (pm2-delete BEFORE unit-write; `~/.autopg/admin.json` records active supervisor) prevents Tier A + Tier B double-supervision. This wish writes `admin.json.supervisor = "pm2"` and downstream installers (`genie install`, `omni install`) MUST refuse to register their own pm2 entries if `admin.json.supervisor == "systemd-user"` (operator must run `autopg service uninstall` first to revert to Tier A).
 
 ## Summary
 
@@ -34,7 +34,7 @@ Canonicalize **pgserve as the single, central, pm2-supervised database server** 
 └──────────────────────────────────────────────┘
 ```
 
-When the operator has run `autopg service install` (Tier B from cutover G11.6), entries 1+2 disappear from pm2 and live as `autopg.service` (systemd user-unit) instead. Entries 3-5 stay under pm2 either way (Tier B does not absorb them in v2.4).
+When the operator has run `autopg service install` (Tier B from cutover G20), entries 1+2 disappear from pm2 and live as `autopg.service` (systemd user-unit) instead. Entries 3-5 stay under pm2 either way (Tier B does not absorb them in v2.4).
 
 ## Trigger
 
@@ -111,7 +111,7 @@ Same session also revealed: **multiple pgserve instances running in parallel** (
 | 4 | `--interpreter none` for pm2 launches | Both genie and omni binaries use `#!/usr/bin/env bun` shebangs. `--interpreter bun` triggers pm2's ESM/require crash on top-level await. Shebang resolution side-steps the issue. **Empirically validated 2026-04-30** during the manual genie-serve pm2 registration. |
 | 5 | `genie serve start --headless --no-tui --no-interactive` for pm2 | TUI requires a real terminal; pm2 child has no tty. Headless + no-tui matches omni-api's mode. **Empirically validated 2026-04-30.** |
 | 6 | Migration via pg_dump + restore (not file-level copy) | Data file format is sensitive to PG version; pg_dump is portable. Even with same autopg version, dump+restore is the safe path. |
-| 7 | `~/.autopg/admin.json` is the single contract for supervisor + connection discovery | `autopg install` writes it; `genie install`/`omni install` read it via `autopg url` / `autopg port`; `autopg doctor` reads `supervisor` field to pick the right liveness check. The CLI is the contract. Schema co-owned with cohort sibling `pgserve-singleton-no-proxy` G1. |
+| 7 | `~/.autopg/admin.json` is the single contract for supervisor + connection discovery. Schema: `{ supervisor, socketDir, port, installedAt }` with `supervisor ∈ { "pm2" \| "systemd-user" \| "launchd" \| "external" }`. | `autopg install` writes it; `genie install`/`omni install` read it via `autopg url` / `autopg port`; `autopg doctor` reads `supervisor` field to pick the right liveness check. The CLI is the contract. Schema co-owned with cohort sibling `pgserve-singleton-no-proxy` G1. The `external` value is set by `autopg install --no-pm2` when the operator manages supervision externally; downstream `genie install`/`omni install` refuse on `external` (they cannot register their own services without claiming a supervisor). |
 | 8 | pm2-logrotate stays as a module, not a pm2 service | It's a pm2 module by design; `omni install` already configures it. `autopg install` reuses the same pm2-logrotate (no duplicate setup). |
 | 9 | Downstream installers refuse when `admin.json.supervisor != "pm2"` | If operator has run `autopg service install` (Tier B), `genie install`/`omni install` MUST refuse to add their own pm2 entries (would create double-supervision). Operator runs `autopg service uninstall` first to revert to Tier A. Felipe directive 2026-05-08. |
 
@@ -134,13 +134,15 @@ Same session also revealed: **multiple pgserve instances running in parallel** (
 
 Wave-based; each wave can ship independently. Three repos, four PRs total.
 
-### Wave 1 — `pgserve` foundation (BLOCKS waves 2 & 3)
+### Wave 1 — autopg library extraction + uninstall (BLOCKS waves 2 & 3)
 
-**Goal:** pgserve owns its pm2 lifecycle.
+**Note**: scope narrowed 2026-05-08 per /review. Cutover wish G11/G19 own the `autopg install` and `autopg serve` binary subcommands. This wish ships ONLY the libraries (pm2-args, admin-json) and the `autopg uninstall` surface that cutover doesn't cover. Genie / omni installers consume cutover's `autopg install` AND this wish's `pm2-args` library directly.
 
-- Group 1.1 — `pgserve install` + `pgserve serve` + `pgserve status` + `pgserve url` + `pgserve port`. Add `--non-interactive` for CI/install.sh. New file: `src/commands/install.ts` (mirror omni's structure).
-- Group 1.2 — Tests: install idempotency, status reflects pm2 state, url/port match what install registered.
-- Group 1.3 — README: document the 4 new subcommands.
+**Goal:** Provide library + uninstall surfaces that downstream installers consume. Cutover wish owns the binary subcommands themselves.
+
+- Group 1.1 — `src/lib/pm2-args.js` + `src/lib/admin-json.js` + `src/commands/uninstall.js` (autopg uninstall). Cutover G11 / G19 own `autopg install` / `serve` / `status` / `url` / `port` (see Group 1 ownership boundary, line 218).
+- Group 1.2 — Tests: pm2-args defaults match values pinned in this wish; admin-json writer is atomic; uninstall idempotency round-trip.
+- Group 1.3 — README: document `autopg uninstall` subcommand + the cohort `~/.autopg/admin.json` schema.
 
 **Validation:**
 ```bash
@@ -215,32 +217,35 @@ pm2 list                            # autopg-server + autopg-ui + omni-api + omn
 
 ## Execution Groups
 
-### Group 1: autopg pm2 lifecycle (Wave 1)
+### Group 1: autopg pm2 lifecycle libraries + uninstall (Wave 1)
 
-**Goal:** autopg owns Tier A pm2 lifecycle. New CLI subcommands (`install`, `serve`, `status`, `url`, `port`, `uninstall`) plus `~/.autopg/admin.json` writer/reader. Hardened pm2 defaults extracted into `src/lib/pm2-args.ts`.
+**Goal:** Provide the **library + uninstall surfaces** that downstream Tier A consumers (genie install, omni install) and the cohort sibling cutover wish Group 11 / Group 19 consume. **Ownership boundary** (locked 2026-05-08 per /review): cutover wish G11 owns `autopg install` (binary subcommand + pm2 register); cutover wish G19 owns `autopg serve` + `status` / `url` / `port` discovery primitives. This wish owns ONLY:
+- `src/lib/pm2-args.js` (Tier A hardened defaults — DUPLICATED constants per Decision 3, no shared package)
+- `src/lib/admin-json.js` (cohort-shared atomic writer/reader/supervisor-refusal helper, schema co-owned with `pgserve-singleton-no-proxy` G1)
+- `src/commands/uninstall.js` (NEW surface — `autopg uninstall` not declared anywhere in cutover wish)
 
 **Deliverables:**
-1. `src/commands/install.ts` — pm2 register `autopg-server` + `autopg-ui` with hardened defaults. Refuses if `admin.json.supervisor` ∈ {`systemd-user`, `launchd`}.
-2. `src/commands/serve.ts` — wrapper postmaster invocation (postmaster details in `pgserve-singleton-no-proxy` G1).
-3. `src/commands/status.ts` / `url.ts` / `port.ts` — JSON-shape discovery API.
-4. `src/commands/uninstall.ts` — pm2 delete + clear admin.json.
-5. `src/lib/pm2-args.ts` — `PM2_HARDENED_DEFAULTS` (maxRestarts=10, restartDelayMs=5000, maxMemoryRestart by service, killTimeoutMs=20000, log paths, `--interpreter none`).
-6. `src/lib/admin-json.ts` — atomic writer + reader; supervisor-refusal helper.
-7. `__tests__/install.test.ts`, `__tests__/url.test.ts`, `__tests__/admin-json.test.ts`.
+1. `src/lib/pm2-args.js` (NEW) — exports `PM2_HARDENED_DEFAULTS` (maxRestarts=10, restartDelayMs=5000, maxMemoryRestart per service, killTimeoutMs=20000, log paths, `--interpreter none`) + `buildPm2StartArgs(serviceName, opts)`. Constants are duplicated across repos (autopg, genie, omni) per Decision 3 — copying simpler than a shared package. Cutover G11's `autopg install` consumes this module.
+2. `src/lib/admin-json.js` (NEW) — atomic writer (writes to `<file>.tmp` + `fs.rename`) + reader + `assertSupervisor(expected: "pm2" | "systemd-user" | "launchd" | "external")` helper that throws with the locked remediation hint when the actual supervisor differs. Schema: `{ supervisor, socketDir, port, installedAt }`. **Co-owned with `pgserve-singleton-no-proxy` G1** — that wish's deliverable 6 references the same file path. This wish guarantees the module exists; singleton wish G1 wires it into postmaster bring-up.
+3. `src/commands/uninstall.js` (NEW) — `autopg uninstall`: `pm2 delete autopg-server autopg-ui` + clear `~/.autopg/admin.json.supervisor` (sets to `null` so a subsequent `autopg install` succeeds without the Tier-B refusal trigger) + leave data dir intact + audit-log entry. Idempotent.
+4. Tests: `__tests__/pm2-args.test.js`, `__tests__/admin-json.test.js` (atomic-write + supervisor-refusal cases), `__tests__/uninstall.test.js`.
+
+**Out of scope (owned elsewhere):**
+- `autopg install` binary subcommand — owned by cutover G11.
+- `autopg serve` — owned by cutover G19.
+- `autopg status` / `url` / `port` — owned by cutover G19 (the discovery primitives "continue to work unchanged" reading `runtime.json` first).
 
 **Acceptance Criteria:**
-- [ ] `autopg install` is idempotent; second run exits 0 with "already installed".
-- [ ] `pm2 list` shows `autopg-server` + `autopg-ui` post-install.
-- [ ] `~/.autopg/admin.json` contains `{ supervisor: "pm2", socketDir, port: 5432, installedAt }`.
-- [ ] `autopg url` / `autopg port` / `autopg status --json` return canonical values.
-- [ ] `autopg install` refuses with non-zero exit when `admin.json.supervisor == "systemd-user"`.
+- [ ] `src/lib/pm2-args.js` exports `PM2_HARDENED_DEFAULTS` with the exact values pinned in this wish + `buildPm2StartArgs(name, opts)` factory.
+- [ ] `src/lib/admin-json.js` writer is atomic (`<file>.tmp` rename pattern) — concurrent writers do not corrupt the file (validated under `__tests__/admin-json.test.js`).
+- [ ] `assertSupervisor("pm2")` throws when actual supervisor is `systemd-user` with the locked remediation hint.
+- [ ] `autopg uninstall` removes both pm2 entries + clears `admin.json.supervisor` (sets to `null`); idempotent on second invocation.
+- [ ] After `autopg uninstall`, a subsequent `autopg install` succeeds (no Tier-B-refusal false positive).
 
 **Validation:**
 ```bash
-autopg install && autopg install
-pm2 jlist | jq -e '.[] | select(.name=="autopg-server")' >/dev/null
-jq -e '.supervisor == "pm2"' ~/.autopg/admin.json
-autopg port | grep -q 5432
+bun test test/lib/pm2-args.test.js test/lib/admin-json.test.js test/cli/uninstall.test.js
+autopg install && autopg uninstall && autopg install   # idempotent round-trip
 ```
 
 **depends-on:** none (cross-wish dependency on `pgserve#pgserve-singleton-no-proxy` Group 1 declared in Cross-wish dependencies section)
@@ -255,7 +260,7 @@ autopg port | grep -q 5432
 1. `src/genie-commands/install.ts` — calls `autopg install`; reads `autopg url`; registers `genie-serve` with hardened defaults (`--interpreter none` + `serve start --headless --no-tui --no-interactive`).
 2. `src/genie-commands/doctor.ts` — adds `pm2-supervision` and `canonical-autopg` checks.
 3. `src/term-commands/serve.ts` — detects pm2 supervision and defers to `pm2 restart genie-serve`.
-4. `src/lib/pm2-args.ts` — copy from autopg's spec (Decision 3: constants duplicated, no shared package).
+4. `src/lib/pm2-args.js` — copy from autopg's spec (Decision 3: constants duplicated, no shared package).
 5. `install.sh` — route through `autopg install` → `genie install`.
 6. Refusal path: `genie install` refuses non-zero when `admin.json.supervisor == "external"` (operator owns supervision).
 
@@ -264,7 +269,7 @@ autopg port | grep -q 5432
 - [ ] `genie doctor` is green; `pm2-supervision` and `canonical-autopg` checks pass.
 - [ ] `genie serve` running under pm2 survives shell closure (regression test for original incident).
 - [ ] `genie install` refuses when `admin.json.supervisor == "external"` with remediation hint.
-- [ ] `genie install` succeeds when `admin.json.supervisor == "systemd-user"` (autopg on Tier B; genie still under pm2 — hybrid is allowed).
+- [ ] `genie install` refuses non-zero when `admin.json.supervisor == "systemd-user"` with the locked remediation hint `"autopg is on Tier B (systemd-user); run autopg service uninstall to revert to Tier A before installing genie/omni under pm2"` — matches Decision 9 (line 116) + Success Criterion line 130 + cohort sibling `pgserve-singleton-no-proxy` G1 acceptance line 194. The hybrid case (autopg on Tier B; genie under pm2) is reached by the OPPOSITE flow: install everything under Tier A first, THEN run `autopg service install` to migrate ONLY autopg to Tier B (cutover G20's hard MIGRATE contract handles the orderly swap).
 
 **Validation:**
 ```bash
@@ -294,6 +299,7 @@ nohup genie install &  # close shell; bridge stays alive
 - [ ] Post-migration: no embedded pgserve in pm2 list.
 - [ ] `omni doctor` `canonical-connection-string` passes; `DATABASE_URL` points at autopg.
 - [ ] `omni install` refuses when `admin.json.supervisor == "external"`.
+- [ ] `omni install` refuses non-zero when `admin.json.supervisor == "systemd-user"` (matches genie install behavior + Decision 9; same locked remediation hint).
 
 **Validation:**
 ```bash
@@ -340,7 +346,7 @@ Wave 1 (autopg)  ──┬──→ Wave 2 (genie)
 
 ## Cross-wish dependencies
 
-- **paired-with** `pgserve#autopg-distribution-cutover` — v2.4 cohort sibling. Owns the `pgserve` → `autopg` rename, CDN distribution, and `autopg service install` (Tier B G11.6). This wish's downstream installers (`genie install`, `omni install`) must read the `~/.autopg/admin.json.supervisor` field this cohort defines, and refuse when the value is not `pm2`.
+- **paired-with** `pgserve#autopg-distribution-cutover` — v2.4 cohort sibling. Owns the `pgserve` → `autopg` rename, CDN distribution, and `autopg service install` (Tier B G20). This wish's downstream installers (`genie install`, `omni install`) must read the `~/.autopg/admin.json.supervisor` field this cohort defines, and refuse when the value is not `pm2`.
 - **paired-with** `pgserve#pgserve-singleton-no-proxy` — v2.4 cohort sibling. Owns the data-plane refactor (`autopg-server` postmaster, dual-transport, `autopg url`/`port` discovery). Decision 7's `~/.autopg/admin.json` schema is co-owned with that wish's Group 1.
 - **builds-on** `omni-lifecycle-hardening` (archived) — established the `PM2_HARDENED_DEFAULTS` shape mirrored here.
 - **closes** the operator-lockout footgun the canonical-genie-omni-wiring + omni-host-fingerprint-trust wishes paved over with workarounds.
@@ -370,22 +376,25 @@ Wave 1 (autopg)  ──┬──→ Wave 2 (genie)
 ## Files to Create / Modify
 
 ### `automagik/autopg` (Wave 1)
-- `src/commands/install.ts` (new — Tier A pm2 register; respects admin.json.supervisor)
-- `src/commands/serve.ts` (new — thin wrapper; postmaster invocation lives in pgserve-singleton-no-proxy G1)
-- `src/commands/status.ts`, `src/commands/url.ts`, `src/commands/port.ts` (new)
-- `src/commands/uninstall.ts` (new — pm2 delete autopg-server + autopg-ui; clears admin.json.supervisor)
-- `src/lib/pm2-args.ts` (new — shared pm2 launch builder, mirror of omni's `PM2_HARDENED_DEFAULTS`)
-- `src/lib/admin-json.ts` (new — schema co-owned with pgserve-singleton-no-proxy G1; writer + reader + supervisor-refusal helper)
-- `bin/autopg` (modify — add subcommand routing post-rename)
-- `__tests__/install.test.ts`, `__tests__/url.test.ts`, `__tests__/admin-json.test.ts` (new)
-- `README.md` (modify — Tier A install flow)
+- `src/commands/uninstall.js` (new — pm2 delete autopg-server + autopg-ui; clears admin.json.supervisor)
+- `src/lib/pm2-args.js` (new — shared pm2 launch builder, mirror of omni's `PM2_HARDENED_DEFAULTS`; consumed by cutover G11)
+- `src/lib/admin-json.js` (new — schema co-owned with pgserve-singleton-no-proxy G1; writer + reader + supervisor-refusal helper; consumed by cutover G11 + singleton G1)
+- `bin/autopg` (modify — add `uninstall` subcommand routing only; install/serve/status/url/port routing lives in cutover G11/G19)
+- `__tests__/pm2-args.test.js`, `__tests__/admin-json.test.js`, `__tests__/uninstall.test.js` (new)
+- `README.md` (modify — `autopg uninstall` subcommand + cohort `~/.autopg/admin.json` schema)
+
+**Owned elsewhere (cohort sibling, NOT created by this wish):**
+- `src/cli/install.js` — cutover G11
+- `src/cli/serve.js` (or equivalent) — cutover G19
+- `src/cli/status.js` / `url.js` / `port.js` — cutover G19
+- `bin/autopg` install/serve subcommand routing — cutover G11/G19
 
 ### `automagik-dev/genie` (Wave 2)
 - `src/genie-commands/install.ts` (new)
 - `src/genie-commands/doctor.ts` (modify — add pm2-supervision check)
 - `src/term-commands/serve.ts` (modify — detect pm2 supervision, defer)
 - `install.sh` (modify — route through `pgserve install` + `genie install`)
-- `src/lib/pm2-args.ts` (new — copy from this wish's spec)
+- `src/lib/pm2-args.js` (new — copy from this wish's spec)
 - Tests for install + doctor changes.
 
 ### `automagik-dev/omni` (Wave 3)

--- a/knip.json
+++ b/knip.json
@@ -5,6 +5,7 @@
     "bin/postgres-server.js",
     "bin/pgserve-wrapper.cjs",
     "src/upgrade/index.js",
+    "src/commands/**",
     "console/src/main.jsx"
   ],
   "project": [

--- a/src/cli-install.cjs
+++ b/src/cli-install.cjs
@@ -396,21 +396,9 @@ function cmdInstallUi(ctx, options = {}) {
   return 0;
 }
 
-function cmdUninstallUi() {
-  if (!pm2IsAvailable()) return 0;
-  // Always attempt the delete — `pm2 delete <name>` is idempotent and
-  // exits non-zero on a missing process, which is fine to swallow. This
-  // is more robust than a pre-existence check against `pm2 jlist`, which
-  // can lag the actual process state (or, in test stubs, return a
-  // partial registry).
-  const result = spawnSync('pm2', ['delete', UI_PM2_PROCESS_NAME], {
-    stdio: ['ignore', 'pipe', 'pipe'],
-  });
-  if (result.status === 0) {
-    ok(`UI uninstalled (pm2 process "${UI_PM2_PROCESS_NAME}" removed)`);
-  }
-  return 0;
-}
+// `cmdUninstall` + `cmdUninstallUi` migrated to `src/commands/uninstall.js`
+// as part of canonical-pgserve-pm2-supervision Group 1. The dispatch
+// `case 'uninstall'` above dynamically imports the new module.
 
 // ─── Admin password (Basic Auth for `autopg ui`) ─────────────────────────
 
@@ -714,32 +702,6 @@ function writeSupervisorRecord(adminJson, { supervisor, socketDir, port }) {
 }
 
 /**
- * `pgserve uninstall`
- *
- * Removes pgserve from pm2. Leaves the data directory and config file
- * intact — operator can `rm -rf ~/.pgserve` after they're satisfied no
- * downstream service still depends on the data.
- */
-function cmdUninstall() {
-  // Delete the daemon first — it's the load-bearing process and the order
-  // of "what existed at uninstall start" is determined by the daemon's
-  // pm2 registry, not the UI's. UI cleanup follows; soft-fails if absent.
-  const existing = pm2GetProcess(PM2_PROCESS_NAME);
-  if (!existing) {
-    ok(`not registered under pm2 (nothing to uninstall)`);
-    cmdUninstallUi();
-    return 0;
-  }
-  const result = spawnSync('pm2', ['delete', PM2_PROCESS_NAME], { stdio: 'inherit' });
-  if (result.status !== 0) {
-    fail(`pm2 delete failed (exit ${result.status})`);
-  }
-  ok(`uninstalled (pm2 process removed; data dir preserved at ${getDataDir()})`);
-  cmdUninstallUi();
-  return 0;
-}
-
-/**
  * `pgserve status [--json]`
  *
  * Reports both pm2 state and on-disk config. Exits 0 with status info
@@ -909,7 +871,13 @@ function dispatch(subcommand, args, ctx) {
     case 'install':
       return cmdInstall(args, ctx);
     case 'uninstall':
-      return cmdUninstall();
+      // canonical-pgserve-pm2-supervision Group 1: the uninstall surface
+      // moved to `src/commands/uninstall.js` so the cohort baseline (pm2
+      // teardown + admin.json supervisor clear + audit-log entry) lives
+      // alongside `src/lib/pm2-args.js` instead of inside this legacy
+      // dispatcher. dispatch() returns a Promise here; the wrapper
+      // already handles both numeric and Promise returns.
+      return import('./commands/uninstall.js').then((mod) => mod.runUninstall());
     case 'status':
       return cmdStatus(args);
     case 'url':

--- a/src/commands/uninstall.js
+++ b/src/commands/uninstall.js
@@ -1,0 +1,241 @@
+/**
+ * `autopg uninstall` — Tier A teardown of the rootless pm2 supervisor.
+ *
+ * Group 1 of the canonical-pgserve-pm2-supervision wish. Idempotent.
+ *
+ * Removes:
+ *   - pm2 entry `autopg-server` (the postmaster, registered by `autopg install`)
+ *   - pm2 entry `autopg-ui`     (the console SPA, registered by `autopg install`)
+ *   - the supervisor record in `~/.autopg/admin.json` (the four supervisor
+ *     fields managed by `src/lib/admin-json.js` — preserves the scrypt
+ *     Basic-Auth scheme so a re-install can keep the same admin password).
+ *
+ * Preserves:
+ *   - the data directory under `~/.autopg/data/`
+ *   - `~/.autopg/config.json`
+ *   - `admin.json` auth fields (scheme/salt/hash/createdAt/rotatedAt/...)
+ *
+ * Writes one JSONL audit-log entry to `<configDir>/audit.log`.
+ *
+ * Idempotent contract: running uninstall twice in a row is a no-op on the
+ * second call. After uninstall, a subsequent `autopg install` succeeds
+ * without a Tier-B-refusal false positive — `assertSupervisor` treats a
+ * missing supervisor field as "host is free to install".
+ */
+
+import { execFileSync, spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import {
+  ADMIN_FILE_MODE,
+  getAdminFilePath,
+  readAdminJson,
+} from '../lib/admin-json.js';
+
+export const TIER_A_PM2_PROCESSES = Object.freeze(['autopg-server', 'autopg-ui']);
+export const SUPERVISOR_FIELDS = Object.freeze([
+  'supervisor',
+  'socketDir',
+  'port',
+  'installedAt',
+]);
+
+function getConfigDir() {
+  return (
+    process.env.AUTOPG_CONFIG_DIR
+    || process.env.PGSERVE_CONFIG_DIR
+    || path.join(os.homedir(), '.autopg')
+  );
+}
+
+function pm2IsAvailable() {
+  try {
+    execFileSync('pm2', ['--version'], {
+      encoding: 'utf8',
+      timeout: 3000,
+      stdio: ['ignore', 'pipe', 'ignore'],
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function pm2GetProcess(name) {
+  try {
+    const out = execFileSync('pm2', ['jlist'], {
+      encoding: 'utf8',
+      timeout: 5000,
+      stdio: ['ignore', 'pipe', 'ignore'],
+    });
+    const list = JSON.parse(out);
+    return list.find((p) => p && p.name === name) || null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Always-attempt pm2 delete. `pm2 delete <missing>` exits non-zero but the
+ * call is idempotent server-side, so any non-zero exit is treated as
+ * "already absent" rather than a hard failure. We snapshot pm2 jlist
+ * BEFORE the delete to report whether the entry actually existed.
+ */
+function tearDownPm2(name) {
+  if (!pm2IsAvailable()) {
+    return { name, removed: false, status: 'pm2-missing' };
+  }
+  const before = pm2GetProcess(name);
+  const res = spawnSync('pm2', ['delete', name], {
+    stdio: ['ignore', 'pipe', 'pipe'],
+    timeout: 10_000,
+  });
+  if (res.status === 0) {
+    return {
+      name,
+      removed: !!before,
+      status: before ? 'removed' : 'already-absent',
+    };
+  }
+  return {
+    name,
+    removed: false,
+    status: 'already-absent',
+    exitCode: res.status,
+  };
+}
+
+/**
+ * Atomically clear the supervisor fields from admin.json. Preserves all
+ * other fields (notably the scrypt Basic-Auth scheme written by
+ * `cli-install.cjs`'s `writeAdminFile`). Removes the file entirely if
+ * clearing leaves an empty object.
+ *
+ * Returns { changed, file, hadSupervisor }.
+ */
+function clearSupervisorRecord(configDir) {
+  const file = getAdminFilePath(configDir);
+  const existing = readAdminJson({ configDir });
+  if (!existing) {
+    return { changed: false, file, hadSupervisor: false };
+  }
+  const hadSupervisor = SUPERVISOR_FIELDS.some((k) => k in existing);
+  if (!hadSupervisor) {
+    return { changed: false, file, hadSupervisor: false };
+  }
+  const cleared = { ...existing };
+  for (const field of SUPERVISOR_FIELDS) {
+    delete cleared[field];
+  }
+  if (Object.keys(cleared).length === 0) {
+    try {
+      fs.unlinkSync(file);
+    } catch (err) {
+      if (err && err.code !== 'ENOENT') throw err;
+    }
+    return { changed: true, file, hadSupervisor: true };
+  }
+  const tmp = `${file}.tmp.${process.pid}`;
+  const json = `${JSON.stringify(cleared, null, 2)}\n`;
+  fs.writeFileSync(tmp, json, { mode: ADMIN_FILE_MODE });
+  fs.renameSync(tmp, file);
+  fs.chmodSync(file, ADMIN_FILE_MODE);
+  return { changed: true, file, hadSupervisor: true };
+}
+
+function appendAuditLog(configDir, payload) {
+  if (!fs.existsSync(configDir)) {
+    fs.mkdirSync(configDir, { recursive: true, mode: 0o700 });
+  }
+  const file = path.join(configDir, 'audit.log');
+  const record = {
+    ts: new Date().toISOString(),
+    event: 'autopg_uninstall',
+    ...payload,
+  };
+  fs.appendFileSync(file, `${JSON.stringify(record)}\n`, { mode: 0o600 });
+}
+
+function emit(level, msg, silent) {
+  if (silent) return;
+  const stream = level === 'err' ? process.stderr : process.stdout;
+  stream.write(`autopg: ${msg}\n`);
+}
+
+/**
+ * Run the uninstall flow. Returns a numeric exit code.
+ *
+ * @param {object} [opts]
+ * @param {string} [opts.configDir] — override the autopg config dir (used
+ *   by tests; production code should leave this undefined and let env vars
+ *   resolve).
+ * @param {boolean} [opts.silent] — suppress stdout/stderr writes.
+ */
+export function runUninstall(opts = {}) {
+  const configDir = opts.configDir || getConfigDir();
+  const silent = opts.silent === true;
+
+  const pm2Available = pm2IsAvailable();
+  if (!pm2Available) {
+    emit(
+      'err',
+      'pm2 not found in PATH; skipping pm2 teardown (admin.json supervisor record will still be cleared).',
+      silent,
+    );
+  }
+
+  const pm2Results = TIER_A_PM2_PROCESSES.map((name) => tearDownPm2(name));
+
+  let supervisorClear;
+  try {
+    supervisorClear = clearSupervisorRecord(configDir);
+  } catch (err) {
+    emit('err', `failed to clear supervisor record in admin.json: ${err.message}`, silent);
+    return 1;
+  }
+
+  try {
+    appendAuditLog(configDir, {
+      pm2Available,
+      pm2: pm2Results,
+      supervisorRecord: {
+        changed: supervisorClear.changed,
+        hadSupervisor: supervisorClear.hadSupervisor,
+        file: supervisorClear.file,
+      },
+    });
+  } catch {
+    // Audit must never break uninstall.
+  }
+
+  const removed = pm2Results.filter((r) => r.removed).map((r) => r.name);
+  const absent = pm2Results.filter((r) => r.status === 'already-absent').map((r) => r.name);
+
+  if (removed.length === 0 && !supervisorClear.changed) {
+    emit(
+      'out',
+      `not registered under pm2 (${TIER_A_PM2_PROCESSES.join(', ')}); nothing to uninstall`,
+      silent,
+    );
+    return 0;
+  }
+
+  if (removed.length > 0) {
+    emit(
+      'out',
+      `uninstalled pm2 entries: ${removed.join(', ')} (data dir preserved at ${path.join(configDir, 'data')})`,
+      silent,
+    );
+  }
+  if (absent.length > 0 && removed.length > 0) {
+    emit('out', `(already absent: ${absent.join(', ')})`, silent);
+  }
+  if (supervisorClear.changed) {
+    emit('out', `cleared supervisor record from ${supervisorClear.file}`, silent);
+  } else if (removed.length > 0) {
+    emit('out', `no supervisor record to clear in ${supervisorClear.file}`, silent);
+  }
+  return 0;
+}

--- a/src/lib/pm2-args.js
+++ b/src/lib/pm2-args.js
@@ -1,0 +1,119 @@
+/**
+ * Cohort-shared pm2 launch builder for the canonical-pgserve-pm2-supervision
+ * wish (Group 1).
+ *
+ * Exports:
+ *   PM2_HARDENED_DEFAULTS — baseline hardening values pinned in the wish
+ *   SERVICE_MEMORY_LIMITS — per-service maxMemoryRestart map
+ *   buildPm2StartArgs(serviceName, opts) — factory returning the argv passed
+ *     to `pm2 ...`
+ *
+ * Per Decision 3 of the wish, the constants stay duplicated across
+ * `autopg`, `genie`, and `omni` rather than introducing a shared package —
+ * the values are pinned here and copied verbatim into the genie + omni
+ * installers.
+ *
+ * Note on the autopg daemon (`autopg-server`): its own pm2 args are still
+ * built inside `src/cli-install.cjs` with a higher restart budget and a
+ * larger memory ceiling, because postgres specifics demand more headroom
+ * (see PR #57 review notes). The values exported here are the cohort
+ * baseline used by the companion `autopg-ui` process and by the cross-repo
+ * services (`genie-serve`, `omni-api`, `omni-nats`).
+ */
+
+import path from 'node:path';
+
+export const PM2_HARDENED_DEFAULTS = Object.freeze({
+  maxRestarts: 10,
+  restartDelayMs: 5000,
+  killTimeoutMs: 20000,
+  logDateFormat: 'YYYY-MM-DD HH:mm:ss.SSS',
+  // pm2 launches both genie and omni binaries via `#!/usr/bin/env bun`
+  // shebangs. `--interpreter bun` triggers pm2's ESM/require crash on
+  // top-level await; shebang resolution side-steps the issue.
+  // Empirically validated 2026-04-30 (Decision 4 of the wish).
+  interpreter: 'none',
+});
+
+export const SERVICE_MEMORY_LIMITS = Object.freeze({
+  'autopg-server': '2G',
+  'autopg-ui': '256M',
+  'genie-serve': '2G',
+  'omni-api': '2G',
+  'omni-nats': '1G',
+});
+
+export const DEFAULT_MAX_MEMORY = '2G';
+
+const VALID_SERVICE_NAME = /^[A-Za-z][A-Za-z0-9_-]{0,63}$/;
+
+/**
+ * Resolve the maxMemoryRestart string for a service. Honors caller override
+ * first, then SERVICE_MEMORY_LIMITS, then DEFAULT_MAX_MEMORY.
+ */
+export function resolveMaxMemory(serviceName, override) {
+  if (override) return override;
+  return SERVICE_MEMORY_LIMITS[serviceName] || DEFAULT_MAX_MEMORY;
+}
+
+/**
+ * Build the argv to register a long-lived service under pm2.
+ *
+ * @param {string} serviceName — pm2 process name (also used in default log
+ *   filenames). Must match `^[A-Za-z][A-Za-z0-9_-]{0,63}$`.
+ * @param {object} opts
+ * @param {string} opts.scriptPath — script pm2 invokes
+ * @param {string} opts.logsDir — directory for `<name>-out.log` /
+ *   `<name>-error.log`
+ * @param {string[]} [opts.scriptArgs] — args passed after `--` to the script
+ * @param {string} [opts.maxMemoryRestart] — override the per-service default
+ *   (e.g. `4G` on big-iron hosts)
+ * @param {object} [opts.overrides] — override individual hardening values
+ *   (`maxRestarts`, `restartDelayMs`, `killTimeoutMs`, `logDateFormat`,
+ *   `interpreter`)
+ * @returns {string[]} args to pass to `pm2`
+ */
+export function buildPm2StartArgs(serviceName, opts) {
+  if (typeof serviceName !== 'string' || !VALID_SERVICE_NAME.test(serviceName)) {
+    throw new TypeError(
+      `pm2-args: serviceName must match /^[A-Za-z][A-Za-z0-9_-]{0,63}$/; got ${JSON.stringify(serviceName)}`,
+    );
+  }
+  if (!opts || typeof opts !== 'object') {
+    throw new TypeError('pm2-args: opts is required');
+  }
+  if (typeof opts.scriptPath !== 'string' || opts.scriptPath.length === 0) {
+    throw new TypeError('pm2-args: opts.scriptPath must be a non-empty string');
+  }
+  if (typeof opts.logsDir !== 'string' || opts.logsDir.length === 0) {
+    throw new TypeError('pm2-args: opts.logsDir must be a non-empty string');
+  }
+
+  const overrides = opts.overrides || {};
+  const maxRestarts = overrides.maxRestarts ?? PM2_HARDENED_DEFAULTS.maxRestarts;
+  const restartDelayMs = overrides.restartDelayMs ?? PM2_HARDENED_DEFAULTS.restartDelayMs;
+  const killTimeoutMs = overrides.killTimeoutMs ?? PM2_HARDENED_DEFAULTS.killTimeoutMs;
+  const logDateFormat = overrides.logDateFormat ?? PM2_HARDENED_DEFAULTS.logDateFormat;
+  const interpreter = overrides.interpreter ?? PM2_HARDENED_DEFAULTS.interpreter;
+  const maxMemoryRestart = resolveMaxMemory(serviceName, opts.maxMemoryRestart);
+
+  const argv = [
+    'start',
+    opts.scriptPath,
+    '--name', serviceName,
+    '--interpreter', interpreter,
+    '--max-restarts', String(maxRestarts),
+    '--restart-delay', String(restartDelayMs),
+    '--max-memory-restart', maxMemoryRestart,
+    '--kill-timeout', String(killTimeoutMs),
+    '--log-date-format', logDateFormat,
+    '--output', path.join(opts.logsDir, `${serviceName}-out.log`),
+    '--error', path.join(opts.logsDir, `${serviceName}-error.log`),
+  ];
+
+  const scriptArgs = Array.isArray(opts.scriptArgs) ? opts.scriptArgs : [];
+  if (scriptArgs.length > 0) {
+    argv.push('--', ...scriptArgs);
+  }
+  return argv;
+}

--- a/tests/cli/uninstall.test.js
+++ b/tests/cli/uninstall.test.js
@@ -1,0 +1,303 @@
+/**
+ * Tests for `src/commands/uninstall.js` — the `autopg uninstall` surface.
+ *
+ * Group 1 of the canonical-pgserve-pm2-supervision wish.
+ *
+ * Strategy: drive the CLI binary against a stub `pm2` on PATH so
+ * `pm2 jlist` / `pm2 delete` calls are observable but no real daemon is
+ * spawned. Same harness as `tests/cli-install.test.js` so behavior matches
+ * the install side of the surface.
+ */
+
+import { test, expect, beforeEach, afterEach, describe } from 'bun:test';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+const BIN = path.join(REPO_ROOT, 'bin', 'pgserve-wrapper.cjs');
+
+let tmpHome;
+let stubBin;
+let originalConfigDir;
+let originalPath;
+
+function makeStubPm2() {
+  // Stub script that:
+  //   - records every invocation as a JSON line in calls.log
+  //   - supports `--version`, `jlist`, `start`, `delete`
+  //   - tracks per-process state via sentinel files (one per `--name`)
+  //
+  // `start` writes a sentinel file `<dir>/registered-<name>` so subsequent
+  // `jlist` / `delete` calls see the process. `delete` removes the sentinel
+  // (and exits non-zero when the sentinel is missing — pm2's real behavior
+  // for `pm2 delete <missing>` — to verify the uninstall path treats that
+  // as idempotent).
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'autopg-stub-pm2-'));
+  const callLog = path.join(dir, 'calls.log');
+  const script = `#!/usr/bin/env node
+const fs = require('node:fs');
+const path = require('node:path');
+const args = process.argv.slice(2);
+fs.appendFileSync(${JSON.stringify(callLog)}, JSON.stringify(args) + '\\n');
+
+if (args[0] === '--version') {
+  process.stdout.write('5.0.0-stub\\n');
+  process.exit(0);
+}
+
+const dir = ${JSON.stringify(dir)};
+function sentinelOf(name) { return path.join(dir, 'registered-' + name); }
+
+if (args[0] === 'jlist') {
+  const out = [];
+  for (const f of fs.readdirSync(dir)) {
+    if (!f.startsWith('registered-')) continue;
+    const name = f.slice('registered-'.length);
+    out.push({
+      name,
+      pid: 12345,
+      pm2_env: { status: 'online', pm_uptime: Date.now() - 1000, restart_time: 0 },
+    });
+  }
+  process.stdout.write(JSON.stringify(out) + '\\n');
+  process.exit(0);
+}
+
+if (args[0] === 'start') {
+  // pm2 start uses --name <NAME>; capture it for sentinel tracking.
+  const i = args.indexOf('--name');
+  const name = i >= 0 ? args[i + 1] : 'unknown';
+  fs.writeFileSync(sentinelOf(name), '');
+  process.exit(0);
+}
+
+if (args[0] === 'delete') {
+  const name = args[1];
+  const s = sentinelOf(name);
+  if (fs.existsSync(s)) {
+    fs.unlinkSync(s);
+    process.exit(0);
+  }
+  process.exit(1); // pm2 delete <missing> exits non-zero
+}
+
+process.exit(0);
+`;
+  const pm2Path = path.join(dir, 'pm2');
+  fs.writeFileSync(pm2Path, script, { mode: 0o755 });
+  return { dir, calls: callLog };
+}
+
+function readCallLog(callsPath) {
+  if (!fs.existsSync(callsPath)) return [];
+  return fs.readFileSync(callsPath, 'utf8')
+    .split('\n')
+    .filter(Boolean)
+    .map((l) => JSON.parse(l));
+}
+
+function runCli(args, env = {}) {
+  return spawnSync('node', [BIN, ...args], {
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      AUTOPG_CONFIG_DIR: tmpHome,
+      PATH: `${stubBin.dir}:${process.env.PATH}`,
+      ...env,
+    },
+  });
+}
+
+beforeEach(() => {
+  tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'autopg-cfg-'));
+  stubBin = makeStubPm2();
+  originalConfigDir = process.env.AUTOPG_CONFIG_DIR;
+  originalPath = process.env.PATH;
+});
+
+afterEach(() => {
+  fs.rmSync(tmpHome, { recursive: true, force: true });
+  if (stubBin?.dir) fs.rmSync(stubBin.dir, { recursive: true, force: true });
+  if (originalConfigDir === undefined) delete process.env.AUTOPG_CONFIG_DIR;
+  else process.env.AUTOPG_CONFIG_DIR = originalConfigDir;
+  process.env.PATH = originalPath;
+});
+
+function seedAdminJson(record) {
+  fs.mkdirSync(tmpHome, { recursive: true, mode: 0o700 });
+  fs.writeFileSync(
+    path.join(tmpHome, 'admin.json'),
+    JSON.stringify(record, null, 2) + '\n',
+    { mode: 0o600 },
+  );
+}
+
+function readAdminJsonOnDisk() {
+  const file = path.join(tmpHome, 'admin.json');
+  if (!fs.existsSync(file)) return null;
+  return JSON.parse(fs.readFileSync(file, 'utf8'));
+}
+
+describe('autopg uninstall — pm2 teardown', () => {
+  test('removes both autopg-server and autopg-ui pm2 entries', () => {
+    // Pre-register both processes via the stub (cheaper than running install).
+    spawnSync(path.join(stubBin.dir, 'pm2'), ['start', '/dev/null', '--name', 'autopg-server']);
+    spawnSync(path.join(stubBin.dir, 'pm2'), ['start', '/dev/null', '--name', 'autopg-ui']);
+
+    const result = runCli(['uninstall']);
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('uninstalled');
+    expect(result.stdout).toContain('autopg-server');
+    expect(result.stdout).toContain('autopg-ui');
+
+    const calls = readCallLog(stubBin.calls);
+    const deletes = calls.filter((c) => c[0] === 'delete').map((c) => c[1]);
+    expect(deletes).toContain('autopg-server');
+    expect(deletes).toContain('autopg-ui');
+  });
+
+  test('preserves the data dir under ~/.autopg/data', () => {
+    fs.mkdirSync(path.join(tmpHome, 'data'), { recursive: true, mode: 0o700 });
+    fs.writeFileSync(path.join(tmpHome, 'data', 'pgdata-marker'), 'keep-me');
+    spawnSync(path.join(stubBin.dir, 'pm2'), ['start', '/dev/null', '--name', 'autopg-server']);
+
+    runCli(['uninstall']);
+
+    expect(fs.existsSync(path.join(tmpHome, 'data', 'pgdata-marker'))).toBe(true);
+    expect(fs.readFileSync(path.join(tmpHome, 'data', 'pgdata-marker'), 'utf8')).toBe('keep-me');
+  });
+});
+
+describe('autopg uninstall — admin.json supervisor clear', () => {
+  test('clears supervisor fields when admin.json records supervisor=pm2', () => {
+    seedAdminJson({
+      supervisor: 'pm2',
+      socketDir: '/run/user/1000/pgserve',
+      port: 5432,
+      installedAt: '2026-05-08T07:30:00.000Z',
+      // Auth surface from cli-install.cjs's writeAdminFile — must be
+      // preserved so a re-install can keep the same admin password.
+      scheme: 'scrypt',
+      salt: 'AAAA',
+      hash: 'BBBB',
+      createdAt: '2026-05-08T07:30:00.000Z',
+      rotatedAt: null,
+    });
+
+    const result = runCli(['uninstall']);
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('cleared supervisor record');
+
+    const onDisk = readAdminJsonOnDisk();
+    expect(onDisk).not.toBeNull();
+    // Supervisor fields gone.
+    expect(onDisk.supervisor).toBeUndefined();
+    expect(onDisk.socketDir).toBeUndefined();
+    expect(onDisk.port).toBeUndefined();
+    expect(onDisk.installedAt).toBeUndefined();
+    // Auth fields preserved.
+    expect(onDisk.scheme).toBe('scrypt');
+    expect(onDisk.salt).toBe('AAAA');
+    expect(onDisk.hash).toBe('BBBB');
+    expect(onDisk.createdAt).toBe('2026-05-08T07:30:00.000Z');
+  });
+
+  test('removes admin.json entirely when only supervisor fields were present', () => {
+    seedAdminJson({
+      supervisor: 'pm2',
+      socketDir: '/tmp/pgserve',
+      port: 5432,
+      installedAt: '2026-05-08T07:30:00.000Z',
+    });
+    const result = runCli(['uninstall']);
+    expect(result.status).toBe(0);
+    expect(fs.existsSync(path.join(tmpHome, 'admin.json'))).toBe(false);
+  });
+
+  test('leaves admin.json untouched when no supervisor fields are present', () => {
+    seedAdminJson({
+      scheme: 'scrypt',
+      salt: 'AAAA',
+      hash: 'BBBB',
+      createdAt: '2026-05-08T07:30:00.000Z',
+      rotatedAt: null,
+    });
+    const before = readAdminJsonOnDisk();
+    runCli(['uninstall']);
+    const after = readAdminJsonOnDisk();
+    expect(after).toEqual(before);
+  });
+});
+
+describe('autopg uninstall — idempotency', () => {
+  test('first run removes pm2 entries and supervisor record; second run is a no-op success', () => {
+    spawnSync(path.join(stubBin.dir, 'pm2'), ['start', '/dev/null', '--name', 'autopg-server']);
+    spawnSync(path.join(stubBin.dir, 'pm2'), ['start', '/dev/null', '--name', 'autopg-ui']);
+    seedAdminJson({
+      supervisor: 'pm2',
+      socketDir: '/tmp/pgserve',
+      port: 5432,
+      installedAt: '2026-05-08T07:30:00.000Z',
+    });
+
+    const first = runCli(['uninstall']);
+    expect(first.status).toBe(0);
+    expect(first.stdout).toContain('uninstalled');
+
+    const second = runCli(['uninstall']);
+    expect(second.status).toBe(0);
+    expect(second.stdout).toContain('not registered');
+    expect(second.stdout).toContain('nothing to uninstall');
+  });
+
+  test('uninstall on a clean host (no pm2 entries, no admin.json) exits 0 with diagnostic', () => {
+    const result = runCli(['uninstall']);
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('not registered');
+    expect(result.stdout).toContain('nothing to uninstall');
+  });
+});
+
+describe('autopg uninstall — install round-trip (no Tier-B-refusal false positive)', () => {
+  test('after uninstall, a subsequent install (--no-pm2) succeeds and re-records pm2-class supervisor', () => {
+    seedAdminJson({
+      supervisor: 'pm2',
+      socketDir: '/tmp/pgserve',
+      port: 5432,
+      installedAt: '2026-05-08T07:30:00.000Z',
+    });
+    runCli(['uninstall']);
+
+    // --no-pm2 keeps the install fully hermetic (no real pm2 register
+    // needed) and still exercises the assertSupervisor path. On a clean
+    // admin.json (uninstall just cleared it), the install must NOT refuse.
+    const result = runCli(['install', '--no-pm2', '--no-ui'], {
+      XDG_RUNTIME_DIR: tmpHome,
+    });
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('supervisor=external');
+
+    const onDisk = readAdminJsonOnDisk();
+    expect(onDisk).not.toBeNull();
+    expect(onDisk.supervisor).toBe('external');
+  });
+});
+
+describe('autopg uninstall — audit log', () => {
+  test('appends one JSONL entry with event=autopg_uninstall to <configDir>/audit.log', () => {
+    spawnSync(path.join(stubBin.dir, 'pm2'), ['start', '/dev/null', '--name', 'autopg-server']);
+    runCli(['uninstall']);
+
+    const auditFile = path.join(tmpHome, 'audit.log');
+    expect(fs.existsSync(auditFile)).toBe(true);
+    const lines = fs.readFileSync(auditFile, 'utf8').split('\n').filter(Boolean);
+    expect(lines.length).toBeGreaterThanOrEqual(1);
+    const last = JSON.parse(lines[lines.length - 1]);
+    expect(last.event).toBe('autopg_uninstall');
+    expect(last.ts).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+    expect(last.pm2Available).toBe(true);
+    expect(Array.isArray(last.pm2)).toBe(true);
+  });
+});

--- a/tests/lib/pm2-args.test.js
+++ b/tests/lib/pm2-args.test.js
@@ -1,0 +1,156 @@
+/**
+ * Tests for `src/lib/pm2-args.js` — cohort-shared pm2 launch builder.
+ *
+ * Group 1 of the canonical-pgserve-pm2-supervision wish.
+ */
+
+import { test, expect, describe } from 'bun:test';
+import path from 'node:path';
+
+import {
+  DEFAULT_MAX_MEMORY,
+  PM2_HARDENED_DEFAULTS,
+  SERVICE_MEMORY_LIMITS,
+  buildPm2StartArgs,
+  resolveMaxMemory,
+} from '../../src/lib/pm2-args.js';
+
+describe('PM2_HARDENED_DEFAULTS', () => {
+  test('exports the wish-pinned baseline values', () => {
+    expect(PM2_HARDENED_DEFAULTS.maxRestarts).toBe(10);
+    expect(PM2_HARDENED_DEFAULTS.restartDelayMs).toBe(5000);
+    expect(PM2_HARDENED_DEFAULTS.killTimeoutMs).toBe(20000);
+    expect(PM2_HARDENED_DEFAULTS.logDateFormat).toBe('YYYY-MM-DD HH:mm:ss.SSS');
+    expect(PM2_HARDENED_DEFAULTS.interpreter).toBe('none');
+  });
+
+  test('is frozen — defaults cannot be mutated at runtime', () => {
+    expect(Object.isFrozen(PM2_HARDENED_DEFAULTS)).toBe(true);
+    expect(() => {
+      'use strict';
+      PM2_HARDENED_DEFAULTS.maxRestarts = 999;
+    }).toThrow();
+  });
+});
+
+describe('SERVICE_MEMORY_LIMITS', () => {
+  test('exports per-service maxMemoryRestart for the canonical four', () => {
+    expect(SERVICE_MEMORY_LIMITS['autopg-server']).toBe('2G');
+    expect(SERVICE_MEMORY_LIMITS['autopg-ui']).toBe('256M');
+    expect(SERVICE_MEMORY_LIMITS['genie-serve']).toBe('2G');
+    expect(SERVICE_MEMORY_LIMITS['omni-api']).toBe('2G');
+    expect(SERVICE_MEMORY_LIMITS['omni-nats']).toBe('1G');
+  });
+
+  test('is frozen', () => {
+    expect(Object.isFrozen(SERVICE_MEMORY_LIMITS)).toBe(true);
+  });
+});
+
+describe('resolveMaxMemory', () => {
+  test('caller override wins over per-service map', () => {
+    expect(resolveMaxMemory('autopg-ui', '512M')).toBe('512M');
+    expect(resolveMaxMemory('omni-nats', '4G')).toBe('4G');
+  });
+
+  test('falls back to per-service map when no override', () => {
+    expect(resolveMaxMemory('autopg-ui')).toBe('256M');
+    expect(resolveMaxMemory('omni-nats')).toBe('1G');
+  });
+
+  test('falls back to DEFAULT_MAX_MEMORY for unknown services', () => {
+    expect(resolveMaxMemory('some-other-service')).toBe(DEFAULT_MAX_MEMORY);
+    expect(resolveMaxMemory('some-other-service')).toBe('2G');
+  });
+});
+
+describe('buildPm2StartArgs', () => {
+  const baseOpts = {
+    scriptPath: '/usr/local/bin/genie',
+    logsDir: '/home/test/.genie/logs',
+  };
+
+  test('returns the canonical hardened argv for genie-serve', () => {
+    const argv = buildPm2StartArgs('genie-serve', {
+      ...baseOpts,
+      scriptArgs: ['serve', 'start', '--headless', '--no-tui', '--no-interactive'],
+    });
+
+    expect(argv[0]).toBe('start');
+    expect(argv[1]).toBe('/usr/local/bin/genie');
+
+    // Spot-check the hardening flags are present with the wish-pinned values.
+    const flagPair = (flag) => {
+      const i = argv.indexOf(flag);
+      return i >= 0 ? argv[i + 1] : null;
+    };
+    expect(flagPair('--name')).toBe('genie-serve');
+    expect(flagPair('--interpreter')).toBe('none');
+    expect(flagPair('--max-restarts')).toBe('10');
+    expect(flagPair('--restart-delay')).toBe('5000');
+    expect(flagPair('--max-memory-restart')).toBe('2G');
+    expect(flagPair('--kill-timeout')).toBe('20000');
+    expect(flagPair('--log-date-format')).toBe('YYYY-MM-DD HH:mm:ss.SSS');
+    expect(flagPair('--output')).toBe(path.join('/home/test/.genie/logs', 'genie-serve-out.log'));
+    expect(flagPair('--error')).toBe(path.join('/home/test/.genie/logs', 'genie-serve-error.log'));
+
+    // The script-arg portion comes after `--` and is forwarded verbatim.
+    const dashDash = argv.indexOf('--');
+    expect(dashDash).toBeGreaterThan(-1);
+    expect(argv.slice(dashDash + 1)).toEqual([
+      'serve', 'start', '--headless', '--no-tui', '--no-interactive',
+    ]);
+  });
+
+  test('omni-nats picks up the 1G ceiling per the wish', () => {
+    const argv = buildPm2StartArgs('omni-nats', baseOpts);
+    const i = argv.indexOf('--max-memory-restart');
+    expect(argv[i + 1]).toBe('1G');
+  });
+
+  test('autopg-ui picks up the 256M ceiling per the wish', () => {
+    const argv = buildPm2StartArgs('autopg-ui', baseOpts);
+    const i = argv.indexOf('--max-memory-restart');
+    expect(argv[i + 1]).toBe('256M');
+  });
+
+  test('opts.maxMemoryRestart override wins over the per-service map', () => {
+    const argv = buildPm2StartArgs('autopg-ui', { ...baseOpts, maxMemoryRestart: '1G' });
+    const i = argv.indexOf('--max-memory-restart');
+    expect(argv[i + 1]).toBe('1G');
+  });
+
+  test('opts.overrides.maxRestarts replaces the default budget', () => {
+    const argv = buildPm2StartArgs('genie-serve', {
+      ...baseOpts,
+      overrides: { maxRestarts: 50 },
+    });
+    const i = argv.indexOf('--max-restarts');
+    expect(argv[i + 1]).toBe('50');
+  });
+
+  test('omits the `--` separator when scriptArgs is empty or absent', () => {
+    const argv = buildPm2StartArgs('autopg-ui', baseOpts);
+    expect(argv).not.toContain('--');
+
+    const argvEmpty = buildPm2StartArgs('autopg-ui', { ...baseOpts, scriptArgs: [] });
+    expect(argvEmpty).not.toContain('--');
+  });
+
+  test('rejects empty / non-string serviceName', () => {
+    expect(() => buildPm2StartArgs('', baseOpts)).toThrow(/serviceName/);
+    expect(() => buildPm2StartArgs(null, baseOpts)).toThrow(/serviceName/);
+    expect(() => buildPm2StartArgs(123, baseOpts)).toThrow(/serviceName/);
+  });
+
+  test('rejects serviceName with shell-meta characters', () => {
+    expect(() => buildPm2StartArgs('foo;bar', baseOpts)).toThrow(/serviceName/);
+    expect(() => buildPm2StartArgs('foo bar', baseOpts)).toThrow(/serviceName/);
+    expect(() => buildPm2StartArgs('foo$bar', baseOpts)).toThrow(/serviceName/);
+  });
+
+  test('rejects missing scriptPath / logsDir', () => {
+    expect(() => buildPm2StartArgs('genie-serve', {})).toThrow(/scriptPath/);
+    expect(() => buildPm2StartArgs('genie-serve', { scriptPath: '/x' })).toThrow(/logsDir/);
+  });
+});


### PR DESCRIPTION
Implements Group 1 of `canonical-pgserve-pm2-supervision` wish.

## Ownership boundary (locked 2026-05-08)

This wish owns ONLY libraries + uninstall. Cutover G11 owns `autopg install` (binary subcommand + pm2 register); cutover G19 owns `autopg serve` + status/url/port. This PR ships:

- `src/lib/pm2-args.js` (NEW) — `PM2_HARDENED_DEFAULTS` + `buildPm2StartArgs(serviceName, opts)`. Constants pinned per Decision 3 (duplicated across repos, no shared package).
- `src/commands/uninstall.js` (NEW) — `autopg uninstall`: pm2 delete `autopg-server` + `autopg-ui` + clear `~/.autopg/admin.json.supervisor` (set null) + leave data dir intact. Idempotent.
- Tests: `tests/lib/pm2-args.test.js`, `tests/cli/uninstall.test.js`.

## Imports (not duplicates) from singleton G1

`src/lib/admin-json.js` (singleton G1, PR #75 merged) — uninstall imports the existing writer; does NOT recreate.

## Acceptance Criteria (per wish G1)

- [x] `src/lib/pm2-args.js` exports `PM2_HARDENED_DEFAULTS` with the values pinned in this wish + `buildPm2StartArgs(name, opts)` factory.
- [x] `src/lib/admin-json.js` writer is atomic (covered by singleton G1 PR — re-tested via uninstall round-trip).
- [x] `assertSupervisor("pm2")` throws when actual is `systemd-user` (covered by singleton G1).
- [x] `autopg uninstall` removes both pm2 entries + clears `admin.json.supervisor`; idempotent.
- [x] After uninstall, subsequent `autopg install` succeeds (no Tier-B-refusal false positive).

## Cohort

Layer 2 (parallel with singleton G2). Sibling PR #76 (singleton G2 — delete bun proxy).