### PR TITLE
feat(cutover#g19): autopg serve dual-transport + runtime.json discovery (WIP — tests pending)

### DIFF
--- a/bin/postgres-server.js
+++ b/bin/postgres-server.js
@@ -17,6 +17,7 @@
 
 import { PostgresManager } from '../src/postgres.js';
 import { resolveSocketDir, ensureSocketDir } from '../src/lib/socket-dir.js';
+import { writeRuntimeJson, clearRuntimeJson } from '../src/lib/runtime-json.js';
 import { createLogger } from '../src/logger.js';
 
 // Global error handlers — surface unhandled rejections + uncaught errors
@@ -95,6 +96,27 @@ async function runPostmasterSubcommand(postmasterArgs) {
     process.exit(1);
   }
 
+  // cutover G19: drop a runtime discovery file at <socketDir>/runtime.json
+  // so consumers' UDS-first probes find the live socket without globbing
+  // ephemeral pid-stamped dirs. The file is intentionally separate from
+  // ~/.autopg/admin.json (which records supervisor metadata, not live
+  // socket info) — that split lets the postmaster restart under a new
+  // pid without rewriting the supervisor record. NO `supervisor` key
+  // here; the writer rejects it.
+  try {
+    writeRuntimeJson({
+      socketDir,
+      port: opts.port,
+      pid: manager.process?.pid ?? process.pid,
+      autopgPid: process.pid,
+    });
+  } catch (err) {
+    logger.warn(
+      { err: err.message },
+      'pgserve postmaster: runtime.json write failed; consumers will fall back to admin.json',
+    );
+  }
+
   logger.info(
     { port: opts.port, socketDir, dataDir: opts.dataDir },
     'pgserve postmaster: ready (Unix socket + TCP)',
@@ -102,6 +124,12 @@ async function runPostmasterSubcommand(postmasterArgs) {
 
   const shutdown = async (signal) => {
     logger.info({ signal }, 'pgserve postmaster: stopping');
+    // Clear runtime.json BEFORE stopping the postmaster so the moment
+    // a graceful-shutdown signal lands, fresh consumers see "no live
+    // socket" instead of racing against a stale-pid record. On crash
+    // (uncaughtException, backend died) the file is left behind; the
+    // operator-facing detector is `process.kill(record.autopgPid, 0)`.
+    clearRuntimeJson(socketDir);
     try {
       await manager.stop();
     } catch (err) {

--- a/src/cli-install.cjs
+++ b/src/cli-install.cjs
@@ -262,11 +262,21 @@ function readDiscovery() {
     : resolveCanonicalSocketDir();
   const runtime = readRuntimeJsonSync(socketDir);
 
+  // PR #80 P2 fix: previous logic treated ANY parsed runtime.json as
+  // authoritative — a malformed-but-JSON file (no port, no socketDir) would
+  // hide later admin.json / config fallbacks because composedPort stayed
+  // null while the precedence chain stopped early. Validate that runtime
+  // actually carries a usable port + socketDir before treating it as live.
+  // Mirrors the admin / config branches' Number.isInteger guard.
   let composedSocketDir = null;
   let composedPort = null;
-  if (runtime) {
-    composedSocketDir = runtime.socketDir ?? socketDir;
-    composedPort = runtime.port ?? null;
+  const runtimeUsable = runtime
+    && Number.isInteger(runtime.port)
+    && typeof runtime.socketDir === 'string'
+    && runtime.socketDir.length > 0;
+  if (runtimeUsable) {
+    composedSocketDir = runtime.socketDir;
+    composedPort = runtime.port;
   } else if (admin && Number.isInteger(admin.port)) {
     composedSocketDir = admin.socketDir ?? socketDir;
     composedPort = admin.port;

--- a/src/cli-install.cjs
+++ b/src/cli-install.cjs
@@ -34,10 +34,15 @@ const path = require('node:path');
 // promise once at module load and await it from async install paths.
 const _adminJsonModuleP = import('./lib/admin-json.js');
 const _socketDirModuleP = import('./lib/socket-dir.js');
+const _runtimeJsonModuleP = import('./lib/runtime-json.js');
 
 async function loadCohortModules() {
-  const [adminJson, socketDirMod] = await Promise.all([_adminJsonModuleP, _socketDirModuleP]);
-  return { adminJson, socketDirMod };
+  const [adminJson, socketDirMod, runtimeJson] = await Promise.all([
+    _adminJsonModuleP,
+    _socketDirModuleP,
+    _runtimeJsonModuleP,
+  ]);
+  return { adminJson, socketDirMod, runtimeJson };
 }
 
 // pgserve singleton (v2.4) — `pgserve-singleton-no-proxy` wish, Group 1.
@@ -163,6 +168,121 @@ function readConfig() {
   } catch {
     return null;
   }
+}
+
+// cutover G19: discovery layer used by `autopg port / url / status`.
+//
+// Order of precedence (most-authoritative first):
+//   1. `<socketDir>/runtime.json` — written by the live postmaster at greet
+//      time, removed on graceful shutdown. Carries the *current* port + pid
+//      for an actually-running daemon.
+//   2. `~/.autopg/admin.json` — supervisor record written at install time.
+//      Survives postmaster restarts; doesn't reflect runtime state.
+//   3. `~/.autopg/config.json` — legacy pre-G19 install record. Final
+//      fallback so older installs that haven't been re-installed under v2.4
+//      still discover cleanly.
+//
+// All readers swallow errors — discovery must never throw on a missing or
+// truncated file. Synchronous on purpose: `dispatch()` for status/url/port
+// is sync and the wrapper handles only `Promise OR number` return types.
+function readRuntimeJsonSync(socketDir) {
+  if (typeof socketDir !== 'string' || socketDir.length === 0) return null;
+  const file = path.join(socketDir, 'runtime.json');
+  let raw;
+  try {
+    raw = fs.readFileSync(file, 'utf8');
+  } catch {
+    return null;
+  }
+  try {
+    const parsed = JSON.parse(raw);
+    return (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+function readAdminJsonSync() {
+  const file = path.join(getConfigDir(), ADMIN_FILE_NAME);
+  let raw;
+  try {
+    raw = fs.readFileSync(file, 'utf8');
+  } catch {
+    return null;
+  }
+  try {
+    const parsed = JSON.parse(raw);
+    return (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+function resolveCanonicalSocketDir() {
+  // Mirror src/lib/socket-dir.js#resolveSocketDir — pure function, no fs
+  // touch. Inlined here so the sync discovery layer doesn't need a top-
+  // level await on the ESM module.
+  const xdg = process.env.XDG_RUNTIME_DIR;
+  const base = xdg && xdg.length > 0 ? xdg : '/tmp';
+  return path.join(base, 'pgserve');
+}
+
+function isLivePid(pid) {
+  if (!Number.isInteger(pid) || pid < 1) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    return err && err.code === 'EPERM';
+  }
+}
+
+/**
+ * Compose a discovery view from runtime.json (preferred), admin.json
+ * (fallback), and config.json (legacy fallback). Returns:
+ *   {
+ *     runtime: { socketDir, port, pid, autopgPid, schemaVersion } | null,
+ *     admin:   { supervisor, socketDir, port, installedAt, ... }    | null,
+ *     config:  { port, dataDir, registeredAt }                       | null,
+ *     // composed view — best effort merge for callers that just want
+ *     // "where do I connect right now?":
+ *     socketDir: <string|null>,
+ *     port:      <number|null>,
+ *     liveAutopg: <boolean>     // true when runtime.json names a live pid
+ *   }
+ */
+function readDiscovery() {
+  const config = readConfig();
+  const admin = readAdminJsonSync();
+  // Prefer the socket dir the supervisor recorded at install time — that's
+  // the path operators configured. Only fall back to the canonical resolver
+  // when the install record is missing (fresh-host case).
+  const socketDir = (admin && typeof admin.socketDir === 'string' && admin.socketDir.length > 0)
+    ? admin.socketDir
+    : resolveCanonicalSocketDir();
+  const runtime = readRuntimeJsonSync(socketDir);
+
+  let composedSocketDir = null;
+  let composedPort = null;
+  if (runtime) {
+    composedSocketDir = runtime.socketDir ?? socketDir;
+    composedPort = runtime.port ?? null;
+  } else if (admin && Number.isInteger(admin.port)) {
+    composedSocketDir = admin.socketDir ?? socketDir;
+    composedPort = admin.port;
+  } else if (config && Number.isInteger(config.port)) {
+    composedPort = config.port;
+    composedSocketDir = socketDir;
+  }
+
+  return {
+    runtime,
+    admin,
+    config,
+    socketDir: composedSocketDir,
+    port: composedPort,
+    liveAutopg: !!(runtime && isLivePid(runtime.autopgPid)),
+  };
 }
 
 function writeConfig(config) {
@@ -704,15 +824,20 @@ function writeSupervisorRecord(adminJson, { supervisor, socketDir, port }) {
 /**
  * `pgserve status [--json]`
  *
- * Reports both pm2 state and on-disk config. Exits 0 with status info
- * regardless of running/stopped — operators script around the JSON output.
- * Non-zero only when the config is missing entirely (i.e. pgserve was
- * never installed).
+ * Reports both pm2 state and on-disk discovery (runtime.json → admin.json
+ * → config.json fallback chain). Exits 0 with status info regardless of
+ * running/stopped — operators script around the JSON output. Non-zero
+ * only when nothing was ever installed (no admin.json AND no config.json).
+ *
+ * Cutover G19: surfaces `runtime` (live socket discovery) and `socketDir`
+ * top-level so consumers can pick UDS vs TCP without parsing pm2 jlist.
  */
 function cmdStatus(args) {
   const json = args.includes('--json');
-  const config = readConfig();
-  if (!config) {
+  const discovery = readDiscovery();
+  const { config, admin, runtime } = discovery;
+
+  if (!config && !admin) {
     if (json) {
       process.stdout.write(`${JSON.stringify({ installed: false })}\n`);
     } else {
@@ -720,24 +845,41 @@ function cmdStatus(args) {
     }
     return 1;
   }
+
   const proc = pm2GetProcess(PM2_PROCESS_NAME);
   const status = proc?.pm2_env?.status ?? 'stopped';
   const pid = proc?.pid ?? null;
   const uptimeMs = proc?.pm2_env?.pm_uptime ? Date.now() - proc.pm2_env.pm_uptime : null;
   const restarts = proc?.pm2_env?.restart_time ?? 0;
 
+  const port = discovery.port;
+  const socketDir = discovery.socketDir;
+  const dataDir = config?.dataDir ?? null;
+
   const payload = {
     installed: true,
     name: PM2_PROCESS_NAME,
     status,
     pid,
-    port: config.port,
-    dataDir: config.dataDir,
+    port,
+    socketDir,
+    dataDir,
     logsDir: getLogsDir(),
-    url: `postgres://localhost:${config.port}/postgres`,
+    url: port ? `postgres://localhost:${port}/postgres` : null,
     uptimeMs,
     restarts,
-    registeredAt: config.registeredAt,
+    registeredAt: config?.registeredAt ?? null,
+    supervisor: admin?.supervisor ?? null,
+    runtime: runtime
+      ? {
+          socketDir: runtime.socketDir,
+          port: runtime.port,
+          pid: runtime.pid,
+          autopgPid: runtime.autopgPid,
+          schemaVersion: runtime.schemaVersion,
+          live: discovery.liveAutopg,
+        }
+      : null,
   };
 
   if (json) {
@@ -746,42 +888,53 @@ function cmdStatus(args) {
   }
   process.stdout.write(`name        ${payload.name}\n`);
   process.stdout.write(`status      ${payload.status}${payload.pid ? ` (pid ${payload.pid})` : ''}\n`);
-  process.stdout.write(`port        ${payload.port}\n`);
-  process.stdout.write(`url         ${payload.url}\n`);
-  process.stdout.write(`dataDir     ${payload.dataDir}\n`);
+  if (payload.supervisor) {
+    process.stdout.write(`supervisor  ${payload.supervisor}\n`);
+  }
+  if (payload.port != null) process.stdout.write(`port        ${payload.port}\n`);
+  if (payload.url) process.stdout.write(`url         ${payload.url}\n`);
+  if (payload.socketDir) process.stdout.write(`socketDir   ${payload.socketDir}\n`);
+  if (payload.dataDir) process.stdout.write(`dataDir     ${payload.dataDir}\n`);
   process.stdout.write(`logsDir     ${payload.logsDir}\n`);
+  if (payload.runtime) {
+    process.stdout.write(`runtime     pid=${payload.runtime.pid} autopgPid=${payload.runtime.autopgPid} live=${payload.runtime.live}\n`);
+  } else {
+    process.stdout.write(`runtime     (no runtime.json — postmaster down or never started)\n`);
+  }
   if (payload.uptimeMs != null) {
     const sec = Math.floor(payload.uptimeMs / 1000);
     process.stdout.write(`uptime      ${sec}s\n`);
   }
   process.stdout.write(`restarts    ${payload.restarts}\n`);
-  process.stdout.write(`registered  ${payload.registeredAt}\n`);
+  if (payload.registeredAt) process.stdout.write(`registered  ${payload.registeredAt}\n`);
   return 0;
 }
 
 /**
  * `pgserve url`
  *
- * Discovery API. Prints the canonical connection string. Downstream
+ * Discovery API. Prints the canonical TCP connection string. Downstream
  * installers (genie install, omni install) call this to learn where to
- * connect, instead of hardcoding a port.
+ * connect, instead of hardcoding a port. The TCP form is stable across
+ * Tier A / Tier B / fingerprint-disabled hosts; UDS callers should
+ * resolve `<socketDir>/.s.PGSQL.<port>` from `autopg status --json`.
  */
 function cmdUrl() {
-  const config = readConfig();
-  if (!config) {
+  const discovery = readDiscovery();
+  if (discovery.port == null) {
     fail('not installed (run: pgserve install)');
   }
-  process.stdout.write(`postgres://localhost:${config.port}/postgres\n`);
+  process.stdout.write(`postgres://localhost:${discovery.port}/postgres\n`);
   return 0;
 }
 
-/** `pgserve port` — print the canonical port. */
+/** `pgserve port` — print the canonical port from runtime.json → admin.json → config.json. */
 function cmdPort() {
-  const config = readConfig();
-  if (!config) {
+  const discovery = readDiscovery();
+  if (discovery.port == null) {
     fail('not installed (run: pgserve install)');
   }
-  process.stdout.write(`${config.port}\n`);
+  process.stdout.write(`${discovery.port}\n`);
   return 0;
 }
 

--- a/src/lib/runtime-json.js
+++ b/src/lib/runtime-json.js
@@ -1,0 +1,181 @@
+/**
+ * `<socketDir>/runtime.json` — runtime discovery file owned by the
+ * `autopg serve` postmaster wrapper (cutover wish G19).
+ *
+ * Schema:
+ *   {
+ *     socketDir:     "<absolute path>",
+ *     port:          <integer>,    // postgres TCP port
+ *     pid:           <integer>,    // postmaster pid
+ *     autopgPid:     <integer>,    // `autopg serve` wrapper pid
+ *     schemaVersion: 1
+ *   }
+ *
+ * Cohort contract — there is **no `supervisor` field**. The supervisor
+ * (pm2 / systemd-user / launchd / external) is recorded once at install
+ * time in `~/.autopg/admin.json`. Mixing the two creates a synchronization
+ * problem (which file is authoritative when the postmaster restarts under
+ * a new pid?). `writeRuntimeJson()` rejects records carrying a `supervisor`
+ * key so the contract can't drift via a future copy-paste.
+ *
+ * Lifecycle:
+ *   - `writeRuntimeJson()` after the postmaster greets healthy.
+ *   - `clearRuntimeJson()` on graceful shutdown (SIGTERM / SIGINT).
+ *   - On crash the file is left in place. Consumers detect a stale record
+ *     via `process.kill(record.autopgPid, 0)` (no-signal probe).
+ *
+ * Atomic semantics: write to `<file>.tmp.<pid>`, then `fs.renameSync()`.
+ * Mode 0644 so unprivileged peers can `cat <socketDir>/runtime.json`
+ * without sudo — the file carries no secrets, only public discovery info.
+ */
+
+import fs from 'fs';
+import path from 'path';
+
+export const RUNTIME_FILE_NAME = 'runtime.json';
+export const RUNTIME_FILE_MODE = 0o644;
+export const RUNTIME_SCHEMA_VERSION = 1;
+
+export function getRuntimeFilePath(socketDir) {
+  if (typeof socketDir !== 'string' || socketDir.length === 0) {
+    throw new TypeError('runtime-json: socketDir must be a non-empty string');
+  }
+  return path.join(socketDir, RUNTIME_FILE_NAME);
+}
+
+function isPlainObject(v) {
+  return v !== null && typeof v === 'object' && !Array.isArray(v);
+}
+
+function validateRecord(record) {
+  if (!isPlainObject(record)) {
+    throw new TypeError('runtime-json: record must be an object');
+  }
+  if (typeof record.socketDir !== 'string' || record.socketDir.length === 0) {
+    throw new TypeError('runtime-json: socketDir must be a non-empty string');
+  }
+  if (!Number.isInteger(record.port) || record.port < 1 || record.port > 65535) {
+    throw new TypeError(`runtime-json: port must be an integer in [1, 65535]; got ${record.port}`);
+  }
+  if (!Number.isInteger(record.pid) || record.pid < 1) {
+    throw new TypeError(`runtime-json: pid must be a positive integer; got ${record.pid}`);
+  }
+  if (!Number.isInteger(record.autopgPid) || record.autopgPid < 1) {
+    throw new TypeError(`runtime-json: autopgPid must be a positive integer; got ${record.autopgPid}`);
+  }
+  if (Object.prototype.hasOwnProperty.call(record, 'supervisor')) {
+    throw new TypeError(
+      'runtime-json: refusing to write `supervisor` into runtime.json — that field '
+      + 'lives only in `~/.autopg/admin.json` (cohort contract).',
+    );
+  }
+}
+
+/**
+ * Read `<socketDir>/runtime.json`. Returns the parsed object on success,
+ * `null` when the file is missing or unreadable. Never throws — callers
+ * treat "missing" and "broken" identically and fall back to admin.json.
+ */
+export function readRuntimeJson(socketDir) {
+  let file;
+  try {
+    file = getRuntimeFilePath(socketDir);
+  } catch {
+    return null;
+  }
+  let raw;
+  try {
+    raw = fs.readFileSync(file, 'utf8');
+  } catch {
+    return null;
+  }
+  try {
+    const parsed = JSON.parse(raw);
+    return isPlainObject(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Atomic write of the runtime discovery record. Validates shape, refuses
+ * a `supervisor` key (the cohort contract — that field belongs in
+ * admin.json), ensures the parent directory exists, and stamps
+ * `schemaVersion: 1` if the caller didn't.
+ */
+export function writeRuntimeJson(input = {}) {
+  if (!isPlainObject(input)) {
+    throw new TypeError('runtime-json: writeRuntimeJson expects an object argument');
+  }
+  // Reject `supervisor` from the input directly — destructuring would
+  // silently drop it and that's a contract failure we want to surface.
+  if (Object.prototype.hasOwnProperty.call(input, 'supervisor')) {
+    throw new TypeError(
+      'runtime-json: refusing to write `supervisor` into runtime.json — that field '
+      + 'lives only in `~/.autopg/admin.json` (cohort contract).',
+    );
+  }
+  const { socketDir, port, pid, autopgPid, schemaVersion = RUNTIME_SCHEMA_VERSION } = input;
+  const record = { socketDir, port, pid, autopgPid, schemaVersion };
+  validateRecord(record);
+
+  if (!fs.existsSync(socketDir)) {
+    fs.mkdirSync(socketDir, { recursive: true, mode: 0o700 });
+  }
+
+  const file = getRuntimeFilePath(socketDir);
+  const tmp = `${file}.tmp.${process.pid}`;
+  const json = `${JSON.stringify(record, null, 2)}\n`;
+  fs.writeFileSync(tmp, json, { mode: RUNTIME_FILE_MODE });
+  fs.renameSync(tmp, file);
+  fs.chmodSync(file, RUNTIME_FILE_MODE);
+  return record;
+}
+
+/**
+ * Best-effort delete of `<socketDir>/runtime.json`. Used during graceful
+ * shutdown so consumers immediately observe "no live postmaster" instead
+ * of seeing a stale-pid record they have to probe with `process.kill()`.
+ *
+ * Returns `true` when the file was removed, `false` when it was already
+ * gone or removal failed. Never throws — graceful shutdown must not
+ * regress because of a permission glitch on the runtime file.
+ */
+export function clearRuntimeJson(socketDir) {
+  let file;
+  try {
+    file = getRuntimeFilePath(socketDir);
+  } catch {
+    return false;
+  }
+  try {
+    fs.unlinkSync(file);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Returns true when the runtime record points at a process that's alive
+ * on this host. `process.kill(pid, 0)` is a no-signal probe — it raises
+ * ESRCH when the pid is gone and EPERM when we can't signal a foreign
+ * uid (still alive, just not ours). Treat EPERM as "alive" so cross-uid
+ * supervisors (e.g. an operator probing a system-installed pgserve)
+ * don't false-negative.
+ */
+export function isLiveRuntime(record) {
+  if (!isPlainObject(record)) return false;
+  // process.kill(pid, 0) accepts a process group sentinel for pid <= 0
+  // (pid 0 = caller's group, pid -1 = every signalable process). Neither
+  // is a meaningful "live postmaster" answer, so reject anything below 1
+  // before we touch the syscall.
+  const pid = record.autopgPid;
+  if (!Number.isInteger(pid) || pid < 1) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    return err && err.code === 'EPERM';
+  }
+}

--- a/tests/cli/serve.test.js
+++ b/tests/cli/serve.test.js
@@ -92,7 +92,10 @@ afterEach(async () => {
   }
 });
 
-function spawnPostmaster({ port = TEST_PORT, extraArgs = [] } = {}) {
+function spawnPostmaster({ port, extraArgs = [] } = {}) {
+  if (!Number.isInteger(port)) {
+    throw new Error('spawnPostmaster: port is required (each test owns its port to avoid TIME_WAIT collision)');
+  }
   const args = [
     POSTMASTER_BIN,
     'postmaster',
@@ -175,8 +178,8 @@ async function waitForExit(child, timeoutMs = 10_000) {
 
 describe('autopg serve — dual-transport binding', () => {
   test('binds UDS at <socketDir>/.s.PGSQL.<port> AND TCP 127.0.0.1:<port>', async () => {
-    proc = spawnPostmaster();
-    const ready = await waitForReady(TEST_PORT);
+    proc = spawnPostmaster({ port: PORT_BIND });
+    const ready = await waitForReady(PORT_BIND);
     if (!ready.ok) {
       const { stdout, stderr } = proc.captureStreams();
       throw new Error(
@@ -190,15 +193,15 @@ describe('autopg serve — dual-transport binding', () => {
     expect(udsOk).toBe(true);
 
     // TCP reachable — bound at 127.0.0.1:<port>
-    const tcpOk = await tcpProbe('127.0.0.1', TEST_PORT);
+    const tcpOk = await tcpProbe('127.0.0.1', PORT_BIND);
     expect(tcpOk).toBe(true);
   }, STARTUP_TIMEOUT_MS + 5000);
 });
 
 describe('autopg serve — runtime.json contract', () => {
   test('writes runtime.json after greet with the cohort-locked shape', async () => {
-    proc = spawnPostmaster();
-    const ready = await waitForReady(TEST_PORT);
+    proc = spawnPostmaster({ port: PORT_RUNTIME });
+    const ready = await waitForReady(PORT_RUNTIME);
     expect(ready.ok).toBe(true);
 
     // runtime.json appears after the postmaster greets healthy. Poll
@@ -218,7 +221,7 @@ describe('autopg serve — runtime.json contract', () => {
 
     // Required fields, all present, all of the right shape.
     expect(record.socketDir).toBe(socketDir);
-    expect(record.port).toBe(TEST_PORT);
+    expect(record.port).toBe(PORT_RUNTIME);
     expect(Number.isInteger(record.pid)).toBe(true);
     expect(record.pid).toBeGreaterThan(0);
     expect(Number.isInteger(record.autopgPid)).toBe(true);
@@ -237,8 +240,8 @@ describe('autopg serve — runtime.json contract', () => {
 
 describe('autopg serve — graceful shutdown removes runtime.json', () => {
   test('SIGTERM clears <socketDir>/runtime.json', async () => {
-    proc = spawnPostmaster();
-    const ready = await waitForReady(TEST_PORT);
+    proc = spawnPostmaster({ port: PORT_SIGTERM });
+    const ready = await waitForReady(PORT_SIGTERM);
     expect(ready.ok).toBe(true);
 
     // Wait for runtime.json to land before signalling — otherwise the
@@ -262,8 +265,8 @@ describe('autopg serve — graceful shutdown removes runtime.json', () => {
 
 describe('autopg serve — crash leaves stale runtime.json', () => {
   test('SIGKILL leaves runtime.json with a non-live autopgPid', async () => {
-    proc = spawnPostmaster();
-    const ready = await waitForReady(TEST_PORT);
+    proc = spawnPostmaster({ port: PORT_SIGKILL });
+    const ready = await waitForReady(PORT_SIGKILL);
     expect(ready.ok).toBe(true);
 
     const deadline = Date.now() + 5000;

--- a/tests/cli/serve.test.js
+++ b/tests/cli/serve.test.js
@@ -1,0 +1,301 @@
+/**
+ * Tests for `autopg serve` (alias for `pgserve postmaster`) — cutover G19.
+ *
+ * Locks the dual-transport binding contract:
+ *   - UDS at `<socketDir>/.s.PGSQL.<port>` accepts TCP-style connections.
+ *   - TCP at 127.0.0.1:<port> accepts connections.
+ *   - `<socketDir>/runtime.json` exists post-greet with the cohort-locked
+ *     shape (`socketDir`, `port`, `pid`, `autopgPid`, `schemaVersion: 1`)
+ *     and **no `supervisor` key** — that field lives only in
+ *     `~/.autopg/admin.json`.
+ *   - SIGTERM removes `runtime.json` (graceful shutdown contract).
+ *   - SIGKILL leaves `runtime.json` in place with a non-live `autopgPid`
+ *     so consumers detect staleness via `process.kill(pid, 0)`.
+ *
+ * Strategy: spawn the real postmaster against a temp datadir on a non-
+ * default port (65432) so it can't collide with a host postgres. The
+ * embedded postgres binaries are installed via `bun install` in the
+ * worktree's optional dep `@embedded-postgres/<platform>-<arch>`; on a
+ * fresh worktree the test boots in a few seconds.
+ */
+
+import { test, expect, beforeAll, beforeEach, afterEach, describe } from 'bun:test';
+import fs from 'node:fs';
+import net from 'node:net';
+import os from 'node:os';
+import path from 'node:path';
+import { spawn } from 'node:child_process';
+
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+const POSTMASTER_BIN = path.join(REPO_ROOT, 'bin', 'postgres-server.js');
+
+// Ephemeral test ports. Picked above the privileged range and well clear
+// of common PG/proxy/dev ports. Each test owns a distinct port so a
+// previous case's TIME_WAIT (or an orphan postgres backend after SIGKILL)
+// can't false-fail the next one's bind.
+const PORT_BIND     = 65432;
+const PORT_RUNTIME  = 65433;
+const PORT_SIGTERM  = 65434;
+const PORT_SIGKILL  = 65435;
+
+// 30s startup budget — embedded postgres initdb on a cold cache can take
+// 5–8s on a slow CI host. We poll every 100ms; well under the budget on
+// a warm cache.
+const STARTUP_TIMEOUT_MS = 30_000;
+const POLL_INTERVAL_MS = 100;
+
+let bunPath;
+
+beforeAll(() => {
+  // The postmaster entry point is ESM and uses Bun.spawn / Bun.SQL inside
+  // PostgresManager — it MUST run under bun, not node. We resolve the bun
+  // binary the same way the wrapper does (node_modules/.bin or the parent
+  // env). `process.execPath` works when this test is invoked via `bun
+  // test`, which it is per package.json.
+  bunPath = process.execPath;
+  if (!bunPath.endsWith('bun') && !bunPath.endsWith('bun.exe')) {
+    throw new Error(
+      `serve.test.js: expected to run under \`bun test\` (process.execPath="${bunPath}")`,
+    );
+  }
+});
+
+let tmpRoot;
+let dataDir;
+let socketDir;
+let runtimeFile;
+let proc;
+
+beforeEach(() => {
+  tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'autopg-serve-'));
+  dataDir = path.join(tmpRoot, 'data');
+  socketDir = path.join(tmpRoot, 'sock');
+  runtimeFile = path.join(socketDir, 'runtime.json');
+  fs.mkdirSync(dataDir, { recursive: true, mode: 0o700 });
+  fs.mkdirSync(socketDir, { recursive: true, mode: 0o700 });
+});
+
+afterEach(async () => {
+  // Best-effort: SIGKILL anything still alive from a failed test before
+  // we rm the tempdir so postgres doesn't keep writing into a deleted
+  // path while the next test is running.
+  if (proc && proc.exitCode === null && proc.signalCode === null) {
+    try { proc.kill('SIGKILL'); } catch { /* already dead */ }
+    await new Promise((resolve) => {
+      const timer = setTimeout(resolve, 2000);
+      proc.once('exit', () => { clearTimeout(timer); resolve(); });
+    });
+  }
+  proc = null;
+  if (tmpRoot && fs.existsSync(tmpRoot)) {
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+  }
+});
+
+function spawnPostmaster({ port = TEST_PORT, extraArgs = [] } = {}) {
+  const args = [
+    POSTMASTER_BIN,
+    'postmaster',
+    '--port', String(port),
+    '--data', dataDir,
+    '--socket-dir', socketDir,
+    '--log', 'warn',
+    ...extraArgs,
+  ];
+  const child = spawn(bunPath, args, {
+    stdio: ['ignore', 'pipe', 'pipe'],
+    env: { ...process.env },
+  });
+  let stderr = '';
+  let stdout = '';
+  child.stderr.on('data', (chunk) => { stderr += chunk.toString('utf8'); });
+  child.stdout.on('data', (chunk) => { stdout += chunk.toString('utf8'); });
+  child.captureStreams = () => ({ stdout, stderr });
+  return child;
+}
+
+async function tcpProbe(host, port, timeoutMs = 1000) {
+  return new Promise((resolve) => {
+    const sock = net.connect({ host, port });
+    let settled = false;
+    const finish = (ok) => {
+      if (settled) return;
+      settled = true;
+      try { sock.destroy(); } catch { /* ignore */ }
+      resolve(ok);
+    };
+    sock.once('connect', () => finish(true));
+    sock.once('error', () => finish(false));
+    setTimeout(() => finish(false), timeoutMs);
+  });
+}
+
+async function udsProbe(socketPath, timeoutMs = 1000) {
+  return new Promise((resolve) => {
+    const sock = net.connect({ path: socketPath });
+    let settled = false;
+    const finish = (ok) => {
+      if (settled) return;
+      settled = true;
+      try { sock.destroy(); } catch { /* ignore */ }
+      resolve(ok);
+    };
+    sock.once('connect', () => finish(true));
+    sock.once('error', () => finish(false));
+    setTimeout(() => finish(false), timeoutMs);
+  });
+}
+
+async function waitForReady(port) {
+  const deadline = Date.now() + STARTUP_TIMEOUT_MS;
+  const sockPath = path.join(socketDir, `.s.PGSQL.${port}`);
+  while (Date.now() < deadline) {
+    if (fs.existsSync(sockPath) && await tcpProbe('127.0.0.1', port)) {
+      return { ok: true, sockPath };
+    }
+    await new Promise((r) => setTimeout(r, POLL_INTERVAL_MS));
+  }
+  return { ok: false, sockPath };
+}
+
+async function waitForExit(child, timeoutMs = 10_000) {
+  if (child.exitCode !== null || child.signalCode !== null) {
+    return { code: child.exitCode, signal: child.signalCode };
+  }
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      reject(new Error(`process did not exit within ${timeoutMs}ms`));
+    }, timeoutMs);
+    child.once('exit', (code, signal) => {
+      clearTimeout(timer);
+      resolve({ code, signal });
+    });
+  });
+}
+
+describe('autopg serve — dual-transport binding', () => {
+  test('binds UDS at <socketDir>/.s.PGSQL.<port> AND TCP 127.0.0.1:<port>', async () => {
+    proc = spawnPostmaster();
+    const ready = await waitForReady(TEST_PORT);
+    if (!ready.ok) {
+      const { stdout, stderr } = proc.captureStreams();
+      throw new Error(
+        `postmaster did not become ready in ${STARTUP_TIMEOUT_MS}ms\n--- stdout ---\n${stdout}\n--- stderr ---\n${stderr}`,
+      );
+    }
+
+    // UDS reachable — bound at <socketDir>/.s.PGSQL.<port>
+    expect(fs.existsSync(ready.sockPath)).toBe(true);
+    const udsOk = await udsProbe(ready.sockPath);
+    expect(udsOk).toBe(true);
+
+    // TCP reachable — bound at 127.0.0.1:<port>
+    const tcpOk = await tcpProbe('127.0.0.1', TEST_PORT);
+    expect(tcpOk).toBe(true);
+  }, STARTUP_TIMEOUT_MS + 5000);
+});
+
+describe('autopg serve — runtime.json contract', () => {
+  test('writes runtime.json after greet with the cohort-locked shape', async () => {
+    proc = spawnPostmaster();
+    const ready = await waitForReady(TEST_PORT);
+    expect(ready.ok).toBe(true);
+
+    // runtime.json appears after the postmaster greets healthy. Poll
+    // briefly to avoid racing a fast postmaster with the test thread.
+    let raw;
+    const deadline = Date.now() + 5000;
+    while (Date.now() < deadline) {
+      if (fs.existsSync(runtimeFile)) {
+        raw = fs.readFileSync(runtimeFile, 'utf8');
+        break;
+      }
+      await new Promise((r) => setTimeout(r, 50));
+    }
+    expect(raw).toBeDefined();
+
+    const record = JSON.parse(raw);
+
+    // Required fields, all present, all of the right shape.
+    expect(record.socketDir).toBe(socketDir);
+    expect(record.port).toBe(TEST_PORT);
+    expect(Number.isInteger(record.pid)).toBe(true);
+    expect(record.pid).toBeGreaterThan(0);
+    expect(Number.isInteger(record.autopgPid)).toBe(true);
+    expect(record.autopgPid).toBeGreaterThan(0);
+    expect(record.schemaVersion).toBe(1);
+
+    // The autopgPid points at our spawned wrapper, not some random pid.
+    expect(record.autopgPid).toBe(proc.pid);
+
+    // Cohort contract: NO `supervisor` field. That key lives only in
+    // `~/.autopg/admin.json`. Mixing them invites desync the moment the
+    // postmaster restarts under a new pid.
+    expect(Object.prototype.hasOwnProperty.call(record, 'supervisor')).toBe(false);
+  }, STARTUP_TIMEOUT_MS + 5000);
+});
+
+describe('autopg serve — graceful shutdown removes runtime.json', () => {
+  test('SIGTERM clears <socketDir>/runtime.json', async () => {
+    proc = spawnPostmaster();
+    const ready = await waitForReady(TEST_PORT);
+    expect(ready.ok).toBe(true);
+
+    // Wait for runtime.json to land before signalling — otherwise the
+    // shutdown path can race the writer and we'd see a missing file for
+    // the wrong reason.
+    const deadline = Date.now() + 5000;
+    while (Date.now() < deadline && !fs.existsSync(runtimeFile)) {
+      await new Promise((r) => setTimeout(r, 50));
+    }
+    expect(fs.existsSync(runtimeFile)).toBe(true);
+
+    proc.kill('SIGTERM');
+    const exit = await waitForExit(proc, 15_000);
+    expect(exit.code).toBe(0);
+
+    // After graceful shutdown the runtime discovery file is gone — fresh
+    // consumers see "no live socket" immediately, no pid-probe needed.
+    expect(fs.existsSync(runtimeFile)).toBe(false);
+  }, STARTUP_TIMEOUT_MS + 20_000);
+});
+
+describe('autopg serve — crash leaves stale runtime.json', () => {
+  test('SIGKILL leaves runtime.json with a non-live autopgPid', async () => {
+    proc = spawnPostmaster();
+    const ready = await waitForReady(TEST_PORT);
+    expect(ready.ok).toBe(true);
+
+    const deadline = Date.now() + 5000;
+    while (Date.now() < deadline && !fs.existsSync(runtimeFile)) {
+      await new Promise((r) => setTimeout(r, 50));
+    }
+    expect(fs.existsSync(runtimeFile)).toBe(true);
+    const recordBefore = JSON.parse(fs.readFileSync(runtimeFile, 'utf8'));
+
+    // SIGKILL — no chance to clean up. Mirrors a hard crash.
+    const killedPid = proc.pid;
+    proc.kill('SIGKILL');
+    await waitForExit(proc, 5000);
+
+    // File is still there; the recorded pid is no longer alive.
+    expect(fs.existsSync(runtimeFile)).toBe(true);
+    const recordAfter = JSON.parse(fs.readFileSync(runtimeFile, 'utf8'));
+    expect(recordAfter.autopgPid).toBe(killedPid);
+    expect(recordAfter).toEqual(recordBefore);
+
+    // Liveness probe via process.kill(pid, 0) — ESRCH means the pid is
+    // gone. Wrap so the test asserts the error path; if the process is
+    // somehow still alive the assertion fails loudly.
+    let alive = false;
+    try {
+      process.kill(recordAfter.autopgPid, 0);
+      alive = true;
+    } catch (err) {
+      // ESRCH is the expected outcome; EPERM would mean the pid is alive
+      // under another uid (impossible here, the wrapper is our child).
+      expect(err.code).toBe('ESRCH');
+    }
+    expect(alive).toBe(false);
+  }, STARTUP_TIMEOUT_MS + 20_000);
+});

--- a/tests/lib/runtime-json.test.js
+++ b/tests/lib/runtime-json.test.js
@@ -1,0 +1,187 @@
+/**
+ * Tests for `src/lib/runtime-json.js` — the `<socketDir>/runtime.json`
+ * reader/writer used by `autopg serve` (cutover G19).
+ *
+ * These lock the cohort contract:
+ *   - schema shape: { socketDir, port, pid, autopgPid, schemaVersion: 1 }
+ *   - NO `supervisor` key (that field lives only in `~/.autopg/admin.json`)
+ *   - reads return null on missing or malformed input — never throw
+ *   - clearRuntimeJson is best-effort and idempotent
+ */
+
+import { test, expect, beforeEach, afterEach, describe } from 'bun:test';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import {
+  RUNTIME_FILE_NAME,
+  RUNTIME_FILE_MODE,
+  RUNTIME_SCHEMA_VERSION,
+  clearRuntimeJson,
+  getRuntimeFilePath,
+  isLiveRuntime,
+  readRuntimeJson,
+  writeRuntimeJson,
+} from '../../src/lib/runtime-json.js';
+
+let tmpDir;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'runtime-json-test-'));
+});
+
+afterEach(() => {
+  if (tmpDir && fs.existsSync(tmpDir)) {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+function makeRecord(overrides = {}) {
+  return {
+    socketDir: tmpDir,
+    port: 5432,
+    pid: 12345,
+    autopgPid: 12340,
+    ...overrides,
+  };
+}
+
+describe('exports', () => {
+  test('exposes the cohort-locked constants', () => {
+    expect(RUNTIME_FILE_NAME).toBe('runtime.json');
+    expect(RUNTIME_FILE_MODE).toBe(0o644);
+    expect(RUNTIME_SCHEMA_VERSION).toBe(1);
+  });
+});
+
+describe('getRuntimeFilePath', () => {
+  test('returns <socketDir>/runtime.json', () => {
+    expect(getRuntimeFilePath('/run/user/1000/pgserve')).toBe('/run/user/1000/pgserve/runtime.json');
+  });
+
+  test('throws on empty / non-string socketDir', () => {
+    expect(() => getRuntimeFilePath('')).toThrow(/non-empty string/);
+    expect(() => getRuntimeFilePath(null)).toThrow(/non-empty string/);
+    expect(() => getRuntimeFilePath(undefined)).toThrow(/non-empty string/);
+  });
+});
+
+describe('writeRuntimeJson', () => {
+  test('writes the cohort-locked shape with schemaVersion stamped', () => {
+    const written = writeRuntimeJson(makeRecord());
+    expect(written.schemaVersion).toBe(1);
+
+    const onDisk = JSON.parse(fs.readFileSync(getRuntimeFilePath(tmpDir), 'utf8'));
+    expect(onDisk).toEqual({
+      socketDir: tmpDir,
+      port: 5432,
+      pid: 12345,
+      autopgPid: 12340,
+      schemaVersion: 1,
+    });
+  });
+
+  test('mode is 0644 (operator-readable, no secrets)', () => {
+    writeRuntimeJson(makeRecord());
+    const stat = fs.statSync(getRuntimeFilePath(tmpDir));
+    expect(stat.mode & 0o777).toBe(0o644);
+  });
+
+  test('refuses a record carrying a supervisor key', () => {
+    expect(() =>
+      writeRuntimeJson({ ...makeRecord(), supervisor: 'pm2' }),
+    ).toThrow(/supervisor.*admin\.json/);
+  });
+
+  test('rejects malformed port', () => {
+    expect(() => writeRuntimeJson(makeRecord({ port: 0 }))).toThrow(/port must be an integer in \[1, 65535\]/);
+    expect(() => writeRuntimeJson(makeRecord({ port: 65536 }))).toThrow(/port must be an integer in \[1, 65535\]/);
+    expect(() => writeRuntimeJson(makeRecord({ port: 'abc' }))).toThrow(/port must be an integer/);
+  });
+
+  test('rejects non-positive pids', () => {
+    expect(() => writeRuntimeJson(makeRecord({ pid: 0 }))).toThrow(/pid must be a positive integer/);
+    expect(() => writeRuntimeJson(makeRecord({ autopgPid: -1 }))).toThrow(/autopgPid must be a positive integer/);
+  });
+
+  test('creates the parent directory when missing', () => {
+    const fresh = path.join(tmpDir, 'nested', 'sock');
+    writeRuntimeJson(makeRecord({ socketDir: fresh }));
+    expect(fs.existsSync(path.join(fresh, 'runtime.json'))).toBe(true);
+  });
+
+  test('writes atomically (no partial file lingering after error)', () => {
+    // Sanity: tmp file pattern matches the documented atomic shape.
+    writeRuntimeJson(makeRecord());
+    const entries = fs.readdirSync(tmpDir);
+    // Only the final file remains; the tmp shim was renamed.
+    expect(entries.filter((f) => f.startsWith('runtime.json.tmp.'))).toEqual([]);
+    expect(entries).toContain('runtime.json');
+  });
+});
+
+describe('readRuntimeJson', () => {
+  test('returns null when the file is missing', () => {
+    expect(readRuntimeJson(tmpDir)).toBeNull();
+  });
+
+  test('returns null when JSON is malformed', () => {
+    fs.writeFileSync(getRuntimeFilePath(tmpDir), 'not-json{', 'utf8');
+    expect(readRuntimeJson(tmpDir)).toBeNull();
+  });
+
+  test('returns null when JSON parses to a non-object', () => {
+    fs.writeFileSync(getRuntimeFilePath(tmpDir), '"a string"', 'utf8');
+    expect(readRuntimeJson(tmpDir)).toBeNull();
+    fs.writeFileSync(getRuntimeFilePath(tmpDir), '[1,2,3]', 'utf8');
+    expect(readRuntimeJson(tmpDir)).toBeNull();
+  });
+
+  test('round-trips a valid record', () => {
+    const written = writeRuntimeJson(makeRecord());
+    expect(readRuntimeJson(tmpDir)).toEqual(written);
+  });
+
+  test('returns null on bad socketDir argument (never throws)', () => {
+    expect(readRuntimeJson('')).toBeNull();
+    expect(readRuntimeJson(null)).toBeNull();
+    expect(readRuntimeJson(undefined)).toBeNull();
+  });
+});
+
+describe('clearRuntimeJson', () => {
+  test('removes the file when present', () => {
+    writeRuntimeJson(makeRecord());
+    expect(fs.existsSync(getRuntimeFilePath(tmpDir))).toBe(true);
+    expect(clearRuntimeJson(tmpDir)).toBe(true);
+    expect(fs.existsSync(getRuntimeFilePath(tmpDir))).toBe(false);
+  });
+
+  test('returns false when file is already gone (idempotent, never throws)', () => {
+    expect(clearRuntimeJson(tmpDir)).toBe(false);
+  });
+
+  test('returns false on bad socketDir argument (never throws)', () => {
+    expect(clearRuntimeJson('')).toBe(false);
+    expect(clearRuntimeJson(null)).toBe(false);
+  });
+});
+
+describe('isLiveRuntime', () => {
+  test('returns true for the current process', () => {
+    expect(isLiveRuntime({ autopgPid: process.pid })).toBe(true);
+  });
+
+  test('returns false for a pid that is definitely dead', () => {
+    // Pick a pid that's so high it can't be in use on a normal kernel.
+    expect(isLiveRuntime({ autopgPid: 999_999_999 })).toBe(false);
+  });
+
+  test('returns false for non-record / missing autopgPid', () => {
+    expect(isLiveRuntime(null)).toBe(false);
+    expect(isLiveRuntime({})).toBe(false);
+    expect(isLiveRuntime({ autopgPid: 'string' })).toBe(false);
+    expect(isLiveRuntime({ autopgPid: -1 })).toBe(false);
+  });
+});


### PR DESCRIPTION
Mid-work checkpoint for cutover G19 (NEW group, was NOT-STARTED per audit). Engineer disbanded before final validation; preserves 5 files (+875/-25) for future engineer to finish.

## What landed

- `src/lib/runtime-json.js` (NEW) — runtime discovery file writer/reader at `<socketDir>/runtime.json`
- `bin/postgres-server.js` — postmaster writes `runtime.json` after greet, cleans on SIGTERM, leaves on crash
- `src/cli-install.cjs` — discovery primitives (port/url/status) read `runtime.json` first, fall back to `~/.autopg/admin.json` and pm2-process inspection
- `tests/cli/serve.test.js` (NEW) — dual-transport + runtime.json shape tests
- `tests/lib/runtime-json.test.js` (NEW) — writer/reader unit tests

## Cohort contract

Critical separation maintained:
- `<socketDir>/runtime.json` = live discovery ({ socketDir, port, pid, autopgPid, schemaVersion }), ephemeral
- `~/.autopg/admin.json` = supervisor config ({ supervisor, socketDir, port, installedAt }), persistent
- `runtime.json` does NOT carry `supervisor` field — that's admin.json territory

## NOT shipped

- Tests not yet validated end-to-end
- G19 acceptance criteria sweep against actual postmaster startup

Holding for engineer to finish before merge.