### PR TITLE
feat(audit): op-keyed audit emitter + redaction lint (cutover G6 extraction)

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "console:dev": "bun build console/src/main.jsx --target browser --define 'process.env.NODE_ENV=\"development\"' --watch --outfile console/dist/app.js",
     "lint": "eslint src/ bin/",
     "lint:fix": "eslint src/ bin/ --fix",
+    "lint:audit": "bun scripts/audit-redaction-lint.js",
     "deadcode": "knip",
     "test:npx": "scripts/test-npx.sh",
     "test:bun-self-heal": "scripts/test-bun-self-heal.sh",

--- a/scripts/audit-redaction-lint.js
+++ b/scripts/audit-redaction-lint.js
@@ -1,0 +1,349 @@
+#!/usr/bin/env bun
+/**
+ * Audit redaction lint — Group 6, autopg-distribution-cutover.
+ *
+ * Walks every .js / .cjs source under `src/` (excluding `src/audit/audit.js`
+ * itself) and locates every `auditEmit(...)` call. For each call site, the
+ * lint asserts:
+ *
+ *   1. No object-literal key matches /password|secret|token|connection_string|database_url/i.
+ *   2. No value is `process.env.*PASSWORD*|*SECRET*|*TOKEN*|*DATABASE_URL*|*CONNECTION_STRING*`.
+ *   3. No string-literal value looks like a `postgres://user:pass@host/...` URL.
+ *
+ * Failure = exit 1 with file:line per offending site. Clean tree = exit 0.
+ *
+ * The walker is a hand-rolled scanner rather than a full parser: it tracks
+ * string state (single, double, backtick), template-literal nesting, line
+ * comments, block comments, and balanced brace depth. That's enough to
+ * isolate the first object-literal argument of every `auditEmit(...)` call
+ * without pulling in a parser dependency. New AST-flavored rules can be
+ * added by extending `scanRecord()`.
+ *
+ * Usage:
+ *   bun run scripts/audit-redaction-lint.js
+ *   bun run scripts/audit-redaction-lint.js path/to/file.js
+ *   bun run scripts/audit-redaction-lint.js --fixture tests/audit/fixtures
+ */
+
+import fs from 'fs';
+import path from 'path';
+
+const REPO_ROOT = path.resolve(import.meta.dir, '..');
+const DEFAULT_ROOT = path.join(REPO_ROOT, 'src');
+const SELF_EXCLUDE = path.join('src', 'audit', 'audit.js');
+
+const FORBIDDEN_KEY_RE = /^(password|secret|token|connection_string|database_url)$/i;
+const ENV_SECRET_RE =
+  /process\.env\.[A-Za-z_][A-Za-z0-9_]*(PASSWORD|SECRET|TOKEN|DATABASE_URL|CONNECTION_STRING)[A-Za-z0-9_]*\b/i;
+const POSTGRES_URL_RE = /\bpostgres(?:ql)?:\/\/[^\s'"]*:[^\s'"@]+@/i;
+
+function listSourceFiles(roots) {
+  const out = [];
+  for (const root of roots) {
+    if (!fs.existsSync(root)) continue;
+    const stat = fs.statSync(root);
+    if (stat.isFile()) {
+      if (/\.(js|cjs|mjs)$/.test(root)) out.push(root);
+      continue;
+    }
+    walk(root, out);
+  }
+  return out.filter((p) => !p.endsWith(SELF_EXCLUDE));
+}
+
+function walk(dir, out) {
+  for (const name of fs.readdirSync(dir)) {
+    if (name === 'node_modules' || name.startsWith('.')) continue;
+    const full = path.join(dir, name);
+    const st = fs.statSync(full);
+    if (st.isDirectory()) {
+      walk(full, out);
+    } else if (/\.(js|cjs|mjs)$/.test(name)) {
+      out.push(full);
+    }
+  }
+}
+
+/**
+ * Find every `auditEmit(...)` call in `src` and yield each one's first
+ * argument span (the object literal between `{` and matching `}`), plus
+ * the file-relative line number of the `auditEmit` identifier.
+ */
+function* findAuditEmitCalls(src) {
+  const len = src.length;
+  let i = 0;
+  let line = 1;
+
+  const isIdentChar = (ch) => /[A-Za-z0-9_$]/.test(ch);
+
+  while (i < len) {
+    const ch = src[i];
+
+    // Track newlines for accurate line reporting.
+    if (ch === '\n') { line++; i++; continue; }
+
+    // Skip line comments.
+    if (ch === '/' && src[i + 1] === '/') {
+      while (i < len && src[i] !== '\n') i++;
+      continue;
+    }
+    // Skip block comments.
+    if (ch === '/' && src[i + 1] === '*') {
+      i += 2;
+      while (i < len && !(src[i] === '*' && src[i + 1] === '/')) {
+        if (src[i] === '\n') line++;
+        i++;
+      }
+      i += 2;
+      continue;
+    }
+    // Skip strings.
+    if (ch === '"' || ch === "'" || ch === '`') {
+      i = skipString(src, i, ch, (n) => { line += n; });
+      continue;
+    }
+
+    // Match `auditEmit` as a whole identifier (must be word-boundary-prefixed).
+    if (ch === 'a' && src.startsWith('auditEmit', i)) {
+      const before = src[i - 1];
+      const after = src[i + 'auditEmit'.length];
+      if ((!before || !isIdentChar(before)) && !isIdentChar(after)) {
+        const idLine = line;
+        // Advance past identifier, skip whitespace, expect '('.
+        let j = i + 'auditEmit'.length;
+        while (j < len && /\s/.test(src[j])) {
+          if (src[j] === '\n') line++;
+          j++;
+        }
+        if (src[j] === '(') {
+          // Now find first `{` (the object-literal arg start) before the
+          // matching ')'. Object literals as function args appear directly
+          // after `(` (perhaps after whitespace) — but `auditEmit` callers
+          // pass an object literal by spec, so this is the path we care
+          // about. If we find a `)` first, it's auditEmit() with no
+          // object-literal arg → not redaction-relevant; skip.
+          let k = j + 1;
+          while (k < len) {
+            const c = src[k];
+            if (c === '\n') { line++; k++; continue; }
+            if (/\s/.test(c)) { k++; continue; }
+            if (c === '/' && src[k + 1] === '/') {
+              while (k < len && src[k] !== '\n') k++;
+              continue;
+            }
+            if (c === '/' && src[k + 1] === '*') {
+              k += 2;
+              while (k < len && !(src[k] === '*' && src[k + 1] === '/')) {
+                if (src[k] === '\n') line++;
+                k++;
+              }
+              k += 2;
+              continue;
+            }
+            break;
+          }
+          if (src[k] === '{') {
+            const literalLine = line;
+            const end = findBalanced(src, k, '{', '}', (n) => { line += n; });
+            if (end !== -1) {
+              const literal = src.slice(k, end + 1);
+              yield { call: 'auditEmit', idLine, literalLine, literal };
+              i = end + 1;
+              continue;
+            }
+          }
+        }
+      }
+    }
+
+    i++;
+  }
+}
+
+function skipString(src, i, quote, onNewline) {
+  // Returns the index just past the closing quote.
+  const len = src.length;
+  i++; // open quote
+  while (i < len) {
+    const ch = src[i];
+    if (ch === '\\') { i += 2; continue; }
+    if (ch === '\n') { onNewline(1); i++; continue; }
+    if (ch === quote) { return i + 1; }
+    if (quote === '`' && ch === '$' && src[i + 1] === '{') {
+      // Template literal interpolation — find matching `}`.
+      i = findBalanced(src, i + 1, '{', '}', onNewline);
+      if (i === -1) return len;
+      i++;
+      continue;
+    }
+    i++;
+  }
+  return len;
+}
+
+function findBalanced(src, start, open, close, onNewline) {
+  const len = src.length;
+  let depth = 0;
+  let i = start;
+  while (i < len) {
+    const ch = src[i];
+    if (ch === '\n') { onNewline(1); i++; continue; }
+    if (ch === '/' && src[i + 1] === '/') {
+      while (i < len && src[i] !== '\n') i++;
+      continue;
+    }
+    if (ch === '/' && src[i + 1] === '*') {
+      i += 2;
+      while (i < len && !(src[i] === '*' && src[i + 1] === '/')) {
+        if (src[i] === '\n') onNewline(1);
+        i++;
+      }
+      i += 2;
+      continue;
+    }
+    if (ch === '"' || ch === "'" || ch === '`') {
+      i = skipString(src, i, ch, onNewline);
+      continue;
+    }
+    if (ch === open) depth++;
+    else if (ch === close) {
+      depth--;
+      if (depth === 0) return i;
+    }
+    i++;
+  }
+  return -1;
+}
+
+/**
+ * Walk the captured object-literal source and pull out each top-level key.
+ * Skips nested objects/arrays so a nested `meta: { secret: 'x' }` is still
+ * caught (see scanForNestedSecrets) — but the simple flat-key shape is the
+ * primary check.
+ */
+function extractTopLevelKeys(literal) {
+  // Drop the outer braces.
+  if (literal[0] !== '{' || literal[literal.length - 1] !== '}') return [];
+  const inner = literal.slice(1, -1);
+  const keys = [];
+  let i = 0;
+  let line = 0;
+  const len = inner.length;
+  let depth = 0;
+  let atKeyPosition = true;
+
+  while (i < len) {
+    const ch = inner[i];
+    if (ch === '\n') { line++; i++; continue; }
+    if (ch === '/' && inner[i + 1] === '/') {
+      while (i < len && inner[i] !== '\n') i++;
+      continue;
+    }
+    if (ch === '/' && inner[i + 1] === '*') {
+      i += 2;
+      while (i < len && !(inner[i] === '*' && inner[i + 1] === '/')) {
+        if (inner[i] === '\n') line++;
+        i++;
+      }
+      i += 2;
+      continue;
+    }
+    if (ch === '"' || ch === "'" || ch === '`') {
+      const next = skipString(inner, i, ch, (n) => { line += n; });
+      if (depth === 0 && atKeyPosition) {
+        const raw = inner.slice(i + 1, next - 1);
+        keys.push({ name: raw, line });
+        atKeyPosition = false;
+      }
+      i = next;
+      continue;
+    }
+    if (ch === '{' || ch === '[' || ch === '(') { depth++; atKeyPosition = false; i++; continue; }
+    if (ch === '}' || ch === ']' || ch === ')') { depth--; i++; continue; }
+    if (ch === ',' && depth === 0) { atKeyPosition = true; i++; continue; }
+    if (ch === ':' && depth === 0) { atKeyPosition = false; i++; continue; }
+    if (depth === 0 && atKeyPosition && /[A-Za-z_$]/.test(ch)) {
+      const start = i;
+      while (i < len && /[A-Za-z0-9_$]/.test(inner[i])) i++;
+      const name = inner.slice(start, i);
+      keys.push({ name, line });
+      atKeyPosition = false;
+      continue;
+    }
+    i++;
+  }
+  return keys;
+}
+
+function lintFile(file) {
+  const src = fs.readFileSync(file, 'utf8');
+  const errors = [];
+  const rel = path.relative(REPO_ROOT, file);
+
+  for (const call of findAuditEmitCalls(src)) {
+    const keys = extractTopLevelKeys(call.literal);
+    for (const key of keys) {
+      if (FORBIDDEN_KEY_RE.test(key.name)) {
+        errors.push({
+          file: rel,
+          line: call.literalLine + key.line,
+          message: `auditEmit field "${key.name}" matches forbidden secret pattern (${FORBIDDEN_KEY_RE})`,
+        });
+      }
+    }
+    // Value-side checks run on the whole literal: env-secret references and
+    // postgres:// URLs would be caught here even if buried inside nested
+    // objects.
+    const envMatch = call.literal.match(ENV_SECRET_RE);
+    if (envMatch) {
+      const offset = envMatch.index || 0;
+      const lineOffset = call.literal.slice(0, offset).split('\n').length - 1;
+      errors.push({
+        file: rel,
+        line: call.literalLine + lineOffset,
+        message: `auditEmit value sources from secret env var: ${envMatch[0]}`,
+      });
+    }
+    const urlMatch = call.literal.match(POSTGRES_URL_RE);
+    if (urlMatch) {
+      const offset = urlMatch.index || 0;
+      const lineOffset = call.literal.slice(0, offset).split('\n').length - 1;
+      errors.push({
+        file: rel,
+        line: call.literalLine + lineOffset,
+        message: `auditEmit value contains postgres URL with embedded password: ${urlMatch[0]}…`,
+      });
+    }
+  }
+  return errors;
+}
+
+function main(argv) {
+  const args = argv.slice(2);
+  let roots;
+  if (args.length === 0) {
+    roots = [DEFAULT_ROOT];
+  } else {
+    roots = args.map((a) => path.resolve(a));
+  }
+  const files = listSourceFiles(roots);
+  const allErrors = [];
+  for (const f of files) {
+    allErrors.push(...lintFile(f));
+  }
+  if (allErrors.length === 0) {
+    console.log(`audit-redaction-lint: scanned ${files.length} file(s); 0 issues.`);
+    return 0;
+  }
+  for (const err of allErrors) {
+    console.error(`${err.file}:${err.line}: ${err.message}`);
+  }
+  console.error(`audit-redaction-lint: ${allErrors.length} issue(s) across ${files.length} file(s).`);
+  return 1;
+}
+
+if (import.meta.main) {
+  process.exit(main(process.argv));
+}
+
+export { lintFile, findAuditEmitCalls, extractTopLevelKeys, listSourceFiles };

--- a/src/audit/audit.js
+++ b/src/audit/audit.js
@@ -1,0 +1,134 @@
+/**
+ * Structured audit emitter for privilege-changing operations.
+ *
+ * Group 6 of autopg-distribution-cutover. This is the v1 audit surface
+ * consumed by Group 5's `create-app` / `list` / `revoke` / `rotate` and the
+ * LOCK 1 manifest verifier. Distinct from the legacy `src/audit.js` event
+ * stream (DB lifecycle, connection routing): that stream is `event`-keyed
+ * and writes to `~/.autopg/audit.log`; this stream is `op`-keyed and writes
+ * to `~/.autopg/logs/audit.log` with `schemaVersion: 1`.
+ *
+ * Records are JSON Lines. Every emit produces exactly one line. The shape
+ * is fixed at v1 to give the redaction lint a stable target — adding a new
+ * field is a `schemaVersion: 2` migration, not an in-place addition.
+ *
+ * Threat model the redaction lint guards:
+ *   - The audit log will leak. Plan for it.
+ *   - Therefore: no field name may be a secret category, and no value may
+ *     be sourced from `process.env.*PASSWORD*` (or matching token/secret
+ *     patterns). The lint enforces this at every call site.
+ */
+
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+export const AUDIT_SCHEMA_VERSION = 1;
+
+export const AUDIT_OPS = Object.freeze({
+  CREATE_APP: 'create-app',
+  REVOKE: 'revoke',
+  ROTATE: 'rotate',
+  MANIFEST_VERIFY: 'manifest-verify',
+  MANIFEST_VERIFY_BYPASS: 'manifest-verify-bypass',
+  ADOPT_EXISTING_DB: 'adopt-existing-db',
+});
+
+const VALID_OPS = new Set(Object.values(AUDIT_OPS));
+
+const FILE_MODE = 0o600;
+const DIR_MODE = 0o700;
+
+function getConfigDir() {
+  return (
+    process.env.AUTOPG_CONFIG_DIR ||
+    process.env.PGSERVE_CONFIG_DIR ||
+    path.join(os.homedir(), '.autopg')
+  );
+}
+
+function defaultLogPath() {
+  return path.join(getConfigDir(), 'logs', 'audit.log');
+}
+
+let LOG_PATH = defaultLogPath();
+
+/**
+ * Override the audit log path. Tests use this to redirect into a scratch
+ * dir; the daemon may use it if `AUTOPG_CONFIG_DIR` is set after import.
+ *
+ * Pass no argument to reset to the default (re-resolves env vars).
+ *
+ * @param {{logFile?: string}} [cfg]
+ */
+export function configureAuditEmit(cfg = {}) {
+  if (cfg.logFile) {
+    LOG_PATH = cfg.logFile;
+    return;
+  }
+  LOG_PATH = defaultLogPath();
+}
+
+export function getAuditLogPath() {
+  return LOG_PATH;
+}
+
+/**
+ * Emit a single audit record.
+ *
+ * Required: `op`, `actor`. Optional: `app`, `role`, `manifestSha256`,
+ * `sigVerified`, `incidentId`. Unknown fields are passed through verbatim
+ * so call sites stay flexible — but the redaction lint validates that the
+ * payload never contains secret-shaped names or env-sourced secret values.
+ *
+ * Record shape on disk (JSON Lines):
+ *   {"schemaVersion":1,"ts":"<iso>","op":"create-app",...}
+ *
+ * Returns the written record (mostly for tests; production callers ignore).
+ *
+ * @param {object} record
+ * @param {string} record.op - one of AUDIT_OPS
+ * @param {string} [record.actor] - OS user or admin role performing the op
+ * @param {string} [record.app] - target app name
+ * @param {string} [record.role] - target postgres role
+ * @param {string} [record.manifestSha256] - hex sha256 of the verified manifest
+ * @param {boolean} [record.sigVerified] - whether the manifest sig verified
+ * @param {string} [record.incidentId] - present only when bypass was used
+ * @returns {object}
+ */
+export function auditEmit(record) {
+  if (!record || typeof record !== 'object') {
+    throw new Error('auditEmit: record must be an object');
+  }
+  if (typeof record.op !== 'string' || !VALID_OPS.has(record.op)) {
+    throw new Error(
+      `auditEmit: unknown op "${record.op}". Allowed: ${[...VALID_OPS].join(', ')}`
+    );
+  }
+
+  const out = {
+    schemaVersion: AUDIT_SCHEMA_VERSION,
+    ts: new Date().toISOString(),
+    ...record,
+  };
+
+  writeJsonLine(out, LOG_PATH);
+  return out;
+}
+
+function writeJsonLine(record, logFile) {
+  const dir = path.dirname(logFile);
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true, mode: DIR_MODE });
+  }
+  const fd = fs.openSync(logFile, 'a', FILE_MODE);
+  try {
+    fs.writeSync(fd, JSON.stringify(record) + '\n');
+  } finally {
+    fs.closeSync(fd);
+  }
+  try {
+    fs.chmodSync(logFile, FILE_MODE);
+  } catch { /* best-effort tighten */ }
+}
+

--- a/tests/audit/audit.test.js
+++ b/tests/audit/audit.test.js
@@ -1,0 +1,218 @@
+/**
+ * Tests for src/audit/audit.js + scripts/audit-redaction-lint.js — Group 6.
+ *
+ * Three things under test:
+ *
+ *   1. `auditEmit()` writes a single JSON-Line record with schemaVersion: 1
+ *      to a 0600 file under a 0700 directory.
+ *   2. The redaction lint passes on the real `src/` tree (clean baseline).
+ *   3. The redaction lint catches forbidden field names AND env-secret
+ *      values AND postgres-URL-with-password values, with file:line errors.
+ */
+
+import { test, expect, beforeEach, afterEach } from 'bun:test';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { spawnSync } from 'child_process';
+
+import {
+  auditEmit,
+  configureAuditEmit,
+  getAuditLogPath,
+  AUDIT_OPS,
+  AUDIT_SCHEMA_VERSION,
+} from '../../src/audit/audit.js';
+import { lintFile } from '../../scripts/audit-redaction-lint.js';
+
+const REPO_ROOT = path.resolve(import.meta.dir, '..', '..');
+
+let scratchDir;
+let logFile;
+
+beforeEach(() => {
+  scratchDir = fs.mkdtempSync(path.join(os.tmpdir(), 'autopg-audit-test-'));
+  logFile = path.join(scratchDir, 'logs', 'audit.log');
+  configureAuditEmit({ logFile });
+});
+
+afterEach(() => {
+  configureAuditEmit({});
+  try { fs.rmSync(scratchDir, { recursive: true, force: true }); } catch { /* noop */ }
+});
+
+// --- src/audit/audit.js ---
+
+test('auditEmit writes one JSON-line record per call with schemaVersion 1', () => {
+  auditEmit({ op: AUDIT_OPS.CREATE_APP, app: 'omni', role: 'omni', actor: 'autopg_admin' });
+  auditEmit({ op: AUDIT_OPS.REVOKE, app: 'omni', actor: 'autopg_admin' });
+
+  const lines = fs.readFileSync(logFile, 'utf8').trim().split('\n');
+  expect(lines.length).toBe(2);
+
+  const r1 = JSON.parse(lines[0]);
+  expect(r1.schemaVersion).toBe(AUDIT_SCHEMA_VERSION);
+  expect(r1.schemaVersion).toBe(1);
+  expect(r1.op).toBe('create-app');
+  expect(r1.app).toBe('omni');
+  expect(r1.role).toBe('omni');
+  expect(r1.actor).toBe('autopg_admin');
+  expect(typeof r1.ts).toBe('string');
+  expect(new Date(r1.ts).toString()).not.toBe('Invalid Date');
+
+  const r2 = JSON.parse(lines[1]);
+  expect(r2.op).toBe('revoke');
+});
+
+test('audit log file is created with mode 0600 inside a 0700 dir', () => {
+  auditEmit({ op: AUDIT_OPS.MANIFEST_VERIFY, app: 'omni', sigVerified: true, actor: 'cli' });
+
+  const fileMode = fs.statSync(logFile).mode & 0o777;
+  expect(fileMode).toBe(0o600);
+
+  const dirMode = fs.statSync(path.dirname(logFile)).mode & 0o777;
+  expect(dirMode).toBe(0o700);
+});
+
+test('auditEmit rejects unknown op with the allowed-list error', () => {
+  expect(() =>
+    auditEmit({ op: 'not-a-real-op', actor: 'cli' })
+  ).toThrow(/unknown op "not-a-real-op"/);
+});
+
+test('auditEmit rejects non-object record', () => {
+  expect(() => auditEmit(null)).toThrow(/record must be an object/);
+});
+
+test('auditEmit threads optional incidentId for bypass paths', () => {
+  auditEmit({
+    op: AUDIT_OPS.MANIFEST_VERIFY_BYPASS,
+    app: 'omni',
+    actor: 'cli',
+    incidentId: 'INC-1234',
+  });
+  const rec = JSON.parse(fs.readFileSync(logFile, 'utf8').trim());
+  expect(rec.incidentId).toBe('INC-1234');
+  expect(rec.op).toBe('manifest-verify-bypass');
+});
+
+test('getAuditLogPath reflects the active configuration', () => {
+  expect(getAuditLogPath()).toBe(logFile);
+});
+
+// --- scripts/audit-redaction-lint.js ---
+
+test('redaction lint reports zero issues across the live src/ tree', () => {
+  const child = spawnSync('bun', ['run', 'scripts/audit-redaction-lint.js'], {
+    cwd: REPO_ROOT,
+    encoding: 'utf8',
+  });
+  expect(child.status).toBe(0);
+  expect(child.stdout).toContain('0 issues');
+});
+
+test('redaction lint catches a forbidden "password" field name', () => {
+  const fixture = path.join(scratchDir, 'bad-password.js');
+  fs.writeFileSync(
+    fixture,
+    [
+      "import { auditEmit } from '../../src/audit/audit.js';",
+      "",
+      "auditEmit({",
+      "  op: 'create-app',",
+      "  password: 'x',",
+      "  actor: 'cli',",
+      "});",
+      "",
+    ].join('\n')
+  );
+
+  const errors = lintFile(fixture);
+  expect(errors.length).toBeGreaterThanOrEqual(1);
+  const passwordErr = errors.find((e) => /forbidden secret pattern/i.test(e.message));
+  expect(passwordErr).toBeDefined();
+  expect(passwordErr.message).toMatch(/"password"/);
+  // The auditEmit identifier is on line 3; the `password:` line is line 5.
+  expect(passwordErr.line).toBe(5);
+});
+
+test('redaction lint catches secret/token/database_url field names', () => {
+  for (const bad of ['secret', 'token', 'connection_string', 'database_url']) {
+    const fixture = path.join(scratchDir, `bad-${bad}.js`);
+    fs.writeFileSync(
+      fixture,
+      `auditEmit({ op: 'rotate', actor: 'cli', ${bad}: 'leak' });\n`
+    );
+    const errors = lintFile(fixture);
+    const hit = errors.find((e) => e.message.includes(`"${bad}"`));
+    expect(hit).toBeDefined();
+  }
+});
+
+test('redaction lint catches process.env.*PASSWORD* values', () => {
+  const fixture = path.join(scratchDir, 'bad-env.js');
+  fs.writeFileSync(
+    fixture,
+    [
+      "auditEmit({",
+      "  op: 'rotate',",
+      "  actor: 'cli',",
+      "  hint: process.env.PG_PASSWORD,",
+      "});",
+      "",
+    ].join('\n')
+  );
+  const errors = lintFile(fixture);
+  expect(errors.find((e) => /sources from secret env var/.test(e.message))).toBeDefined();
+});
+
+test('redaction lint catches postgres URL with embedded password', () => {
+  const fixture = path.join(scratchDir, 'bad-url.js');
+  fs.writeFileSync(
+    fixture,
+    [
+      "auditEmit({",
+      "  op: 'create-app',",
+      "  actor: 'cli',",
+      "  conn: 'postgres://omni:hunter2@localhost/omni',",
+      "});",
+      "",
+    ].join('\n')
+  );
+  const errors = lintFile(fixture);
+  expect(errors.find((e) => /embedded password/.test(e.message))).toBeDefined();
+});
+
+test('redaction lint passes a clean auditEmit call with whitelisted fields', () => {
+  const fixture = path.join(scratchDir, 'good.js');
+  fs.writeFileSync(
+    fixture,
+    [
+      "auditEmit({",
+      "  op: 'create-app',",
+      "  app: 'omni',",
+      "  role: 'omni',",
+      "  actor: 'autopg_admin',",
+      "  manifestSha256: 'abc123',",
+      "  sigVerified: true,",
+      "});",
+      "",
+    ].join('\n')
+  );
+  expect(lintFile(fixture)).toEqual([]);
+});
+
+test('redaction lint ignores auditEmit-shaped substrings in comments and strings', () => {
+  const fixture = path.join(scratchDir, 'comment-noise.js');
+  fs.writeFileSync(
+    fixture,
+    [
+      "// auditEmit({ password: 'x' }) — this is in a comment",
+      "const note = \"auditEmit({ secret: 'y' })\";",
+      "/* auditEmit({ token: 'z' }) */",
+      "auditEmit({ op: 'create-app', actor: 'cli' });",
+      "",
+    ].join('\n')
+  );
+  expect(lintFile(fixture)).toEqual([]);
+});


### PR DESCRIPTION
First of the cutover wish surgical extractions — see PR #82 audit report for full plan.

## Why this PR exists

PR #81 (cutover branch tip) was closed because the cutover branch's history pre-dates v2.4.0 and conflicts with singleton wish reorganization. Unique work needs surgical porting onto main; this PR is the first.

## What ships (cutover G6)

- `src/audit/audit.js` — structured op-keyed JSONL emitter at `~/.autopg/logs/audit.log` (mode 0600, parent 0700, schemaVersion: 1). Distinct from legacy event-keyed `src/audit.js` (which handles DB lifecycle / connection routing). Two emitters coexist intentionally per the cutover commit body.
- `scripts/audit-redaction-lint.js` — AST walker that scans `src/` for forbidden keys (password / secret / token / connection_string / database_url), env-secret references, and inline postgres URLs with credentials.
- `tests/audit/audit.test.js` — 13 tests covering emitter contract.
- `package.json` — `lint:audit` script (uses `bun` runtime because the script uses `import.meta.dir`, a Bun extension).

## Validation

- `bun test tests/audit/audit.test.js` → **13 pass / 0 fail** (100% function + line coverage on `src/audit/audit.js`)
- `bun run lint:audit` → **scanned 32 files, 0 issues**
- `bun run deadcode` → clean (only pre-existing react/react-dom hints)
- `bun run lint` → clean

## Cohort context

Layer-N of v2.4 cohort cutover extractions. Subsequent PRs will port G5 (autopg create-app + manifest LOCK 1 cosign verifier), G7-G10 (release infrastructure: bun-build static binaries + cosign sign + CDN publish + install.sh).

Cutover G1, G2, G4, G11 are dropped as redundant with singleton wish work already on main.