### PR TITLE
feat(singleton#4): cosign verify (WIP — tests pending)

### DIFF
--- a/bin/pgserve-wrapper.cjs
+++ b/bin/pgserve-wrapper.cjs
@@ -43,6 +43,10 @@ const __installSubcommands = new Set([
   'upgrade',
   'restart',
   'ui',
+  // pgserve singleton (v2.4) — `pgserve-singleton-no-proxy` wish, Group 4.
+  // `verify` shells out to cosign + writes an HMAC cache token. Pure node
+  // (no bun) so it must skip the bun probe like the install surface above.
+  'verify',
 ]);
 if (__subcommand && __installSubcommands.has(__subcommand)) {
   const cli = require(path.join(__dirname, '..', 'src', 'cli-install.cjs'));

--- a/knip.json
+++ b/knip.json
@@ -6,6 +6,7 @@
     "bin/pgserve-wrapper.cjs",
     "src/upgrade/index.js",
     "src/commands/**",
+    "src/cosign/**",
     "console/src/main.jsx"
   ],
   "project": [

--- a/src/cli-install.cjs
+++ b/src/cli-install.cjs
@@ -913,6 +913,13 @@ function dispatch(subcommand, args, ctx) {
     }
     case 'auth':
       return cmdAuthDispatch(args);
+    case 'verify': {
+      // pgserve singleton (v2.4) — `pgserve-singleton-no-proxy` wish, Group 4.
+      // `pgserve verify` is a pure-node command (cosign shellout + HMAC
+      // cache token write); routes through the same async-import pattern
+      // as `uninstall` so the ESM module isn't eagerly loaded.
+      return import('./commands/verify.js').then((mod) => mod.runVerify(args));
+    }
     default:
       throw new Error(`pgserve: dispatch called with unknown subcommand "${subcommand}"`);
   }

--- a/src/commands/verify.js
+++ b/src/commands/verify.js
@@ -1,0 +1,345 @@
+/**
+ * `pgserve verify <binary-path>` — cosign-keyless-OIDC verification.
+ *
+ * pgserve singleton (v2.4) — `pgserve-singleton-no-proxy` wish, Group 4.
+ *
+ * Flow:
+ *   1. Resolve target binary, compute realpath + sha256 + size + mtime.
+ *   2. Look up the HMAC-signed cache at `$XDG_STATE_HOME/pgserve/verified/
+ *      <fingerprint>.token`. If valid (HMAC matches, sliding expiry not
+ *      lapsed, binary attestation matches mtime/size) → short-circuit.
+ *   3. Otherwise call `verifyBinary()` (cosign verify-blob against the
+ *      hardcoded trust list per `src/cosign/trust-list.js`).
+ *   4. On success: persist the cache token (mode 0600). On failure: emit
+ *      a diagnostic and exit non-zero.
+ *
+ * Flags:
+ *   --json                 — emit machine-readable result on stdout
+ *   --skip-sigstore        — bypass cosign and consult the operator's
+ *                            offline trust file. Refuses unless the file
+ *                            records at least one offline-cosign-key entry
+ *                            (managed by G3's `pgserve trust add`).
+ *   --bundle <path>        — override the sigstore bundle sidecar path
+ *   --cosign-bin <path>    — override the cosign executable
+ *   --allow-fetch          — let cosign be fetched if missing on PATH
+ *   --no-cache             — never read or write the verified-cache token
+ *
+ * Exit codes:
+ *   0  — verified (fresh or cache hit)
+ *   2  — verification failed (cosign rejected, tampered binary, ...)
+ *   3  — invocation problem (--skip-sigstore without pretrusted key,
+ *         missing binary, missing bundle, no cosign on PATH, ...)
+ */
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import {
+  buildTokenPayload,
+  computeBinaryAttestation,
+  deleteCacheToken,
+  getStateDir,
+  readCacheToken,
+  touchCacheToken,
+  writeCacheToken,
+} from '../cosign/cache-token.js';
+import { sha256File, verifyBinary } from '../cosign/verify-binary.js';
+
+const EXIT_OK = 0;
+const EXIT_VERIFY_FAILED = 2;
+const EXIT_INVOCATION = 3;
+
+/**
+ * Compute the cache fingerprint for a binary. We use the realpath +
+ * sha256 first 32 chars so two distinct binaries get distinct cache
+ * entries even if they share a directory layout, while keeping the
+ * filename short enough to be readable in `ls`.
+ */
+export function computeFingerprint(binaryRealpath, sha256) {
+  return `${path.basename(binaryRealpath).replace(/[^A-Za-z0-9._-]/g, '_')}.${sha256.slice(0, 16)}`;
+}
+
+function getTrustFilePath() {
+  if (process.env.PGSERVE_TRUST_FILE) return process.env.PGSERVE_TRUST_FILE;
+  const home = process.env.HOME || os.homedir();
+  return path.join(home, '.pgserve', 'trust', 'identities.json');
+}
+
+/**
+ * Load the operator-managed offline trust file. G3's `pgserve trust add
+ * --offline-cosign-key` writes to this path; in G4 we only consume it.
+ *
+ * Expected shape:
+ *   {
+ *     offlineKeys: [
+ *       { id: '<short-id>', publisher: '<package>', keyFingerprint: '...',
+ *         addedAt: '<ISO>' },
+ *       ...
+ *     ]
+ *   }
+ */
+function readOfflineTrust() {
+  const file = getTrustFilePath();
+  if (!fs.existsSync(file)) return { ok: false, reason: 'trust-file-missing', file };
+  let raw;
+  try {
+    raw = fs.readFileSync(file, 'utf8');
+  } catch (err) {
+    return { ok: false, reason: 'trust-file-unreadable', detail: err.message, file };
+  }
+  let doc;
+  try {
+    doc = JSON.parse(raw);
+  } catch (err) {
+    return { ok: false, reason: 'trust-file-malformed', detail: err.message, file };
+  }
+  const keys = Array.isArray(doc?.offlineKeys) ? doc.offlineKeys : null;
+  if (!keys || keys.length === 0) {
+    return { ok: false, reason: 'no-offline-keys', file };
+  }
+  return { ok: true, keys, file };
+}
+
+function parseArgs(args) {
+  const opts = {
+    binaryPath: null,
+    json: false,
+    skipSigstore: false,
+    bundlePath: null,
+    cosignBin: null,
+    allowFetch: false,
+    noCache: false,
+  };
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i];
+    if (a === '--json') opts.json = true;
+    else if (a === '--skip-sigstore') opts.skipSigstore = true;
+    else if (a === '--allow-fetch') opts.allowFetch = true;
+    else if (a === '--no-cache') opts.noCache = true;
+    else if (a === '--bundle') opts.bundlePath = args[++i];
+    else if (a === '--cosign-bin') opts.cosignBin = args[++i];
+    else if (a === '--help' || a === '-h') {
+      printHelp(process.stdout);
+      return { exit: EXIT_OK };
+    } else if (a.startsWith('-')) {
+      process.stderr.write(`pgserve verify: unknown option ${JSON.stringify(a)}\n`);
+      return { exit: EXIT_INVOCATION };
+    } else if (opts.binaryPath === null) {
+      opts.binaryPath = a;
+    } else {
+      process.stderr.write(`pgserve verify: unexpected positional argument ${JSON.stringify(a)}\n`);
+      return { exit: EXIT_INVOCATION };
+    }
+  }
+  if (!opts.binaryPath) {
+    printHelp(process.stderr);
+    return { exit: EXIT_INVOCATION };
+  }
+  return { opts };
+}
+
+function printHelp(stream) {
+  stream.write(`pgserve verify <binary-path> [options]
+
+Verify a binary against the cosign keyless OIDC trust list. On success,
+persists an HMAC-signed cache token so subsequent invocations short-circuit
+the cosign call until the binary changes (mtime/size) or the sliding
+expiry lapses (1h idle / 7d max).
+
+Options:
+  --json                 Emit a machine-readable JSON result on stdout
+  --skip-sigstore        Bypass cosign — requires \`pgserve trust add\` (G3)
+  --bundle <path>        Override the sigstore bundle sidecar path
+                         (default: <binary>.bundle)
+  --cosign-bin <path>    Override the cosign executable
+  --allow-fetch          Allow downloading cosign if missing
+  --no-cache             Never read or write the verified-cache token
+  --help, -h             Show this help
+
+Exit codes:
+  0  Verified (fresh or cache hit)
+  2  Verification failed
+  3  Invocation problem (missing binary/bundle/cosign/pretrusted key)
+`);
+}
+
+function emit({ json }, payload) {
+  if (json) {
+    process.stdout.write(`${JSON.stringify(payload)}\n`);
+    return;
+  }
+  if (payload.ok) {
+    const tag = payload.cached ? 'cached' : 'verified';
+    process.stdout.write(`pgserve verify: ${tag} ${payload.binary} as ${payload.identity} (${payload.tier})\n`);
+    if (payload.cached === false) {
+      process.stdout.write(`pgserve verify: cache token written → ${payload.cacheFile}\n`);
+    }
+    return;
+  }
+  process.stderr.write(`pgserve verify: FAILED — ${payload.reason}${payload.detail ? `: ${payload.detail}` : ''}\n`);
+  if (payload.identityChain && payload.identityChain.length > 0) {
+    process.stderr.write(`pgserve verify: trust roots tried: ${JSON.stringify(payload.identityChain)}\n`);
+  }
+}
+
+/**
+ * Run the verify command. `argv` is the bare argument list AFTER the
+ * `verify` token. Returns an integer exit code.
+ */
+export function runVerify(argv) {
+  const parsed = parseArgs(argv);
+  if (parsed.exit !== undefined) return parsed.exit;
+  const opts = parsed.opts;
+
+  const binaryPath = path.resolve(opts.binaryPath);
+  if (!fs.existsSync(binaryPath)) {
+    emit(opts, { ok: false, reason: 'binary-missing', detail: binaryPath });
+    return EXIT_INVOCATION;
+  }
+
+  let attestation;
+  try {
+    attestation = computeBinaryAttestation(binaryPath);
+  } catch (err) {
+    emit(opts, { ok: false, reason: 'binary-attestation-failed', detail: err.message });
+    return EXIT_INVOCATION;
+  }
+  const sha256 = sha256File(binaryPath);
+  const fingerprint = computeFingerprint(attestation.realpath, sha256);
+
+  // ── Cache lookup ─────────────────────────────────────────────────────
+  if (!opts.noCache) {
+    const cache = readCacheToken(fingerprint, { binaryAttestation: attestation });
+    if (cache.ok) {
+      // Cache hit — bump lastUsedAt and return.
+      touchCacheToken(cache.payload, {});
+      emit(opts, {
+        ok: true,
+        cached: true,
+        binary: binaryPath,
+        identity: cache.payload.identity,
+        tier: cache.payload.tier,
+        sha256: cache.payload.sha256 || sha256,
+        cacheFile: cache.file,
+      });
+      return EXIT_OK;
+    }
+    // Stale binary attestation invalidates the cache so the new fingerprint
+    // wins. We delete defensively when the binary changed under us.
+    if (cache.reason === 'binary-changed') {
+      deleteCacheToken(fingerprint, {});
+    }
+  }
+
+  // ── --skip-sigstore path ─────────────────────────────────────────────
+  if (opts.skipSigstore) {
+    const trust = readOfflineTrust();
+    if (!trust.ok) {
+      emit(opts, {
+        ok: false,
+        reason: 'skip-sigstore-without-pretrusted-key',
+        detail:
+          `--skip-sigstore requires an offline trust entry. None found (${trust.reason}). `
+          + 'Operators must run `pgserve trust add --offline-cosign-key '
+          + '<key-file> --identity <id>` once Group 3 of the singleton wish ships. '
+          + `Trust file path: ${trust.file}`,
+      });
+      return EXIT_INVOCATION;
+    }
+    // Operator vouched for the binary via an offline-cosign-key entry; we
+    // record it as `self_signed` tier (NOT cosign_signed — this is a less
+    // strong attestation than a Sigstore OIDC chain).
+    const identity = trust.keys[0].id;
+    const payload = buildTokenPayload({
+      fingerprint,
+      binary: attestation,
+      identity,
+      tier: 'self_signed',
+      sha256,
+    });
+    let cacheFile = null;
+    if (!opts.noCache) {
+      try {
+        cacheFile = writeCacheToken(payload, {});
+      } catch (err) {
+        emit(opts, { ok: false, reason: 'cache-write-failed', detail: err.message });
+        return EXIT_VERIFY_FAILED;
+      }
+    }
+    emit(opts, {
+      ok: true,
+      cached: false,
+      binary: binaryPath,
+      identity,
+      tier: 'self_signed',
+      sha256,
+      cacheFile,
+      skipSigstore: true,
+    });
+    return EXIT_OK;
+  }
+
+  // ── Cosign path ──────────────────────────────────────────────────────
+  const result = verifyBinary(binaryPath, {
+    cosignBin: opts.cosignBin || process.env.PGSERVE_COSIGN_BIN || undefined,
+    bundlePath: opts.bundlePath || undefined,
+    allowFetch: opts.allowFetch === true,
+  });
+
+  if (!result.ok) {
+    emit(opts, {
+      ok: false,
+      reason: result.reason,
+      detail: result.detail,
+      identityChain: result.identityChain,
+    });
+    if (result.reason === 'binary-missing'
+        || result.reason === 'binary-unreadable'
+        || result.reason === 'binary-not-a-file'
+        || result.reason === 'bundle-missing'
+        || result.reason === 'cosign-missing'
+        || result.reason === 'empty-trust-list'
+        || result.reason === 'invalid-args') {
+      return EXIT_INVOCATION;
+    }
+    return EXIT_VERIFY_FAILED;
+  }
+
+  let cacheFile = null;
+  if (!opts.noCache) {
+    try {
+      const payload = buildTokenPayload({
+        fingerprint,
+        binary: attestation,
+        identity: result.identity,
+        tier: result.tier,
+        sha256: result.sha256,
+      });
+      cacheFile = writeCacheToken(payload, {});
+    } catch (err) {
+      emit(opts, { ok: false, reason: 'cache-write-failed', detail: err.message });
+      return EXIT_VERIFY_FAILED;
+    }
+  }
+  emit(opts, {
+    ok: true,
+    cached: false,
+    binary: binaryPath,
+    identity: result.identity,
+    publisher: result.publisher,
+    tier: result.tier,
+    sha256: result.sha256,
+    cacheFile,
+    bundle: result.bundle,
+    cosignBin: result.cosignBin,
+  });
+  return EXIT_OK;
+}
+
+// Convenience export so tests can introspect paths without re-implementing.
+export const _internals = {
+  computeFingerprint,
+  getStateDir,
+  getTrustFilePath,
+};

--- a/src/commands/verify.js
+++ b/src/commands/verify.js
@@ -212,18 +212,33 @@ export function runVerify(argv) {
   if (!opts.noCache) {
     const cache = readCacheToken(fingerprint, { binaryAttestation: attestation });
     if (cache.ok) {
-      // Cache hit — bump lastUsedAt and return.
-      touchCacheToken(cache.payload, {});
-      emit(opts, {
-        ok: true,
-        cached: true,
-        binary: binaryPath,
-        identity: cache.payload.identity,
-        tier: cache.payload.tier,
-        sha256: cache.payload.sha256 || sha256,
-        cacheFile: cache.file,
-      });
-      return EXIT_OK;
+      // PR #79 P1 security fix: honor the requested tier strictly. Without
+      // this gate, a token written under `--skip-sigstore` (tier:self_signed)
+      // would be accepted on a subsequent run WITHOUT `--skip-sigstore`,
+      // letting the operator bypass cosign verification entirely. The fix:
+      // - default invocation (no --skip-sigstore) requires tier:cosign_signed
+      // - --skip-sigstore invocation requires tier:self_signed
+      // Mismatched-tier cache hits are treated as cache misses (fall through
+      // to re-verify under the requested tier).
+      const cachedTier = cache.payload.tier;
+      const expectedTier = opts.skipSigstore ? 'self_signed' : 'cosign_signed';
+      if (cachedTier === expectedTier) {
+        // Tier matches — bump lastUsedAt and return.
+        touchCacheToken(cache.payload, {});
+        emit(opts, {
+          ok: true,
+          cached: true,
+          binary: binaryPath,
+          identity: cache.payload.identity,
+          tier: cachedTier,
+          sha256: cache.payload.sha256 || sha256,
+          cacheFile: cache.file,
+        });
+        return EXIT_OK;
+      }
+      // Tier mismatch — fall through. Do NOT delete the cache token: the
+      // existing token is valid for its own tier; we just need a fresh
+      // verification under the currently-requested tier.
     }
     // Stale binary attestation invalidates the cache so the new fingerprint
     // wins. We delete defensively when the binary changed under us.

--- a/src/cosign/cache-token.js
+++ b/src/cosign/cache-token.js
@@ -1,0 +1,328 @@
+/**
+ * HMAC-signed verification cache tokens.
+ *
+ * pgserve singleton (v2.4) — `pgserve-singleton-no-proxy` wish, Group 4.
+ *
+ * After `pgserve verify <binary>` succeeds we stash a token at
+ *   `$XDG_STATE_HOME/pgserve/verified/<fingerprint>.token`
+ * with mode 0600. Subsequent invocations short-circuit cosign when:
+ *   - the token's HMAC matches (tamper-evident, keyed on cache.hmac),
+ *   - the binary's mtime/size still match the cached values (re-verify
+ *     when the binary changes on disk per SHARED-DESIGN.md §2.4),
+ *   - the sliding-expiry window has not lapsed:
+ *         idle  ≤ 1 hour since lastUsedAt
+ *         total ≤ 7 days since createdAt.
+ *
+ * The HMAC key lives at `$XDG_STATE_HOME/pgserve/cache.hmac` (32 random
+ * bytes, 0600). Auto-generated on first write; re-generated if the file
+ * is missing or sized wrong (treated as cache-poisoning recovery).
+ *
+ * Tokens are stored as canonical JSON wrapped in an envelope:
+ *   { v: 1, payload: <stable-stringify(token)>, mac: <hex hmac256> }
+ * `payload` is a string (not a nested object) so we HMAC the exact bytes
+ * we serialized. Nested objects would invite key-ordering ambiguity.
+ */
+
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+export const TOKEN_VERSION = 1;
+export const TOKEN_MODE = 0o600;
+export const HMAC_KEY_BYTES = 32;
+export const HMAC_KEY_MODE = 0o600;
+export const TOKEN_DIR_MODE = 0o700;
+export const SLIDING_IDLE_MS = 60 * 60 * 1000;             // 1 hour
+export const SLIDING_MAX_MS = 7 * 24 * 60 * 60 * 1000;     // 7 days
+
+/**
+ * Resolve `$XDG_STATE_HOME/pgserve` (preferred) or
+ * `$HOME/.local/state/pgserve` (XDG default fallback). Mirrors the spec
+ * referenced in the wish (`$XDG_STATE_HOME/pgserve/verified/...`).
+ */
+export function getStateDir() {
+  const xdg = process.env.XDG_STATE_HOME;
+  if (xdg && xdg.length > 0) return path.join(xdg, 'pgserve');
+  return path.join(os.homedir(), '.local', 'state', 'pgserve');
+}
+
+export function getVerifiedDir(stateDir = getStateDir()) {
+  return path.join(stateDir, 'verified');
+}
+
+export function getHmacKeyPath(stateDir = getStateDir()) {
+  return path.join(stateDir, 'cache.hmac');
+}
+
+export function getTokenPath(fingerprint, stateDir = getStateDir()) {
+  if (typeof fingerprint !== 'string' || fingerprint.length === 0) {
+    throw new TypeError('cache-token: fingerprint must be a non-empty string');
+  }
+  if (!/^[A-Za-z0-9._-]+$/.test(fingerprint)) {
+    throw new TypeError(
+      `cache-token: fingerprint contains unsafe characters: ${JSON.stringify(fingerprint)}`,
+    );
+  }
+  return path.join(getVerifiedDir(stateDir), `${fingerprint}.token`);
+}
+
+function ensureDir(dir, mode) {
+  fs.mkdirSync(dir, { recursive: true, mode });
+  fs.chmodSync(dir, mode);
+}
+
+/**
+ * Read or create the HMAC key. The key is 32 random bytes stored at
+ * mode 0600. Missing / wrong-sized files are recreated — treat poisoning
+ * as a cache miss rather than a hard failure.
+ */
+export function ensureHmacKey({ stateDir = getStateDir() } = {}) {
+  ensureDir(stateDir, TOKEN_DIR_MODE);
+  const file = getHmacKeyPath(stateDir);
+  if (fs.existsSync(file)) {
+    const buf = fs.readFileSync(file);
+    if (buf.length === HMAC_KEY_BYTES) return buf;
+  }
+  const buf = crypto.randomBytes(HMAC_KEY_BYTES);
+  const tmp = `${file}.tmp.${process.pid}`;
+  fs.writeFileSync(tmp, buf, { mode: HMAC_KEY_MODE });
+  fs.renameSync(tmp, file);
+  fs.chmodSync(file, HMAC_KEY_MODE);
+  return buf;
+}
+
+function stableStringify(obj) {
+  // Deterministic JSON: sort keys at every level so the same logical
+  // payload always produces the same bytes (and HMAC).
+  if (obj === null || typeof obj !== 'object') return JSON.stringify(obj);
+  if (Array.isArray(obj)) return `[${obj.map(stableStringify).join(',')}]`;
+  const keys = Object.keys(obj).sort();
+  const body = keys.map((k) => `${JSON.stringify(k)}:${stableStringify(obj[k])}`).join(',');
+  return `{${body}}`;
+}
+
+function hmacHex(key, payloadString) {
+  return crypto.createHmac('sha256', key).update(payloadString).digest('hex');
+}
+
+function timingSafeEqHex(a, b) {
+  if (typeof a !== 'string' || typeof b !== 'string') return false;
+  if (a.length !== b.length) return false;
+  try {
+    return crypto.timingSafeEqual(Buffer.from(a, 'hex'), Buffer.from(b, 'hex'));
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Compute the binary attestation used as part of the cache key. Re-using
+ * mtime + size catches the simple "operator updated the binary" case
+ * cheaply; sha256 is intentionally NOT recomputed here on the cached path
+ * (callers can recompute on demand if they want defense in depth).
+ */
+export function computeBinaryAttestation(binaryPath) {
+  const stat = fs.statSync(binaryPath);
+  if (!stat.isFile()) {
+    throw new Error(`cache-token: binary path is not a file: ${binaryPath}`);
+  }
+  return {
+    realpath: fs.realpathSync(binaryPath),
+    size: stat.size,
+    mtimeMs: Math.floor(stat.mtimeMs),
+  };
+}
+
+/**
+ * Build the canonical token payload. Caller supplies verification result;
+ * we layer in createdAt / lastUsedAt timestamps and the binary attestation.
+ */
+export function buildTokenPayload({
+  fingerprint,
+  binary,
+  identity,
+  tier,
+  sha256,
+  now = Date.now(),
+}) {
+  if (typeof fingerprint !== 'string' || fingerprint.length === 0) {
+    throw new TypeError('cache-token: fingerprint must be a non-empty string');
+  }
+  if (!binary || typeof binary !== 'object') {
+    throw new TypeError('cache-token: binary attestation required');
+  }
+  if (typeof identity !== 'string' || identity.length === 0) {
+    throw new TypeError('cache-token: identity must be a non-empty string');
+  }
+  if (typeof tier !== 'string' || tier.length === 0) {
+    throw new TypeError('cache-token: tier must be a non-empty string');
+  }
+  return {
+    v: TOKEN_VERSION,
+    fingerprint,
+    binary: {
+      realpath: binary.realpath,
+      size: binary.size,
+      mtimeMs: binary.mtimeMs,
+    },
+    identity,
+    tier,
+    sha256: sha256 || null,
+    createdAt: now,
+    lastUsedAt: now,
+  };
+}
+
+/**
+ * Persist a verification token. Computes HMAC over the canonical payload
+ * with the key from `ensureHmacKey()`. Atomic write via tmp+rename. mode
+ * 0600.
+ */
+export function writeCacheToken(payload, { stateDir = getStateDir() } = {}) {
+  if (!payload || typeof payload !== 'object') {
+    throw new TypeError('cache-token: payload must be an object');
+  }
+  if (payload.v !== TOKEN_VERSION) {
+    throw new TypeError(`cache-token: unsupported token version ${payload.v}`);
+  }
+  const key = ensureHmacKey({ stateDir });
+  ensureDir(getVerifiedDir(stateDir), TOKEN_DIR_MODE);
+
+  const file = getTokenPath(payload.fingerprint, stateDir);
+  const payloadString = stableStringify(payload);
+  const envelope = {
+    v: TOKEN_VERSION,
+    payload: payloadString,
+    mac: hmacHex(key, payloadString),
+  };
+  const tmp = `${file}.tmp.${process.pid}`;
+  fs.writeFileSync(tmp, `${JSON.stringify(envelope)}\n`, { mode: TOKEN_MODE });
+  fs.renameSync(tmp, file);
+  fs.chmodSync(file, TOKEN_MODE);
+  return file;
+}
+
+function classifyError(reason, detail) {
+  return { ok: false, reason, ...(detail ? { detail } : {}) };
+}
+
+/**
+ * Read + validate a cached token. Returns `{ ok: true, payload, file }`
+ * on hit, `{ ok: false, reason }` on miss. Never throws on malformed
+ * tokens — bad input is treated as a cache miss so the caller can fall
+ * back to a fresh verify.
+ */
+export function readCacheToken(fingerprint, {
+  binaryAttestation,
+  stateDir = getStateDir(),
+  now = Date.now(),
+} = {}) {
+  let file;
+  try {
+    file = getTokenPath(fingerprint, stateDir);
+  } catch (err) {
+    return classifyError('invalid-fingerprint', err.message);
+  }
+  if (!fs.existsSync(file)) {
+    return classifyError('missing');
+  }
+  let raw;
+  try {
+    raw = fs.readFileSync(file, 'utf8');
+  } catch (err) {
+    return classifyError('unreadable', err.message);
+  }
+  let envelope;
+  try {
+    envelope = JSON.parse(raw);
+  } catch (err) {
+    return classifyError('malformed-envelope', err.message);
+  }
+  if (
+    !envelope || typeof envelope !== 'object'
+    || envelope.v !== TOKEN_VERSION
+    || typeof envelope.payload !== 'string'
+    || typeof envelope.mac !== 'string'
+  ) {
+    return classifyError('malformed-envelope');
+  }
+
+  const key = ensureHmacKey({ stateDir });
+  const expected = hmacHex(key, envelope.payload);
+  if (!timingSafeEqHex(expected, envelope.mac)) {
+    return classifyError('hmac-mismatch');
+  }
+
+  let payload;
+  try {
+    payload = JSON.parse(envelope.payload);
+  } catch (err) {
+    return classifyError('malformed-payload', err.message);
+  }
+  if (!payload || payload.v !== TOKEN_VERSION) {
+    return classifyError('malformed-payload');
+  }
+  if (payload.fingerprint !== fingerprint) {
+    return classifyError('fingerprint-mismatch');
+  }
+
+  const createdAt = Number(payload.createdAt);
+  const lastUsedAt = Number(payload.lastUsedAt);
+  if (!Number.isFinite(createdAt) || !Number.isFinite(lastUsedAt)) {
+    return classifyError('malformed-timestamps');
+  }
+  if (now - createdAt > SLIDING_MAX_MS) {
+    return classifyError('expired-max');
+  }
+  if (now - lastUsedAt > SLIDING_IDLE_MS) {
+    return classifyError('expired-idle');
+  }
+
+  if (binaryAttestation) {
+    const cached = payload.binary || {};
+    if (
+      cached.realpath !== binaryAttestation.realpath
+      || cached.size !== binaryAttestation.size
+      || cached.mtimeMs !== binaryAttestation.mtimeMs
+    ) {
+      return classifyError('binary-changed');
+    }
+  }
+
+  return { ok: true, payload, file };
+}
+
+/**
+ * Bump `lastUsedAt` to `now` on a hit. Returns the rewritten payload, or
+ * `null` if the touch fails (treat as soft failure — the cached token is
+ * still valid for this invocation).
+ */
+export function touchCacheToken(payload, { stateDir = getStateDir(), now = Date.now() } = {}) {
+  if (!payload || typeof payload !== 'object' || payload.v !== TOKEN_VERSION) return null;
+  const next = { ...payload, lastUsedAt: now };
+  try {
+    writeCacheToken(next, { stateDir });
+    return next;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Delete a cached token. Idempotent — missing file is a no-op.
+ */
+export function deleteCacheToken(fingerprint, { stateDir = getStateDir() } = {}) {
+  let file;
+  try {
+    file = getTokenPath(fingerprint, stateDir);
+  } catch {
+    return false;
+  }
+  try {
+    fs.unlinkSync(file);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/src/cosign/schema.js
+++ b/src/cosign/schema.js
@@ -1,0 +1,97 @@
+/**
+ * `pgserve_meta` schema delta — additive verification columns.
+ *
+ * pgserve singleton (v2.4) — `pgserve-singleton-no-proxy` wish, Group 4.
+ *
+ * Decision P4 (locked): the schema delta is purely additive. Pre-cosign
+ * `path`-tier rows continue to work — we add `verified_at`,
+ * `verified_identity`, `verified_tier` only. Group 3 (`pgserve provision`)
+ * writes these columns when its tier resolution lands in the cosign-signed
+ * path; older rows leave them NULL and behave exactly as before.
+ *
+ * Why a separate module: the underlying `pgserve_meta` table is owned by
+ * Group 3 (provision) which lands after Group 4 in Wave 2. We ship the
+ * column definitions + idempotent ALTER statements here so Group 3 / 7
+ * can call us once their CREATE TABLE has run. Idempotency relies on
+ * `ADD COLUMN IF NOT EXISTS` and `ADD CONSTRAINT IF NOT EXISTS` so re-
+ * running on an already-migrated database is a no-op.
+ */
+
+export const VERIFIED_TIER_VALUES = Object.freeze([
+  'path',
+  'host_signed',
+  'self_signed',
+  'cosign_signed',
+]);
+
+export const VERIFIED_TIER_CHECK_NAME = 'pgserve_meta_verified_tier_check';
+
+const TIER_LIST_SQL = VERIFIED_TIER_VALUES.map((v) => `'${v}'`).join(', ');
+
+/**
+ * Idempotent ALTER statements that add the verification columns to an
+ * existing `pgserve_meta` table. Returned as an array so callers can run
+ * each statement individually for clearer error reporting.
+ *
+ * The CHECK constraint is added via DO-block guarded `pg_constraint`
+ * lookup because `ADD CONSTRAINT IF NOT EXISTS` is not standardized
+ * across all postgres major versions we still support.
+ */
+export function getMigrationStatements() {
+  return [
+    'ALTER TABLE pgserve_meta ADD COLUMN IF NOT EXISTS verified_at TIMESTAMPTZ',
+    'ALTER TABLE pgserve_meta ADD COLUMN IF NOT EXISTS verified_identity TEXT',
+    'ALTER TABLE pgserve_meta ADD COLUMN IF NOT EXISTS verified_tier TEXT',
+    [
+      'DO $$',
+      'BEGIN',
+      '  IF NOT EXISTS (',
+      '    SELECT 1 FROM pg_constraint',
+      `    WHERE conname = '${VERIFIED_TIER_CHECK_NAME}'`,
+      '  ) THEN',
+      '    EXECUTE $check$',
+      `      ALTER TABLE pgserve_meta ADD CONSTRAINT ${VERIFIED_TIER_CHECK_NAME}`,
+      `      CHECK (verified_tier IS NULL OR verified_tier IN (${TIER_LIST_SQL}))`,
+      '    $check$;',
+      '  END IF;',
+      'END$$',
+    ].join('\n'),
+  ];
+}
+
+/**
+ * Single SQL string variant — convenient for embedding the migration in
+ * pg-init scripts that run statements in a transaction.
+ */
+export function getMigrationSQL() {
+  return `${getMigrationStatements().join(';\n\n')};\n`;
+}
+
+/**
+ * Apply the migration via a node-postgres-compatible client. The client
+ * must expose an async `query(sql)` method (matches both `pg.Client` and
+ * `pg.PoolClient`). Returns the list of statements executed for caller
+ * diagnostics.
+ *
+ * Statements run sequentially — DO blocks need their own statement
+ * boundary and we don't want a single-line failure to masquerade as
+ * success on later statements.
+ */
+export async function applyVerifiedColumns(client) {
+  if (!client || typeof client.query !== 'function') {
+    throw new TypeError('schema: client must expose an async query() method');
+  }
+  const statements = getMigrationStatements();
+  for (const sql of statements) {
+    await client.query(sql);
+  }
+  return statements;
+}
+
+/**
+ * Convenience predicate — true when the tier value is one the wish
+ * accepts. Group 3 (`pgserve provision`) calls this before writing rows.
+ */
+export function isValidTier(tier) {
+  return VERIFIED_TIER_VALUES.includes(tier);
+}

--- a/src/cosign/trust-list.js
+++ b/src/cosign/trust-list.js
@@ -1,0 +1,81 @@
+/**
+ * Hardcoded cosign trust list — Tier 2 (cosign_signed) identity table.
+ *
+ * pgserve singleton (v2.4) — `pgserve-singleton-no-proxy` wish, Group 4.
+ *
+ * Identities listed here are baked into the binary (Decision P6 in the
+ * wish). Operators cannot remove or override them; updates flow only
+ * through `pgserve update` shipping a new build. User-extensible roots
+ * live separately in `~/.pgserve/trust/identities.json` (Group 3 surface),
+ * not here.
+ *
+ * Identity shape mirrors what `cosign verify` consumes via
+ * `--certificate-identity` + `--certificate-oidc-issuer` flags. The
+ * `identityRegexp` form (Sigstore conventional) accepts `--certificate-
+ * identity-regexp`.
+ *
+ * SHARED-DESIGN.md §2.4 commits to GitHub Actions OIDC for the Namastex
+ * automagik release workflows: `release.yml@refs/tags/v*`. We pin both the
+ * exact issuer URL and the regexp form so callers can pick whichever
+ * cosign CLI flag set is convenient.
+ */
+
+export const SIGSTORE_GITHUB_ACTIONS_ISSUER = 'https://token.actions.githubusercontent.com';
+
+/**
+ * Hardcoded trust roots — frozen to prevent runtime mutation.
+ *
+ * Each entry:
+ *   id            short stable identifier used in diagnostics
+ *   publisher     `package.json` `pgserve.publisher` value the entry attests
+ *   issuer        OIDC issuer URL (Sigstore --certificate-oidc-issuer)
+ *   identityRegexp Sigstore --certificate-identity-regexp value
+ *   description   human-readable summary for `pgserve trust list`
+ */
+export const TRUSTED_IDENTITIES = Object.freeze([
+  Object.freeze({
+    id: 'automagik-genie-release',
+    publisher: '@automagik/genie',
+    issuer: SIGSTORE_GITHUB_ACTIONS_ISSUER,
+    identityRegexp: '^https://github.com/automagik-dev/genie/.github/workflows/release.yml@refs/tags/v.*$',
+    description: 'Namastex automagik genie release workflow (GitHub Actions OIDC)',
+  }),
+  Object.freeze({
+    id: 'automagik-omni-release',
+    publisher: '@automagik/omni',
+    issuer: SIGSTORE_GITHUB_ACTIONS_ISSUER,
+    identityRegexp: '^https://github.com/automagik/omni/.github/workflows/release.yml@refs/tags/v.*$',
+    description: 'Namastex automagik omni release workflow (GitHub Actions OIDC)',
+  }),
+  Object.freeze({
+    id: 'automagik-pgserve-release',
+    publisher: '@automagik/pgserve',
+    issuer: SIGSTORE_GITHUB_ACTIONS_ISSUER,
+    identityRegexp: '^https://github.com/automagik/pgserve/.github/workflows/release.yml@refs/tags/v.*$',
+    description: 'Namastex automagik pgserve release workflow (GitHub Actions OIDC)',
+  }),
+]);
+
+const TRUSTED_BY_ID = new Map(TRUSTED_IDENTITIES.map((e) => [e.id, e]));
+const TRUSTED_BY_PUBLISHER = new Map(TRUSTED_IDENTITIES.map((e) => [e.publisher, e]));
+
+export function getTrustedById(id) {
+  return TRUSTED_BY_ID.get(id) || null;
+}
+
+export function getTrustedByPublisher(publisher) {
+  return TRUSTED_BY_PUBLISHER.get(publisher) || null;
+}
+
+/**
+ * Return the trust roots in serialized-list form for `pgserve trust list`.
+ * Includes the hardcoded marker so the surface can refuse `trust remove`
+ * operations against compiled-in entries.
+ */
+export function listHardcodedTrust() {
+  return TRUSTED_IDENTITIES.map((entry) => ({
+    ...entry,
+    source: 'hardcoded',
+    removable: false,
+  }));
+}

--- a/src/cosign/verify-binary.js
+++ b/src/cosign/verify-binary.js
@@ -1,0 +1,277 @@
+/**
+ * Cosign keyless OIDC binary verifier.
+ *
+ * pgserve singleton (v2.4) — `pgserve-singleton-no-proxy` wish, Group 4.
+ *
+ * Per Decision P5 (locked), we shell out to the `cosign` CLI rather than
+ * vendoring sigstore-rs. Verification model:
+ *
+ *   - Each binary distributed by an automagik release ships with a
+ *     paired Sigstore bundle file at `<binary>.bundle` (modern keyless
+ *     OIDC attestation, JSON-encoded).
+ *   - We invoke `cosign verify-blob --bundle <bundle>
+ *     --certificate-identity-regexp <re> --certificate-oidc-issuer <iss>
+ *     <binary>` — once per entry in the trust list.
+ *   - First entry that exits 0 wins. We return its identity + tier.
+ *   - If every entry fails, we surface the most-specific cosign diagnostic
+ *     (the last exit) so the operator knows which trust root we tried.
+ *
+ * Resolution of the cosign executable:
+ *   1. Caller-supplied `cosignBin` (used by tests + `--cosign-bin` flag)
+ *   2. `cosign` on `$PATH`
+ *   3. Cached static binary at `~/.pgserve/bin/cosign`
+ *   4. Download official static binary from sigstore release (offline by
+ *      default — only triggered when `allowFetch: true` is passed)
+ *
+ * Returns a tagged union:
+ *   { ok: true,  identity, tier, sha256, cosignBin, bundle }
+ *   { ok: false, reason, detail?, identityChain? }
+ */
+
+import { spawnSync } from 'node:child_process';
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { TRUSTED_IDENTITIES } from './trust-list.js';
+
+export const COSIGN_TIER = 'cosign_signed';
+export const COSIGN_BIN_DIR = path.join(os.homedir(), '.pgserve', 'bin');
+export const COSIGN_BIN_FILE = path.join(COSIGN_BIN_DIR, process.platform === 'win32' ? 'cosign.exe' : 'cosign');
+
+const COSIGN_RELEASE_VERSION = 'v2.2.4';
+const COSIGN_RELEASE_BASE = `https://github.com/sigstore/cosign/releases/download/${COSIGN_RELEASE_VERSION}`;
+
+/**
+ * Compute sha256 of a file. Returns lowercase hex.
+ */
+export function sha256File(filePath) {
+  const hash = crypto.createHash('sha256');
+  const buf = fs.readFileSync(filePath);
+  hash.update(buf);
+  return hash.digest('hex');
+}
+
+/**
+ * Resolve the sidecar bundle path for a given binary path. Convention:
+ * `<binary>.bundle`. Operators that publish detached `.sig` + `.cert` can
+ * regenerate a bundle with `cosign sign-blob --bundle <path>.bundle`; we
+ * intentionally only support the bundle form to keep the surface narrow.
+ */
+export function resolveBundlePath(binaryPath) {
+  return `${binaryPath}.bundle`;
+}
+
+/**
+ * Resolve which `cosign` executable to use. Returns a string path or null
+ * if no cosign is available and `allowFetch: false`.
+ *
+ * PATH probing is implemented in-process (rather than shelling out to
+ * `which` / `where`) so the resolver works inside test harnesses that
+ * scrub PATH down to a single stub directory.
+ */
+export function resolveCosignBin({ cosignBin, allowFetch = false } = {}) {
+  if (cosignBin && fs.existsSync(cosignBin)) return cosignBin;
+
+  const fromPath = lookupOnPath(process.platform === 'win32' ? 'cosign.exe' : 'cosign');
+  if (fromPath) return fromPath;
+
+  // Cached static binary.
+  if (fs.existsSync(COSIGN_BIN_FILE)) return COSIGN_BIN_FILE;
+
+  if (!allowFetch) return null;
+
+  try {
+    return fetchCosignBin();
+  } catch {
+    return null;
+  }
+}
+
+function lookupOnPath(name) {
+  const PATH = process.env.PATH || '';
+  if (!PATH) return null;
+  const sep = process.platform === 'win32' ? ';' : ':';
+  const dirs = PATH.split(sep).filter(Boolean);
+  for (const dir of dirs) {
+    const candidate = path.join(dir, name);
+    try {
+      const stat = fs.statSync(candidate);
+      if (stat.isFile()) {
+        // On POSIX, ensure it's executable; on Windows, file existence is enough.
+        if (process.platform === 'win32') return candidate;
+        if ((stat.mode & 0o111) !== 0) return candidate;
+      }
+    } catch {
+      // missing or stat error — try next dir
+    }
+  }
+  return null;
+}
+
+/**
+ * Download the official cosign static binary into `~/.pgserve/bin/cosign`.
+ * Synchronous — used by `pgserve verify` when no cosign is on PATH and the
+ * operator opts into the fetch (see Decision P5: "if cosign not on PATH,
+ * pgserve install shells out to a downloader to fetch the official static
+ * binary into ~/.pgserve/bin/cosign").
+ *
+ * Network-dependent. Throws on failure. Tests stub via `cosignBin` instead
+ * of this code path.
+ */
+export function fetchCosignBin({
+  releaseBase = COSIGN_RELEASE_BASE,
+  targetFile = COSIGN_BIN_FILE,
+  targetDir = COSIGN_BIN_DIR,
+} = {}) {
+  fs.mkdirSync(targetDir, { recursive: true, mode: 0o755 });
+  const assetName = pickCosignAssetName();
+  const url = `${releaseBase}/${assetName}`;
+  const tmp = `${targetFile}.tmp.${process.pid}`;
+  downloadToFileSync(url, tmp);
+  fs.chmodSync(tmp, 0o755);
+  fs.renameSync(tmp, targetFile);
+  return targetFile;
+}
+
+function pickCosignAssetName() {
+  const arch = process.arch === 'x64' ? 'amd64' : process.arch === 'arm64' ? 'arm64' : process.arch;
+  if (process.platform === 'darwin') return `cosign-darwin-${arch}`;
+  if (process.platform === 'win32') return `cosign-windows-${arch}.exe`;
+  return `cosign-linux-${arch}`;
+}
+
+function downloadToFileSync(url, destPath) {
+  // Node has no built-in synchronous HTTP. We fall back to spawning curl
+  // since this only runs once per host (cached afterward) and curl is
+  // ubiquitous on the supported platforms.
+  const curl = spawnSync('curl', ['-fsSL', '-o', destPath, url], {
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  if (curl.status === 0) return;
+  // Fallback: try wget.
+  const wget = spawnSync('wget', ['-qO', destPath, url], { stdio: ['ignore', 'pipe', 'pipe'] });
+  if (wget.status === 0) return;
+  throw new Error(
+    `cosign-verify: failed to download cosign from ${url} (curl exit ${curl.status}, wget exit ${wget?.status ?? 'n/a'})`,
+  );
+}
+
+/**
+ * Verify a binary with cosign.
+ *
+ * @param {string} binaryPath
+ * @param {object} [options]
+ * @param {string} [options.cosignBin]   override cosign executable
+ * @param {string} [options.bundlePath]  override bundle sidecar path
+ * @param {Array}  [options.trustList]   override hardcoded TRUSTED_IDENTITIES
+ * @param {boolean}[options.allowFetch]  allow fetching the cosign binary if missing
+ * @returns {{ ok: true, identity, tier, sha256, cosignBin, bundle, identityChain }
+ *         | { ok: false, reason, detail?, identityChain? }}
+ */
+export function verifyBinary(binaryPath, options = {}) {
+  if (typeof binaryPath !== 'string' || binaryPath.length === 0) {
+    return { ok: false, reason: 'invalid-args', detail: 'binaryPath required' };
+  }
+  if (!fs.existsSync(binaryPath)) {
+    return { ok: false, reason: 'binary-missing', detail: binaryPath };
+  }
+  let stat;
+  try {
+    stat = fs.statSync(binaryPath);
+  } catch (err) {
+    return { ok: false, reason: 'binary-unreadable', detail: err.message };
+  }
+  if (!stat.isFile()) {
+    return { ok: false, reason: 'binary-not-a-file', detail: binaryPath };
+  }
+
+  const bundlePath = options.bundlePath || resolveBundlePath(binaryPath);
+  if (!fs.existsSync(bundlePath)) {
+    return {
+      ok: false,
+      reason: 'bundle-missing',
+      detail: `expected sigstore bundle at ${bundlePath} (run \`cosign sign-blob --bundle ${bundlePath} ${binaryPath}\` to attest)`,
+    };
+  }
+
+  const trustList = options.trustList || TRUSTED_IDENTITIES;
+  if (!Array.isArray(trustList) || trustList.length === 0) {
+    return { ok: false, reason: 'empty-trust-list' };
+  }
+
+  const cosignBin = resolveCosignBin({
+    cosignBin: options.cosignBin,
+    allowFetch: options.allowFetch === true,
+  });
+  if (!cosignBin) {
+    return {
+      ok: false,
+      reason: 'cosign-missing',
+      detail:
+        'no `cosign` binary on $PATH or in ~/.pgserve/bin/cosign — install cosign or rerun with --allow-fetch',
+    };
+  }
+
+  const sha256 = sha256File(binaryPath);
+  const identityChain = [];
+  let lastFailure = null;
+
+  for (const identity of trustList) {
+    if (!identity || !identity.id || !identity.issuer || !identity.identityRegexp) {
+      identityChain.push({ id: identity?.id || '<malformed>', status: 'skipped' });
+      continue;
+    }
+    const result = invokeCosign({
+      cosignBin,
+      bundlePath,
+      binaryPath,
+      identity,
+    });
+    if (result.ok) {
+      identityChain.push({ id: identity.id, status: 'matched' });
+      return {
+        ok: true,
+        identity: identity.id,
+        publisher: identity.publisher,
+        tier: COSIGN_TIER,
+        sha256,
+        cosignBin,
+        bundle: bundlePath,
+        identityChain,
+      };
+    }
+    identityChain.push({ id: identity.id, status: 'rejected', exitCode: result.exitCode });
+    lastFailure = result;
+  }
+
+  return {
+    ok: false,
+    reason: 'no-trust-match',
+    detail: lastFailure?.stderr || 'cosign rejected the binary against every trust root',
+    identityChain,
+  };
+}
+
+function invokeCosign({ cosignBin, bundlePath, binaryPath, identity }) {
+  const args = [
+    'verify-blob',
+    '--bundle', bundlePath,
+    '--certificate-identity-regexp', identity.identityRegexp,
+    '--certificate-oidc-issuer', identity.issuer,
+    binaryPath,
+  ];
+  const proc = spawnSync(cosignBin, args, {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  if (proc.status === 0) {
+    return { ok: true, stdout: proc.stdout || '' };
+  }
+  return {
+    ok: false,
+    exitCode: typeof proc.status === 'number' ? proc.status : -1,
+    stderr: (proc.stderr || proc.stdout || '').trim().slice(0, 4096),
+  };
+}

--- a/src/upgrade/index.js
+++ b/src/upgrade/index.js
@@ -20,11 +20,16 @@ import * as plpgsqlResolve from './steps/plpgsql-resolve.js';
 import * as envRefresh from './steps/env-refresh.js';
 import * as consumerSignal from './steps/consumer-signal.js';
 import * as healthValidate from './steps/health-validate.js';
+import * as cosignMetaMigration from './steps/cosign-meta-migration.js';
 
 export const STEPS = [
   { name: 'port-reconcile', impl: portReconcile },
   { name: 'binary-cache-flush', impl: binaryCacheFlush },
   { name: 'plpgsql-resolve', impl: plpgsqlResolve },
+  // pgserve singleton (v2.4) — `pgserve-singleton-no-proxy` wish, Group 4.
+  // Adds the additive `verified_*` columns to `pgserve_meta`. Runs after
+  // plpgsql-resolve so the extension is available; idempotent per-DB.
+  { name: 'cosign-meta-migration', impl: cosignMetaMigration },
   { name: 'env-refresh', impl: envRefresh },
   { name: 'consumer-signal', impl: consumerSignal },
   { name: 'health-validate', impl: healthValidate },

--- a/src/upgrade/steps/cosign-meta-migration.js
+++ b/src/upgrade/steps/cosign-meta-migration.js
@@ -1,0 +1,108 @@
+/**
+ * Step — pgserve_meta cosign columns (additive).
+ *
+ * pgserve singleton (v2.4) — `pgserve-singleton-no-proxy` wish, Group 4.
+ *
+ * Adds `verified_at`, `verified_identity`, `verified_tier` to every
+ * `pgserve_meta` table the upgrade step finds. The schema delta is
+ * additive (Decision P4) — pre-cosign rows continue to work, columns are
+ * NULL until Group 3's `pgserve provision` writes them.
+ *
+ * Runs idempotently: `ADD COLUMN IF NOT EXISTS` plus a guarded DO-block
+ * for the CHECK constraint. Re-running on an already-migrated host is a
+ * no-op. If `pgserve_meta` does not exist (fresh install before G3 has
+ * provisioned anything) the step is a SKIP.
+ */
+
+import { execSync } from 'node:child_process';
+
+import { getMigrationStatements } from '../../cosign/schema.js';
+
+export const name = 'cosign-meta-migration';
+const CANONICAL_PORT = 5432;
+const SYSTEM_DBS = new Set(['template0', 'template1']);
+
+function pgQuery({ db, sql, captureStdout = false, port = CANONICAL_PORT }) {
+  const env = { ...process.env, PGPASSWORD: process.env.PGPASSWORD || 'postgres' };
+  const cmd = `psql -h 127.0.0.1 -p ${port} -U postgres -d ${db} -At -c ${JSON.stringify(sql)}`;
+  return captureStdout
+    ? execSync(cmd, { env, stdio: ['ignore', 'pipe', 'pipe'] }).toString().trim()
+    : execSync(cmd, { env, stdio: 'pipe' });
+}
+
+function listUserDbs() {
+  const out = pgQuery({
+    db: 'postgres',
+    sql: "SELECT datname FROM pg_database WHERE NOT datistemplate ORDER BY datname",
+    captureStdout: true,
+  });
+  return out ? out.split('\n').filter(Boolean).filter((d) => !SYSTEM_DBS.has(d)) : [];
+}
+
+function pgserveMetaExists(db) {
+  const out = pgQuery({
+    db,
+    sql: "SELECT to_regclass('public.pgserve_meta') IS NOT NULL",
+    captureStdout: true,
+  });
+  return out === 't' || out === 'true';
+}
+
+export async function plan() {
+  let dbs;
+  try {
+    dbs = listUserDbs();
+  } catch (err) {
+    return `cannot enumerate DBs: ${err.message}`;
+  }
+  if (dbs.length === 0) return 'no user DBs — skip';
+  const targets = [];
+  for (const db of dbs) {
+    try {
+      if (pgserveMetaExists(db)) targets.push(db);
+    } catch {
+      // Skip silently — DB might be unreachable, listed but not connectable.
+    }
+  }
+  if (targets.length === 0) return 'no DB hosts pgserve_meta yet — skip';
+  return `would apply additive cosign columns to pgserve_meta in: ${targets.join(', ')}`;
+}
+
+export async function execute({ log, warn }) {
+  let dbs;
+  try {
+    dbs = listUserDbs();
+  } catch (err) {
+    return { status: 'FAIL', detail: `cannot enumerate DBs: ${err.message}` };
+  }
+  if (dbs.length === 0) return { status: 'SKIP', detail: 'no user DBs to migrate' };
+
+  const statements = getMigrationStatements();
+  let migrated = 0;
+  let skipped = 0;
+  for (const db of dbs) {
+    let exists;
+    try {
+      exists = pgserveMetaExists(db);
+    } catch (err) {
+      warn(`[cosign-meta-migration] ${db}: cannot probe pgserve_meta — ${err.message}`);
+      skipped++;
+      continue;
+    }
+    if (!exists) {
+      skipped++;
+      continue;
+    }
+    try {
+      for (const sql of statements) {
+        pgQuery({ db, sql });
+      }
+      log(`[cosign-meta-migration] ${db}: applied ${statements.length} idempotent statement(s)`);
+      migrated++;
+    } catch (err) {
+      warn(`[cosign-meta-migration] ${db}: failed — ${err.message}`);
+      skipped++;
+    }
+  }
+  return { status: 'OK', detail: `migrated ${migrated} DB(s), skipped ${skipped}` };
+}

--- a/src/upgrade/steps/cosign-meta-migration.js
+++ b/src/upgrade/steps/cosign-meta-migration.js
@@ -14,7 +14,7 @@
  * provisioned anything) the step is a SKIP.
  */
 
-import { execSync } from 'node:child_process';
+import { spawnSync } from 'node:child_process';
 
 import { getMigrationStatements } from '../../cosign/schema.js';
 
@@ -22,12 +22,27 @@ export const name = 'cosign-meta-migration';
 const CANONICAL_PORT = 5432;
 const SYSTEM_DBS = new Set(['template0', 'template1']);
 
+// PR #79 fix: previous implementation used execSync with a template string +
+// JSON.stringify(sql). The migration SQL contains `DO $$ ... $$` blocks; bash
+// expands `$$` to its PID, corrupting the SQL before psql sees it. Switch to
+// spawnSync (shell:false) with the SQL fed through stdin — no shell parsing,
+// no expansion, no injection surface.
 function pgQuery({ db, sql, captureStdout = false, port = CANONICAL_PORT }) {
   const env = { ...process.env, PGPASSWORD: process.env.PGPASSWORD || 'postgres' };
-  const cmd = `psql -h 127.0.0.1 -p ${port} -U postgres -d ${db} -At -c ${JSON.stringify(sql)}`;
-  return captureStdout
-    ? execSync(cmd, { env, stdio: ['ignore', 'pipe', 'pipe'] }).toString().trim()
-    : execSync(cmd, { env, stdio: 'pipe' });
+  const result = spawnSync(
+    'psql',
+    ['-h', '127.0.0.1', '-p', String(port), '-U', 'postgres', '-d', db, '-At', '-f', '-'],
+    { env, input: sql, stdio: ['pipe', 'pipe', 'pipe'] }
+  );
+  if (result.status !== 0) {
+    const stderr = (result.stderr || Buffer.from('')).toString();
+    const err = new Error(`psql exited ${result.status}: ${stderr.trim()}`);
+    err.status = result.status;
+    err.stderr = stderr;
+    throw err;
+  }
+  const stdout = (result.stdout || Buffer.from('')).toString();
+  return captureStdout ? stdout.trim() : stdout;
 }
 
 function listUserDbs() {

--- a/tests/cli/verify.test.js
+++ b/tests/cli/verify.test.js
@@ -1,0 +1,321 @@
+/**
+ * Tests for `pgserve verify <binary-path>` — Group 4 acceptance battery.
+ *
+ * pgserve singleton (v2.4) — `pgserve-singleton-no-proxy` wish, Group 4.
+ *
+ * Drives the wrapper end-to-end:
+ *   - legitimate signed binary: passes, cache written, second invocation
+ *     short-circuits cosign.
+ *   - tampered binary: rejects with diagnostic.
+ *   - --skip-sigstore without pretrusted key: refuses non-zero with the
+ *     cross-group remediation hint.
+ *   - --skip-sigstore with offline-cosign-key entry: passes, marks
+ *     self_signed tier in the cache.
+ *   - cache mtime invalidation: bumping the binary's mtime forces a fresh
+ *     verify (cosign called twice).
+ *
+ * `cosign` is stubbed on PATH so we don't drag the real verifier into the
+ * test loop. The trust list itself stays the hardcoded production list —
+ * we override it with PGSERVE_TRUST_LIST_OVERRIDE only for tests that
+ * care about identity selection (none of the four acceptance cases do).
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+const BIN = path.join(REPO_ROOT, 'bin', 'pgserve-wrapper.cjs');
+
+let tmpStateRoot;     // XDG_STATE_HOME for cache tokens
+let tmpHome;          // HOME for offline trust file
+let tmpBinDir;        // where we drop the fake postgres binary
+let stubCosignDir;    // where the stub cosign + its calls log live
+let originalEnv;
+
+function makeStubCosign({ allow = 'LEGIT_BINARY_v1' } = {}) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'pgserve-verify-stub-cosign-'));
+  const callLog = path.join(dir, 'calls.log');
+  // Hardcode `process.execPath` in the shebang because the child runs with
+  // PATH=<stub dir only>, so `#!/usr/bin/env node` would fail to find node.
+  const script = `#!${process.execPath}
+const fs = require('node:fs');
+const args = process.argv.slice(2);
+fs.appendFileSync(${JSON.stringify(callLog)}, JSON.stringify(args) + '\\n');
+if (args[0] !== 'verify-blob') process.exit(2);
+const binaryPath = args[args.length - 1];
+let body;
+try { body = fs.readFileSync(binaryPath, 'utf8'); } catch { process.exit(3); }
+if (body.startsWith(${JSON.stringify(allow)})) {
+  process.stdout.write('Verified OK\\n');
+  process.exit(0);
+}
+process.stderr.write('cosign-stub: rejected\\n');
+process.exit(1);
+`;
+  const stubPath = path.join(dir, 'cosign');
+  fs.writeFileSync(stubPath, script, { mode: 0o755 });
+  return { dir, stubPath, callLog };
+}
+
+function makeBinary(body) {
+  const file = path.join(tmpBinDir, 'postgres');
+  fs.writeFileSync(file, body);
+  fs.chmodSync(file, 0o755);
+  return file;
+}
+
+function makeBundle(binaryPath) {
+  const bundle = `${binaryPath}.bundle`;
+  fs.writeFileSync(bundle, '{"fake":"bundle","version":1}');
+  return bundle;
+}
+
+function readCalls(callLog) {
+  if (!fs.existsSync(callLog)) return [];
+  return fs.readFileSync(callLog, 'utf8').split('\n').filter(Boolean).map((l) => JSON.parse(l));
+}
+
+function runCli(args, env = {}) {
+  // Use process.execPath (absolute path to node) so we don't need /usr/bin
+  // on PATH. PATH inside the child is set to ONLY the stub cosign dir so
+  // the verifier can't accidentally find a real cosign on the host.
+  return spawnSync(process.execPath, [BIN, 'verify', ...args], {
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      // Cache tokens land under XDG_STATE_HOME/pgserve.
+      XDG_STATE_HOME: tmpStateRoot,
+      // Offline trust file is read via $HOME/.pgserve/trust/identities.json
+      // unless PGSERVE_TRUST_FILE points elsewhere.
+      HOME: tmpHome,
+      // Cosign comes only from the stub — do NOT inherit the real PATH
+      // in case a real cosign sits in front of our stub.
+      PATH: stubCosignDir,
+      ...env,
+    },
+  });
+}
+
+beforeEach(() => {
+  tmpStateRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'pgserve-verify-state-'));
+  tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'pgserve-verify-home-'));
+  tmpBinDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pgserve-verify-bin-'));
+  const stub = makeStubCosign({});
+  stubCosignDir = stub.dir;
+  originalEnv = {
+    XDG_STATE_HOME: process.env.XDG_STATE_HOME,
+    HOME: process.env.HOME,
+    PGSERVE_TRUST_FILE: process.env.PGSERVE_TRUST_FILE,
+  };
+});
+
+afterEach(() => {
+  fs.rmSync(tmpStateRoot, { recursive: true, force: true });
+  fs.rmSync(tmpHome, { recursive: true, force: true });
+  fs.rmSync(tmpBinDir, { recursive: true, force: true });
+  fs.rmSync(stubCosignDir, { recursive: true, force: true });
+  for (const [k, v] of Object.entries(originalEnv)) {
+    if (v === undefined) delete process.env[k];
+    else process.env[k] = v;
+  }
+});
+
+// ────────────────────────────────────────────────────────────────────────
+// Acceptance #1: legitimate signed binary passes, second call uses cache.
+// ────────────────────────────────────────────────────────────────────────
+
+describe('legitimate signed binary', () => {
+  test('first invocation calls cosign + writes a 0600 cache token', () => {
+    const binary = makeBinary('LEGIT_BINARY_v1\nELF...');
+    makeBundle(binary);
+    const callLog = path.join(stubCosignDir, 'calls.log');
+    const result = runCli([binary, '--json']);
+    expect(result.status).toBe(0);
+    const out = JSON.parse(result.stdout);
+    expect(out.ok).toBe(true);
+    expect(out.tier).toBe('cosign_signed');
+    expect(out.cached).toBe(false);
+    expect(typeof out.cacheFile).toBe('string');
+    expect(fs.existsSync(out.cacheFile)).toBe(true);
+    const mode = fs.statSync(out.cacheFile).mode & 0o777;
+    expect(mode).toBe(0o600);
+    expect(readCalls(callLog).length).toBe(1);
+  });
+
+  test('second invocation hits the cache (cosign NOT called again)', () => {
+    const binary = makeBinary('LEGIT_BINARY_v1\nELF...');
+    makeBundle(binary);
+    const callLog = path.join(stubCosignDir, 'calls.log');
+
+    const first = runCli([binary, '--json']);
+    expect(first.status).toBe(0);
+    expect(readCalls(callLog).length).toBe(1);
+
+    const second = runCli([binary, '--json']);
+    expect(second.status).toBe(0);
+    const out = JSON.parse(second.stdout);
+    expect(out.ok).toBe(true);
+    expect(out.cached).toBe(true);
+    expect(out.tier).toBe('cosign_signed');
+    // Cosign call count unchanged — cache short-circuited.
+    expect(readCalls(callLog).length).toBe(1);
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────
+// Acceptance #2: tampered binary is rejected with diagnostic.
+// ────────────────────────────────────────────────────────────────────────
+
+describe('tampered binary', () => {
+  test('exits non-zero with diagnostic, does NOT write cache', () => {
+    const binary = makeBinary('TAMPERED_PAYLOAD_v1\n');
+    makeBundle(binary);
+    const result = runCli([binary, '--json']);
+    expect(result.status).not.toBe(0);
+    const out = JSON.parse(result.stdout || '{}');
+    expect(out.ok).toBe(false);
+    expect(out.reason).toBe('no-trust-match');
+    // No cache token should have been written.
+    const verifiedDir = path.join(tmpStateRoot, 'pgserve', 'verified');
+    if (fs.existsSync(verifiedDir)) {
+      const files = fs.readdirSync(verifiedDir);
+      expect(files.length).toBe(0);
+    }
+  });
+
+  test('plain (non-JSON) output prints FAILED on stderr', () => {
+    const binary = makeBinary('TAMPERED_PAYLOAD_v1\n');
+    makeBundle(binary);
+    const result = runCli([binary]);
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain('FAILED');
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────
+// Acceptance #3: --skip-sigstore without pretrusted key refuses.
+// ────────────────────────────────────────────────────────────────────────
+
+describe('--skip-sigstore without pretrusted key', () => {
+  test('refuses non-zero with cross-group remediation hint', () => {
+    const binary = makeBinary('LEGIT_BINARY_v1\n');
+    // Note: NO bundle, NO trust file. --skip-sigstore should not need
+    // either, but it must refuse because no offline key is registered.
+    const result = runCli([binary, '--skip-sigstore', '--json']);
+    expect(result.status).not.toBe(0);
+    const out = JSON.parse(result.stdout || '{}');
+    expect(out.ok).toBe(false);
+    expect(out.reason).toBe('skip-sigstore-without-pretrusted-key');
+    expect(out.detail).toContain('pgserve trust add --offline-cosign-key');
+  });
+
+  test('exits with EXIT_INVOCATION (3) — operator misuse, not verify failure', () => {
+    const binary = makeBinary('LEGIT_BINARY_v1\n');
+    const result = runCli([binary, '--skip-sigstore']);
+    expect(result.status).toBe(3);
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────
+// Acceptance #3b: --skip-sigstore WITH a pretrusted key passes (self_signed).
+// G3 will populate this trust file via `pgserve trust add
+// --offline-cosign-key`. Until G3 ships, we test against a hand-written
+// fixture in the expected schema.
+// ────────────────────────────────────────────────────────────────────────
+
+describe('--skip-sigstore with offline-cosign-key', () => {
+  test('passes verification, records self_signed tier in cache', () => {
+    const trustDir = path.join(tmpHome, '.pgserve', 'trust');
+    fs.mkdirSync(trustDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(trustDir, 'identities.json'),
+      JSON.stringify({
+        offlineKeys: [{
+          id: 'operator-rebuild-key',
+          publisher: '@automagik/pgserve',
+          keyFingerprint: 'sha256:deadbeef',
+          addedAt: '2026-05-08T00:00:00Z',
+        }],
+      }, null, 2),
+      { mode: 0o600 },
+    );
+    const binary = makeBinary('OPERATOR_REBUILT_v1\n');
+    const result = runCli([binary, '--skip-sigstore', '--json']);
+    expect(result.status).toBe(0);
+    const out = JSON.parse(result.stdout);
+    expect(out.ok).toBe(true);
+    expect(out.tier).toBe('self_signed');
+    expect(out.identity).toBe('operator-rebuild-key');
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────
+// Acceptance #4: cache invalidation on binary mtime change.
+// ────────────────────────────────────────────────────────────────────────
+
+describe('cache invalidation', () => {
+  test('binary mtime change forces a fresh cosign call', () => {
+    const binary = makeBinary('LEGIT_BINARY_v1\nv1');
+    makeBundle(binary);
+    const callLog = path.join(stubCosignDir, 'calls.log');
+
+    const first = runCli([binary, '--json']);
+    expect(first.status).toBe(0);
+    expect(readCalls(callLog).length).toBe(1);
+
+    // Bump mtime to the future. Re-write content (legit prefix preserved
+    // so the second verify still passes — we're testing invalidation, not
+    // tamper detection).
+    fs.writeFileSync(binary, 'LEGIT_BINARY_v1\nv2-with-different-bytes');
+    const future = new Date(Date.now() + 60 * 1000);
+    fs.utimesSync(binary, future, future);
+
+    const second = runCli([binary, '--json']);
+    expect(second.status).toBe(0);
+    const out = JSON.parse(second.stdout);
+    expect(out.ok).toBe(true);
+    expect(out.cached).toBe(false);
+    // Cosign was invoked again because the cached attestation no longer
+    // matches the binary's mtime/size.
+    expect(readCalls(callLog).length).toBe(2);
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────
+// Misuse: missing binary, missing bundle.
+// ────────────────────────────────────────────────────────────────────────
+
+describe('invocation errors', () => {
+  test('missing binary path → EXIT_INVOCATION (3) + binary-missing', () => {
+    const result = runCli([path.join(tmpBinDir, 'no-such-file'), '--json']);
+    expect(result.status).toBe(3);
+    const out = JSON.parse(result.stdout || '{}');
+    expect(out.ok).toBe(false);
+    expect(out.reason).toBe('binary-missing');
+  });
+
+  test('missing bundle sidecar → EXIT_INVOCATION (3) + bundle-missing', () => {
+    const binary = makeBinary('LEGIT_BINARY_v1\n');
+    // intentionally NO bundle file.
+    const result = runCli([binary, '--json']);
+    expect(result.status).toBe(3);
+    const out = JSON.parse(result.stdout || '{}');
+    expect(out.ok).toBe(false);
+    expect(out.reason).toBe('bundle-missing');
+  });
+
+  test('no positional arg → prints help and exits 3', () => {
+    const result = runCli(['--json']);
+    expect(result.status).toBe(3);
+    expect(result.stderr).toContain('pgserve verify');
+  });
+
+  test('--help exits 0 and prints usage', () => {
+    const result = runCli(['--help']);
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('pgserve verify');
+  });
+});

--- a/tests/cosign/cache-token.test.js
+++ b/tests/cosign/cache-token.test.js
@@ -1,0 +1,301 @@
+/**
+ * Tests for src/cosign/cache-token.js — HMAC-signed verification cache.
+ *
+ * pgserve singleton (v2.4) — `pgserve-singleton-no-proxy` wish, Group 4.
+ *
+ * Strategy: each test owns its own tempdir which we wire as the
+ * `XDG_STATE_HOME` so `getStateDir()` resolves under the tempdir without
+ * touching the real `~/.local/state`.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import {
+  buildTokenPayload,
+  computeBinaryAttestation,
+  deleteCacheToken,
+  ensureHmacKey,
+  getHmacKeyPath,
+  getStateDir,
+  getTokenPath,
+  getVerifiedDir,
+  HMAC_KEY_BYTES,
+  readCacheToken,
+  SLIDING_IDLE_MS,
+  SLIDING_MAX_MS,
+  TOKEN_VERSION,
+  touchCacheToken,
+  writeCacheToken,
+} from '../../src/cosign/cache-token.js';
+
+let tmpStateRoot;
+let tmpBinDir;
+let originalXdg;
+
+function makeBinary(name = 'fake-postgres', body = 'LEGIT_BINARY_v1') {
+  const file = path.join(tmpBinDir, name);
+  fs.writeFileSync(file, body);
+  fs.chmodSync(file, 0o755);
+  return file;
+}
+
+beforeEach(() => {
+  tmpStateRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'pgserve-cache-test-'));
+  tmpBinDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pgserve-cache-bin-'));
+  originalXdg = process.env.XDG_STATE_HOME;
+  process.env.XDG_STATE_HOME = tmpStateRoot;
+});
+
+afterEach(() => {
+  fs.rmSync(tmpStateRoot, { recursive: true, force: true });
+  fs.rmSync(tmpBinDir, { recursive: true, force: true });
+  if (originalXdg === undefined) delete process.env.XDG_STATE_HOME;
+  else process.env.XDG_STATE_HOME = originalXdg;
+});
+
+describe('getStateDir resolves under XDG_STATE_HOME', () => {
+  test('returns $XDG_STATE_HOME/pgserve when set', () => {
+    expect(getStateDir()).toBe(path.join(tmpStateRoot, 'pgserve'));
+  });
+
+  test('verified dir is $XDG_STATE_HOME/pgserve/verified', () => {
+    expect(getVerifiedDir()).toBe(path.join(tmpStateRoot, 'pgserve', 'verified'));
+  });
+
+  test('hmac key path is $XDG_STATE_HOME/pgserve/cache.hmac', () => {
+    expect(getHmacKeyPath()).toBe(path.join(tmpStateRoot, 'pgserve', 'cache.hmac'));
+  });
+});
+
+describe('ensureHmacKey', () => {
+  test('creates the key file with mode 0600 on first call', () => {
+    const key = ensureHmacKey();
+    expect(key.length).toBe(HMAC_KEY_BYTES);
+    const file = getHmacKeyPath();
+    expect(fs.existsSync(file)).toBe(true);
+    const mode = fs.statSync(file).mode & 0o777;
+    expect(mode).toBe(0o600);
+  });
+
+  test('returns the same bytes across calls', () => {
+    const a = ensureHmacKey();
+    const b = ensureHmacKey();
+    expect(Buffer.compare(a, b)).toBe(0);
+  });
+
+  test('regenerates when file is wrong-sized (treats as cache poisoning)', () => {
+    ensureHmacKey();
+    fs.writeFileSync(getHmacKeyPath(), 'too-short');
+    const fresh = ensureHmacKey();
+    expect(fresh.length).toBe(HMAC_KEY_BYTES);
+  });
+});
+
+describe('getTokenPath', () => {
+  test('rejects fingerprints with shell-unsafe characters', () => {
+    expect(() => getTokenPath('a/b')).toThrow(/unsafe/);
+    expect(() => getTokenPath('a b')).toThrow(/unsafe/);
+    expect(() => getTokenPath('')).toThrow(/non-empty/);
+  });
+
+  test('accepts dotted hex-style fingerprints', () => {
+    expect(() => getTokenPath('postgres.0123abcd')).not.toThrow();
+  });
+});
+
+describe('writeCacheToken + readCacheToken — round trip', () => {
+  test('writes a 0600 token and reads it back', () => {
+    const file = makeBinary();
+    const attestation = computeBinaryAttestation(file);
+    const payload = buildTokenPayload({
+      fingerprint: 'fake.aaaa1111',
+      binary: attestation,
+      identity: 'automagik-pgserve-release',
+      tier: 'cosign_signed',
+      sha256: 'aaaa1111',
+    });
+    const tokenFile = writeCacheToken(payload, {});
+    expect(fs.existsSync(tokenFile)).toBe(true);
+    const mode = fs.statSync(tokenFile).mode & 0o777;
+    expect(mode).toBe(0o600);
+
+    const loaded = readCacheToken('fake.aaaa1111', { binaryAttestation: attestation });
+    expect(loaded.ok).toBe(true);
+    expect(loaded.payload.identity).toBe('automagik-pgserve-release');
+    expect(loaded.payload.tier).toBe('cosign_signed');
+    expect(loaded.payload.v).toBe(TOKEN_VERSION);
+  });
+
+  test('detects HMAC tampering (corrupted envelope.mac)', () => {
+    const file = makeBinary();
+    const attestation = computeBinaryAttestation(file);
+    const payload = buildTokenPayload({
+      fingerprint: 'fake.bbbb2222',
+      binary: attestation,
+      identity: 'automagik-genie-release',
+      tier: 'cosign_signed',
+      sha256: 'bbbb2222',
+    });
+    const tokenFile = writeCacheToken(payload, {});
+    const envelope = JSON.parse(fs.readFileSync(tokenFile, 'utf8'));
+    envelope.mac = '0'.repeat(envelope.mac.length);
+    fs.writeFileSync(tokenFile, JSON.stringify(envelope));
+
+    const loaded = readCacheToken('fake.bbbb2222', { binaryAttestation: attestation });
+    expect(loaded.ok).toBe(false);
+    expect(loaded.reason).toBe('hmac-mismatch');
+  });
+
+  test('detects payload tampering (mac ok, payload mutated)', () => {
+    const file = makeBinary();
+    const attestation = computeBinaryAttestation(file);
+    const payload = buildTokenPayload({
+      fingerprint: 'fake.cccc3333',
+      binary: attestation,
+      identity: 'automagik-genie-release',
+      tier: 'cosign_signed',
+      sha256: 'cccc3333',
+    });
+    const tokenFile = writeCacheToken(payload, {});
+    const envelope = JSON.parse(fs.readFileSync(tokenFile, 'utf8'));
+    envelope.payload = envelope.payload.replace('cosign_signed', 'self_signed___');
+    fs.writeFileSync(tokenFile, JSON.stringify(envelope));
+
+    const loaded = readCacheToken('fake.cccc3333', { binaryAttestation: attestation });
+    expect(loaded.ok).toBe(false);
+    expect(loaded.reason).toBe('hmac-mismatch');
+  });
+});
+
+describe('binary-attestation invalidation', () => {
+  test('mtime change invalidates the cached token', () => {
+    const file = makeBinary('postgres', 'before-mtime-bump');
+    const attestation = computeBinaryAttestation(file);
+    const payload = buildTokenPayload({
+      fingerprint: 'postgres.dddd4444',
+      binary: attestation,
+      identity: 'automagik-pgserve-release',
+      tier: 'cosign_signed',
+      sha256: 'dddd4444',
+    });
+    writeCacheToken(payload, {});
+
+    // Bump the mtime (simulate "operator updated the binary").
+    const future = new Date(Date.now() + 60 * 1000);
+    fs.utimesSync(file, future, future);
+    const newAttestation = computeBinaryAttestation(file);
+
+    const loaded = readCacheToken('postgres.dddd4444', { binaryAttestation: newAttestation });
+    expect(loaded.ok).toBe(false);
+    expect(loaded.reason).toBe('binary-changed');
+  });
+
+  test('size change invalidates the cached token', () => {
+    const file = makeBinary('pg-tools', 'short');
+    const attestation = computeBinaryAttestation(file);
+    writeCacheToken(buildTokenPayload({
+      fingerprint: 'pg-tools.eeee5555',
+      binary: attestation,
+      identity: 'automagik-pgserve-release',
+      tier: 'cosign_signed',
+      sha256: 'eeee5555',
+    }), {});
+
+    fs.writeFileSync(file, 'a-completely-different-and-larger-payload');
+    const loaded = readCacheToken('pg-tools.eeee5555', { binaryAttestation: computeBinaryAttestation(file) });
+    expect(loaded.ok).toBe(false);
+    expect(loaded.reason).toBe('binary-changed');
+  });
+});
+
+describe('sliding expiry', () => {
+  test('lapses on idle window', () => {
+    const file = makeBinary();
+    const attestation = computeBinaryAttestation(file);
+    const oldNow = Date.now() - SLIDING_IDLE_MS - 1000;
+    const payload = buildTokenPayload({
+      fingerprint: 'idle.ffff6666',
+      binary: attestation,
+      identity: 'automagik-genie-release',
+      tier: 'cosign_signed',
+      sha256: 'ffff6666',
+      now: oldNow,
+    });
+    writeCacheToken(payload, {});
+    const loaded = readCacheToken('idle.ffff6666', { binaryAttestation: attestation });
+    expect(loaded.ok).toBe(false);
+    expect(loaded.reason).toBe('expired-idle');
+  });
+
+  test('lapses on absolute max window', () => {
+    const file = makeBinary();
+    const attestation = computeBinaryAttestation(file);
+    const veryOld = Date.now() - SLIDING_MAX_MS - 1000;
+    const payload = buildTokenPayload({
+      fingerprint: 'max.7777aaaa',
+      binary: attestation,
+      identity: 'automagik-genie-release',
+      tier: 'cosign_signed',
+      sha256: '7777aaaa',
+      now: veryOld,
+    });
+    writeCacheToken(payload, {});
+    // Bump lastUsedAt to "now" so idle alone wouldn't trip — only max should.
+    const tokenFile = getTokenPath('max.7777aaaa');
+    const envelope = JSON.parse(fs.readFileSync(tokenFile, 'utf8'));
+    const innerPayload = JSON.parse(envelope.payload);
+    innerPayload.lastUsedAt = Date.now();
+    // Re-write deterministically. We can't sign without re-running writeCacheToken,
+    // so produce a fresh payload that keeps `createdAt` ancient but lastUsedAt fresh.
+    writeCacheToken({ ...innerPayload }, {});
+
+    const loaded = readCacheToken('max.7777aaaa', { binaryAttestation: attestation });
+    expect(loaded.ok).toBe(false);
+    expect(loaded.reason).toBe('expired-max');
+  });
+});
+
+describe('touchCacheToken bumps lastUsedAt', () => {
+  test('rewrites the token with a fresher lastUsedAt', () => {
+    const file = makeBinary();
+    const attestation = computeBinaryAttestation(file);
+    const oldNow = Date.now() - 30 * 60 * 1000; // 30 min ago
+    const payload = buildTokenPayload({
+      fingerprint: 'touch.8888bbbb',
+      binary: attestation,
+      identity: 'automagik-genie-release',
+      tier: 'cosign_signed',
+      sha256: '8888bbbb',
+      now: oldNow,
+    });
+    writeCacheToken(payload, {});
+    const before = readCacheToken('touch.8888bbbb', { binaryAttestation: attestation });
+    expect(before.ok).toBe(true);
+    const bumped = touchCacheToken(before.payload, {});
+    expect(bumped).not.toBeNull();
+    expect(bumped.lastUsedAt).toBeGreaterThan(before.payload.lastUsedAt);
+  });
+});
+
+describe('deleteCacheToken', () => {
+  test('removes an existing token file (returns true)', () => {
+    const file = makeBinary();
+    const attestation = computeBinaryAttestation(file);
+    writeCacheToken(buildTokenPayload({
+      fingerprint: 'del.9999cccc',
+      binary: attestation,
+      identity: 'automagik-pgserve-release',
+      tier: 'cosign_signed',
+      sha256: '9999cccc',
+    }), {});
+    expect(deleteCacheToken('del.9999cccc', {})).toBe(true);
+    expect(fs.existsSync(getTokenPath('del.9999cccc'))).toBe(false);
+  });
+
+  test('returns false on missing file', () => {
+    expect(deleteCacheToken('does-not-exist', {})).toBe(false);
+  });
+});

--- a/tests/cosign/schema.test.js
+++ b/tests/cosign/schema.test.js
@@ -1,0 +1,95 @@
+/**
+ * Tests for src/cosign/schema.js — additive `pgserve_meta` migration.
+ *
+ * pgserve singleton (v2.4) — `pgserve-singleton-no-proxy` wish, Group 4.
+ *
+ * No live postgres is required: `applyVerifiedColumns()` only needs an
+ * object with an async `query()` method, so we drive it with a fake that
+ * records the SQL. Confidence in the actual SQL idempotency lives in
+ * Group 9's integration tests.
+ */
+
+import { describe, expect, test } from 'bun:test';
+
+import {
+  applyVerifiedColumns,
+  getMigrationSQL,
+  getMigrationStatements,
+  isValidTier,
+  VERIFIED_TIER_CHECK_NAME,
+  VERIFIED_TIER_VALUES,
+} from '../../src/cosign/schema.js';
+
+class FakePgClient {
+  constructor() {
+    this.executed = [];
+  }
+  async query(sql) {
+    this.executed.push(sql);
+    return { rows: [] };
+  }
+}
+
+describe('VERIFIED_TIER_VALUES contract', () => {
+  test('lists exactly the four tiers from the wish', () => {
+    expect([...VERIFIED_TIER_VALUES]).toEqual(['path', 'host_signed', 'self_signed', 'cosign_signed']);
+  });
+
+  test('isValidTier accepts every listed tier', () => {
+    for (const t of VERIFIED_TIER_VALUES) expect(isValidTier(t)).toBe(true);
+  });
+
+  test('isValidTier rejects unknown tiers', () => {
+    expect(isValidTier('something-else')).toBe(false);
+    expect(isValidTier('')).toBe(false);
+    expect(isValidTier(null)).toBe(false);
+  });
+});
+
+describe('getMigrationStatements()', () => {
+  const stmts = getMigrationStatements();
+
+  test('emits 4 idempotent statements (3 ADD COLUMN + 1 DO-block CHECK)', () => {
+    expect(stmts.length).toBe(4);
+  });
+
+  test('each ADD COLUMN uses IF NOT EXISTS for idempotency', () => {
+    expect(stmts[0]).toContain('ADD COLUMN IF NOT EXISTS verified_at');
+    expect(stmts[1]).toContain('ADD COLUMN IF NOT EXISTS verified_identity');
+    expect(stmts[2]).toContain('ADD COLUMN IF NOT EXISTS verified_tier');
+  });
+
+  test('CHECK constraint names the canonical constant', () => {
+    expect(stmts[3]).toContain(VERIFIED_TIER_CHECK_NAME);
+  });
+
+  test('CHECK constraint enumerates every tier literal', () => {
+    for (const tier of VERIFIED_TIER_VALUES) {
+      expect(stmts[3]).toContain(`'${tier}'`);
+    }
+  });
+});
+
+describe('getMigrationSQL()', () => {
+  test('joins all statements into a single semicolon-terminated blob', () => {
+    const sql = getMigrationSQL();
+    expect(sql.trim().endsWith(';')).toBe(true);
+    expect(sql).toContain('verified_at');
+    expect(sql).toContain('verified_identity');
+    expect(sql).toContain('verified_tier');
+  });
+});
+
+describe('applyVerifiedColumns()', () => {
+  test('issues each statement once, in order, on the supplied client', async () => {
+    const fake = new FakePgClient();
+    const issued = await applyVerifiedColumns(fake);
+    expect(issued.length).toBe(4);
+    expect(fake.executed).toEqual(issued);
+  });
+
+  test('refuses clients without a query() method', async () => {
+    expect(applyVerifiedColumns(null)).rejects.toThrow(/query/);
+    expect(applyVerifiedColumns({})).rejects.toThrow(/query/);
+  });
+});

--- a/tests/cosign/verify-binary.test.js
+++ b/tests/cosign/verify-binary.test.js
@@ -1,0 +1,222 @@
+/**
+ * Tests for src/cosign/verify-binary.js — cosign keyless verifier shim.
+ *
+ * pgserve singleton (v2.4) — `pgserve-singleton-no-proxy` wish, Group 4.
+ *
+ * Strategy: stub `cosign` on a temp PATH (cheaper than installing a real
+ * cosign + cooking real signatures). The stub:
+ *   - exit 0 if the binary content begins with `LEGIT_BINARY_v1`,
+ *   - exit 1 otherwise.
+ * That gives us the four behaviors we need (legit pass / tampered reject /
+ * trust-root iteration / cosign-missing diagnostics) without dragging
+ * Sigstore into the test loop.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { resolveBundlePath, sha256File, verifyBinary } from '../../src/cosign/verify-binary.js';
+
+const FAKE_TRUST_LIST = [
+  Object.freeze({
+    id: 'fake-genie-release',
+    publisher: '@automagik/genie',
+    issuer: 'https://token.actions.githubusercontent.com',
+    identityRegexp: '^https://github.com/automagik-dev/genie/.*$',
+    description: 'fake genie identity (test fixture)',
+  }),
+];
+
+let tmpRoot;
+let stubBinDir;
+let stubLog;
+
+function makeStubCosign({ allow = 'LEGIT_BINARY_v1' } = {}) {
+  // Stubs cosign verify-blob. Exits 0 when the binary's first bytes match
+  // `allow`; non-zero otherwise. Records every invocation as JSON lines.
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'pgserve-cosign-stub-'));
+  const callLog = path.join(dir, 'calls.log');
+  // Hardcode `process.execPath` in the shebang so the stub doesn't need
+  // /usr/bin/env or `node` on the child's PATH (callers may scrub it).
+  const script = `#!${process.execPath}
+const fs = require('node:fs');
+const args = process.argv.slice(2);
+fs.appendFileSync(${JSON.stringify(callLog)}, JSON.stringify(args) + '\\n');
+
+if (args[0] !== 'verify-blob') {
+  process.stderr.write('cosign-stub: unsupported subcommand ' + args[0] + '\\n');
+  process.exit(2);
+}
+
+// Last arg is the binary path.
+const binaryPath = args[args.length - 1];
+let body;
+try { body = fs.readFileSync(binaryPath, 'utf8'); }
+catch (err) {
+  process.stderr.write('cosign-stub: cannot read ' + binaryPath + ': ' + err.message + '\\n');
+  process.exit(3);
+}
+
+const allow = ${JSON.stringify(allow)};
+if (body.startsWith(allow)) {
+  process.stdout.write('Verified OK\\n');
+  process.exit(0);
+}
+process.stderr.write('cosign-stub: rejected — body did not start with allow marker\\n');
+process.exit(1);
+`;
+  const stubPath = path.join(dir, 'cosign');
+  fs.writeFileSync(stubPath, script, { mode: 0o755 });
+  return { dir, stubPath, callLog };
+}
+
+function makeBinary(name, body) {
+  const file = path.join(tmpRoot, name);
+  fs.writeFileSync(file, body);
+  fs.chmodSync(file, 0o755);
+  return file;
+}
+
+function makeBundle(binaryPath, body = '{"fake":"bundle"}') {
+  const bundle = resolveBundlePath(binaryPath);
+  fs.writeFileSync(bundle, body);
+  return bundle;
+}
+
+beforeEach(() => {
+  tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'pgserve-verify-bin-'));
+  const stub = makeStubCosign({});
+  stubBinDir = stub.dir;
+  stubLog = stub.callLog;
+});
+
+afterEach(() => {
+  fs.rmSync(tmpRoot, { recursive: true, force: true });
+  fs.rmSync(stubBinDir, { recursive: true, force: true });
+});
+
+function readCallLog() {
+  if (!fs.existsSync(stubLog)) return [];
+  return fs.readFileSync(stubLog, 'utf8').split('\n').filter(Boolean).map((l) => JSON.parse(l));
+}
+
+describe('verifyBinary — happy path', () => {
+  test('returns ok with identity + cosign tier when stub cosign passes', () => {
+    const binary = makeBinary('postgres', 'LEGIT_BINARY_v1\nELF\0...');
+    makeBundle(binary);
+    const result = verifyBinary(binary, {
+      cosignBin: path.join(stubBinDir, 'cosign'),
+      trustList: FAKE_TRUST_LIST,
+    });
+    expect(result.ok).toBe(true);
+    expect(result.identity).toBe('fake-genie-release');
+    expect(result.tier).toBe('cosign_signed');
+    expect(result.sha256).toBe(sha256File(binary));
+    expect(result.cosignBin).toBe(path.join(stubBinDir, 'cosign'));
+  });
+
+  test('invokes cosign with verify-blob + identity flags', () => {
+    const binary = makeBinary('postgres-1', 'LEGIT_BINARY_v1\nrest');
+    makeBundle(binary);
+    verifyBinary(binary, {
+      cosignBin: path.join(stubBinDir, 'cosign'),
+      trustList: FAKE_TRUST_LIST,
+    });
+    const calls = readCallLog();
+    expect(calls.length).toBe(1);
+    const args = calls[0];
+    expect(args[0]).toBe('verify-blob');
+    expect(args).toContain('--bundle');
+    expect(args).toContain('--certificate-identity-regexp');
+    expect(args).toContain('--certificate-oidc-issuer');
+    expect(args[args.length - 1]).toBe(binary);
+  });
+});
+
+describe('verifyBinary — rejection paths', () => {
+  test('tampered binary content → no-trust-match', () => {
+    const binary = makeBinary('postgres-tampered', 'TAMPERED_BINARY\nELF\0...');
+    makeBundle(binary);
+    const result = verifyBinary(binary, {
+      cosignBin: path.join(stubBinDir, 'cosign'),
+      trustList: FAKE_TRUST_LIST,
+    });
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe('no-trust-match');
+    expect(result.identityChain).toBeDefined();
+    expect(result.identityChain[0].status).toBe('rejected');
+  });
+
+  test('missing bundle → bundle-missing', () => {
+    const binary = makeBinary('no-bundle', 'LEGIT_BINARY_v1\n');
+    const result = verifyBinary(binary, {
+      cosignBin: path.join(stubBinDir, 'cosign'),
+      trustList: FAKE_TRUST_LIST,
+    });
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe('bundle-missing');
+  });
+
+  test('missing binary → binary-missing', () => {
+    const result = verifyBinary(path.join(tmpRoot, 'nonexistent'), {
+      cosignBin: path.join(stubBinDir, 'cosign'),
+      trustList: FAKE_TRUST_LIST,
+    });
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe('binary-missing');
+  });
+
+  test('binary path is a directory → binary-not-a-file', () => {
+    const dir = path.join(tmpRoot, 'a-dir');
+    fs.mkdirSync(dir);
+    const result = verifyBinary(dir, {
+      cosignBin: path.join(stubBinDir, 'cosign'),
+      trustList: FAKE_TRUST_LIST,
+    });
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe('binary-not-a-file');
+  });
+
+  test('cosign rejection from a stub that always fails → no-trust-match', () => {
+    // Build a second stub that rejects unconditionally — exercises the
+    // failure path without depending on host PATH state. The
+    // cosign-missing branch is exercised by the CLI tests where we can
+    // fully control PATH + HOME.
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'pgserve-cosign-fail-'));
+    const stubPath = path.join(dir, 'cosign');
+    fs.writeFileSync(stubPath, '#!/usr/bin/env node\nprocess.exit(1);\n', { mode: 0o755 });
+    try {
+      const binary = makeBinary('postgres-2', 'LEGIT_BINARY_v1\n');
+      makeBundle(binary);
+      const result = verifyBinary(binary, {
+        cosignBin: stubPath,
+        trustList: FAKE_TRUST_LIST,
+      });
+      expect(result.ok).toBe(false);
+      expect(result.reason).toBe('no-trust-match');
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('verifyBinary — input validation', () => {
+  test('rejects empty binaryPath', () => {
+    const r = verifyBinary('', { trustList: FAKE_TRUST_LIST });
+    expect(r.ok).toBe(false);
+    expect(r.reason).toBe('invalid-args');
+  });
+
+  test('rejects empty trust list', () => {
+    const binary = makeBinary('p-empty', 'LEGIT_BINARY_v1');
+    makeBundle(binary);
+    const r = verifyBinary(binary, {
+      cosignBin: path.join(stubBinDir, 'cosign'),
+      trustList: [],
+    });
+    expect(r.ok).toBe(false);
+    expect(r.reason).toBe('empty-trust-list');
+  });
+});

--- a/tests/upgrade/postinstall.test.js
+++ b/tests/upgrade/postinstall.test.js
@@ -36,10 +36,12 @@ test('postinstall: fresh install (no data dir) exits 0 silently', () => {
   fs.rmSync(tmp, { recursive: true, force: true });
 });
 
-test('upgrade orchestrator: dry-run lists 6 steps without executing', async () => {
+test('upgrade orchestrator: dry-run lists 7 steps without executing', async () => {
   const { upgrade, STEPS } = await import(path.join(__dirname, '..', '..', 'src', 'upgrade', 'index.js'));
-  expect(STEPS.length).toBe(6);
+  // 7 steps after pgserve singleton (v2.4) added cosign-meta-migration.
+  expect(STEPS.length).toBe(7);
+  expect(STEPS.map((s) => s.name)).toContain('cosign-meta-migration');
   const r = await upgrade({ dryRun: true, quiet: true });
-  expect(r.results.length).toBe(6);
+  expect(r.results.length).toBe(7);
   expect(r.results.every((x) => x.status === 'DRY-RUN')).toBe(true);
 });


### PR DESCRIPTION
Mid-work checkpoint. Engineer disbanded before tests landed. Preserves 11 files (+1686 lines) for future engineer to finish + validate.

## What landed

- `src/cosign/cache-token.js`, `schema.js`, `trust-list.js` — skeletons (parked from prior round)
- `src/cosign/verify-binary.js` (NEW) — cosign CLI shellout per Decision P5
- `src/commands/verify.js` (NEW) — `pgserve verify <path>` entry point
- `src/cli-install.cjs` — routing for verify subcommand
- `src/upgrade/index.js` — pgserve_meta migration runner wiring
- `bin/pgserve-wrapper.cjs` — subcommand dispatch
- `knip.json` — `src/cosign/**` added to entry list

## NOT shipped (work remaining for G4 acceptance)

- `tests/cli/verify.test.js` + `tests/cosign/` — not yet written
- `--skip-sigstore` flag completeness
- Cache-token mtime invalidation testing
- pgserve_meta delta idempotency proof

Cohort: singleton G4 of pgserve v2.4. Holding for engineer to finish before merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `pgserve verify` command for verifying binary authenticity using keyless OIDC signatures
  * Implemented automatic verification caching with configurable sliding expiration windows
  * Added `--skip-sigstore` option for offline verification using a local trust list
  * Added `--json` output format for machine-readable verification results
  * Extended database schema to store verification metadata

<!-- end of auto-generated comment: release notes by coderabbit.ai -->