### PR TITLE
feat(trust): pgserve trust add/list/remove (singleton G3 verb 2)

### DIFF
--- a/bin/pgserve-wrapper.cjs
+++ b/bin/pgserve-wrapper.cjs
@@ -47,6 +47,10 @@ const __installSubcommands = new Set([
   // `verify` shells out to cosign + writes an HMAC cache token. Pure node
   // (no bun) so it must skip the bun probe like the install surface above.
   'verify',
+  // pgserve singleton (v2.4) — wish Group 3. `trust` manages the
+  // user-extensible cosign trust store at ~/.pgserve/trust/identities.json.
+  // Pure node, must skip bun probe.
+  'trust',
 ]);
 if (__subcommand && __installSubcommands.has(__subcommand)) {
   const cli = require(path.join(__dirname, '..', 'src', 'cli-install.cjs'));

--- a/src/cli-install.cjs
+++ b/src/cli-install.cjs
@@ -1123,7 +1123,10 @@ function dispatch(subcommand, args, ctx) {
       // pgserve singleton (v2.4) — wish Group 3, second read-only verb.
       // `pgserve trust add/list/remove` manages the user-extensible cosign
       // trust store at ~/.pgserve/trust/identities.json. Pure node.
-      return import('./commands/trust.js').then((mod) => mod.runTrust(args).then((code) => process.exit(code)));
+      // The wrapper handles the numeric-exit-code case; matches the
+      // verify dispatch style so the wrapper, not the verb, owns
+      // process.exit.
+      return import('./commands/trust.js').then((mod) => mod.runTrust(args));
     default:
       throw new Error(`pgserve: dispatch called with unknown subcommand "${subcommand}"`);
   }

--- a/src/cli-install.cjs
+++ b/src/cli-install.cjs
@@ -1119,6 +1119,11 @@ function dispatch(subcommand, args, ctx) {
       // as `uninstall` so the ESM module isn't eagerly loaded.
       return import('./commands/verify.js').then((mod) => mod.runVerify(args));
     }
+    case 'trust':
+      // pgserve singleton (v2.4) — wish Group 3, second read-only verb.
+      // `pgserve trust add/list/remove` manages the user-extensible cosign
+      // trust store at ~/.pgserve/trust/identities.json. Pure node.
+      return import('./commands/trust.js').then((mod) => mod.runTrust(args).then((code) => process.exit(code)));
     default:
       throw new Error(`pgserve: dispatch called with unknown subcommand "${subcommand}"`);
   }

--- a/src/commands/trust.js
+++ b/src/commands/trust.js
@@ -1,0 +1,187 @@
+/**
+ * `pgserve trust` — manage the cosign trust list.
+ *
+ * pgserve singleton (v2.4) — `pgserve-singleton-no-proxy` wish, Group 3.
+ *
+ * Subverbs:
+ *   pgserve trust list                  show hardcoded + user entries
+ *   pgserve trust add <id> [flags]      add a user entry
+ *   pgserve trust remove <id>           remove a user entry (refuses hardcoded)
+ *
+ * `add` flags (all required except where noted):
+ *   --issuer <url>                      OIDC issuer URL
+ *   --identity-regexp <regex>           sigstore --certificate-identity-regexp value
+ *   --publisher <name>                  package.json `pgserve.publisher` (optional)
+ *   --description <text>                human-readable summary (optional)
+ *
+ * Output modes:
+ *   default        human-readable table / status line
+ *   --json         emit a JSON object on stdout instead
+ *
+ * Exit codes:
+ *   0   success
+ *   1   user error (bad flags, unknown id, hardcoded id collision)
+ *   2   trust store on disk is malformed and must be repaired by hand
+ */
+
+import { listAllTrust, addUserTrust, removeUserTrust } from '../cosign/trust-store.js';
+
+const USAGE = `Usage: pgserve trust <list|add|remove> [args]
+
+  list                                    show hardcoded + user entries
+  add <id> --issuer <url> --identity-regexp <re> [--publisher <name>] [--description <text>]
+  remove <id>                             remove a user entry (refuses hardcoded)
+
+Common: --json    emit JSON instead of human-readable output`;
+
+function parseFlags(argv) {
+  const out = { positional: [], json: false, flags: {} };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--json') {
+      out.json = true;
+      continue;
+    }
+    if (a === '--help' || a === '-h') {
+      out.flags.help = true;
+      continue;
+    }
+    if (a.startsWith('--')) {
+      const name = a.slice(2);
+      const next = argv[i + 1];
+      if (next === undefined || next.startsWith('--')) {
+        out.flags[name] = true;
+      } else {
+        out.flags[name] = next;
+        i++;
+      }
+      continue;
+    }
+    out.positional.push(a);
+  }
+  return out;
+}
+
+function emit(json, payload, humanLine) {
+  if (json) {
+    process.stdout.write(JSON.stringify(payload) + '\n');
+  } else if (humanLine) {
+    process.stdout.write(humanLine + '\n');
+  }
+}
+
+function emitErr(json, code, message) {
+  if (json) {
+    process.stdout.write(JSON.stringify({ ok: false, error: { code, message } }) + '\n');
+  } else {
+    process.stderr.write(`pgserve trust: ${message}\n`);
+  }
+}
+
+function cmdList(opts) {
+  let entries;
+  try {
+    entries = listAllTrust();
+  } catch (err) {
+    emitErr(opts.json, err.code || 'ETRUSTSTORE', err.message);
+    return 2;
+  }
+  if (opts.json) {
+    emit(true, { ok: true, entries }, null);
+    return 0;
+  }
+  if (entries.length === 0) {
+    emit(false, null, 'pgserve trust: no entries');
+    return 0;
+  }
+  const widthId = Math.max(2, ...entries.map((e) => e.id.length));
+  const widthSrc = Math.max(6, ...entries.map((e) => e.source.length));
+  const widthPub = Math.max(9, ...entries.map((e) => (e.publisher || '').length));
+  const header = `${'id'.padEnd(widthId)}  ${'source'.padEnd(widthSrc)}  ${'publisher'.padEnd(widthPub)}  identityRegexp`;
+  process.stdout.write(`${header}\n`);
+  process.stdout.write(`${'-'.repeat(header.length)}\n`);
+  for (const e of entries) {
+    process.stdout.write(
+      `${e.id.padEnd(widthId)}  ${e.source.padEnd(widthSrc)}  ${(e.publisher || '').padEnd(widthPub)}  ${e.identityRegexp}\n`,
+    );
+  }
+  return 0;
+}
+
+function cmdAdd(opts) {
+  const id = opts.positional[1]; // [0]='add', [1]=id
+  if (!id) {
+    emitErr(opts.json, 'EUSAGE', `add requires an <id> argument\n\n${USAGE}`);
+    return 1;
+  }
+  const issuer = opts.flags.issuer;
+  const identityRegexp = opts.flags['identity-regexp'];
+  if (typeof issuer !== 'string' || !issuer) {
+    emitErr(opts.json, 'EUSAGE', '--issuer <url> is required');
+    return 1;
+  }
+  if (typeof identityRegexp !== 'string' || !identityRegexp) {
+    emitErr(opts.json, 'EUSAGE', '--identity-regexp <regex> is required');
+    return 1;
+  }
+  const candidate = {
+    id,
+    issuer,
+    identityRegexp,
+    publisher: typeof opts.flags.publisher === 'string' ? opts.flags.publisher : '',
+    description: typeof opts.flags.description === 'string' ? opts.flags.description : '',
+  };
+  let entry;
+  try {
+    entry = addUserTrust(candidate);
+  } catch (err) {
+    emitErr(opts.json, err.code || 'ETRUSTADD', err.message);
+    return err.code === 'ETRUSTSTORE' ? 2 : 1;
+  }
+  emit(opts.json, { ok: true, entry }, `pgserve trust: added "${entry.id}"`);
+  return 0;
+}
+
+function cmdRemove(opts) {
+  const id = opts.positional[1];
+  if (!id) {
+    emitErr(opts.json, 'EUSAGE', `remove requires an <id> argument\n\n${USAGE}`);
+    return 1;
+  }
+  let removed;
+  try {
+    removed = removeUserTrust(id);
+  } catch (err) {
+    emitErr(opts.json, err.code || 'ETRUSTREMOVE', err.message);
+    return err.code === 'ETRUSTSTORE' ? 2 : 1;
+  }
+  if (!removed) {
+    emitErr(opts.json, 'ENOENT', `no user trust entry with id "${id}"`);
+    return 1;
+  }
+  emit(opts.json, { ok: true, removed: id }, `pgserve trust: removed "${id}"`);
+  return 0;
+}
+
+export async function runTrust(argv = []) {
+  const opts = parseFlags(argv);
+  if (opts.flags.help || opts.positional.length === 0) {
+    process.stdout.write(USAGE + '\n');
+    return opts.flags.help ? 0 : 1;
+  }
+  const verb = opts.positional[0];
+  switch (verb) {
+    case 'list':
+      return cmdList(opts);
+    case 'add':
+      return cmdAdd(opts);
+    case 'remove':
+    case 'rm':
+      return cmdRemove(opts);
+    default:
+      emitErr(opts.json, 'EUSAGE', `unknown subverb "${verb}"\n\n${USAGE}`);
+      return 1;
+  }
+}
+
+export const __testInternals = Object.freeze({ parseFlags });

--- a/src/cosign/trust-store.js
+++ b/src/cosign/trust-store.js
@@ -86,6 +86,27 @@ export function readTrustStore({ homeDir = os.homedir() } = {}) {
     e.code = 'ETRUSTSTORE';
     throw e;
   }
+  // Per-entry shape check. Without this, a manually-edited
+  // identities.json containing `{"entries":[{}]}` would slip past the
+  // store-level guard and crash the formatter in `pgserve trust list`
+  // with a generic TypeError on first field access — losing the
+  // documented exit-2 ("malformed store") path. Fail fast here with
+  // the same ETRUSTSTORE code so downstream callers (the CLI command,
+  // `pgserve verify`, future provisioner) can branch on it uniformly.
+  for (let i = 0; i < parsed.entries.length; i++) {
+    const e = parsed.entries[i];
+    if (!e || typeof e !== 'object'
+        || typeof e.id !== 'string' || e.id.length === 0
+        || typeof e.issuer !== 'string' || e.issuer.length === 0
+        || typeof e.identityRegexp !== 'string' || e.identityRegexp.length === 0) {
+      const err = new Error(
+        `pgserve trust store at ${file}: entries[${i}] is missing required fields ` +
+          `(id, issuer, identityRegexp)`,
+      );
+      err.code = 'ETRUSTSTORE';
+      throw err;
+    }
+  }
   return parsed;
 }
 
@@ -130,6 +151,13 @@ export function validateEntry(candidate) {
       `trust entry id "${candidate.id}" must match /^[a-z0-9][a-z0-9._-]{0,63}$/i`,
     );
   }
+  // Normalize id to lowercase. The regex accepts upper-case (/i flag) so
+  // operators can paste pretty identifiers, but storage + lookup are
+  // case-insensitive — otherwise an entry typed "Foo" could shadow a
+  // hardcoded "foo" silently. Normalizing once on write keeps the
+  // hardcoded-shadow check simple and makes `trust remove FOO` idempotent
+  // with `trust add foo`.
+  const normalizedId = candidate.id.toLowerCase();
   // Validate the identityRegexp parses as JS regex (cosign uses a similar
   // RE2-ish dialect; this catches the obvious garbage while letting valid
   // sigstore patterns through).
@@ -139,7 +167,7 @@ export function validateEntry(candidate) {
     throw new Error(`trust entry identityRegexp is not a valid regex: ${err.message}`);
   }
   return {
-    id: candidate.id,
+    id: normalizedId,
     publisher: typeof candidate.publisher === 'string' ? candidate.publisher : '',
     issuer: candidate.issuer,
     identityRegexp: candidate.identityRegexp,
@@ -151,7 +179,13 @@ export function validateEntry(candidate) {
 }
 
 function isHardcodedId(id) {
-  return TRUSTED_IDENTITIES.some((e) => e.id === id);
+  // Compare lowercase-against-lowercase. validateEntry normalizes new
+  // user entries to lowercase; hardcoded ids in TRUSTED_IDENTITIES
+  // already use lowercase by convention, but we lowercase both sides to
+  // make the predicate symmetric and immune to a typo in the hardcoded
+  // table from leaking through.
+  const needle = id.toLowerCase();
+  return TRUSTED_IDENTITIES.some((e) => e.id.toLowerCase() === needle);
 }
 
 /**
@@ -186,14 +220,17 @@ export function removeUserTrust(id, opts = {}) {
   if (typeof id !== 'string' || id.length === 0) {
     throw new Error('removeUserTrust: id must be a non-empty string');
   }
-  if (isHardcodedId(id)) {
-    const e = new Error(`cannot remove "${id}" — hardcoded trust roots are not removable`);
+  // Lowercase normalization mirrors validateEntry — `trust remove FOO`
+  // must find the entry that `trust add foo` (or `trust add Foo`) wrote.
+  const normalizedId = id.toLowerCase();
+  if (isHardcodedId(normalizedId)) {
+    const e = new Error(`cannot remove "${normalizedId}" — hardcoded trust roots are not removable`);
     e.code = 'ETRUSTHARDCODED';
     throw e;
   }
   const store = readTrustStore(opts);
   const before = store.entries.length;
-  store.entries = store.entries.filter((x) => x.id !== id);
+  store.entries = store.entries.filter((x) => x.id !== normalizedId);
   if (store.entries.length === before) return false;
   writeTrustStore(store, opts);
   return true;

--- a/src/cosign/trust-store.js
+++ b/src/cosign/trust-store.js
@@ -1,0 +1,213 @@
+/**
+ * User-extensible cosign trust store at `~/.pgserve/trust/identities.json`.
+ *
+ * pgserve singleton (v2.4) — `pgserve-singleton-no-proxy` wish, Group 3
+ * (the `pgserve trust add/list/remove` CLI surface).
+ *
+ * Hardcoded trust roots live in `src/cosign/trust-list.js` and ship in the
+ * binary; operators cannot remove or override them. This module owns the
+ * separate, mutable layer where operators add their own publishers (e.g.
+ * a private fork of pgserve, an internal release workflow).
+ *
+ * File format (v1):
+ *   {
+ *     "schemaVersion": 1,
+ *     "entries": [
+ *       {
+ *         "id":             "<short-stable-id>",
+ *         "publisher":      "<package-json-pgserve-publisher>",
+ *         "issuer":         "<oidc-issuer-url>",
+ *         "identityRegexp": "<sigstore-cert-identity-regexp>",
+ *         "description":    "<human-readable, optional>",
+ *         "addedAt":        "<iso-8601>"
+ *       }
+ *     ]
+ *   }
+ *
+ * Write semantics: atomic via tmp-file + rename, file mode 0600.
+ * Read semantics: missing file or empty contents → `{ schemaVersion: 1, entries: [] }`.
+ */
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { TRUSTED_IDENTITIES, listHardcodedTrust } from './trust-list.js';
+
+const SCHEMA_VERSION = 1;
+const FILE_MODE = 0o600;
+const DIR_MODE = 0o700;
+
+const TRUST_FILE_NAME = 'identities.json';
+
+export function getTrustDir(homeDir = os.homedir()) {
+  return path.join(homeDir, '.pgserve', 'trust');
+}
+
+export function getTrustFilePath(homeDir = os.homedir()) {
+  return path.join(getTrustDir(homeDir), TRUST_FILE_NAME);
+}
+
+function emptyStore() {
+  return { schemaVersion: SCHEMA_VERSION, entries: [] };
+}
+
+/**
+ * Read the user trust store. Returns the parsed object on success, or an
+ * empty store if the file is missing. Throws on parse failure / bad shape.
+ */
+export function readTrustStore({ homeDir = os.homedir() } = {}) {
+  const file = getTrustFilePath(homeDir);
+  let raw;
+  try {
+    raw = fs.readFileSync(file, 'utf8');
+  } catch (err) {
+    if (err.code === 'ENOENT') return emptyStore();
+    throw err;
+  }
+  if (!raw.trim()) return emptyStore();
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    const e = new Error(`pgserve trust store at ${file} is not valid JSON: ${err.message}`);
+    e.code = 'ETRUSTSTORE';
+    throw e;
+  }
+  if (!parsed || typeof parsed !== 'object' || !Array.isArray(parsed.entries)) {
+    const e = new Error(`pgserve trust store at ${file} is missing the entries array`);
+    e.code = 'ETRUSTSTORE';
+    throw e;
+  }
+  if (parsed.schemaVersion !== SCHEMA_VERSION) {
+    const e = new Error(
+      `pgserve trust store schemaVersion ${parsed.schemaVersion} unsupported (expected ${SCHEMA_VERSION})`,
+    );
+    e.code = 'ETRUSTSTORE';
+    throw e;
+  }
+  return parsed;
+}
+
+/**
+ * Atomically write the trust store. Creates the directory if absent.
+ */
+export function writeTrustStore(store, { homeDir = os.homedir() } = {}) {
+  if (!store || typeof store !== 'object' || !Array.isArray(store.entries)) {
+    throw new Error('writeTrustStore: store must be { schemaVersion, entries }');
+  }
+  const dir = getTrustDir(homeDir);
+  const file = getTrustFilePath(homeDir);
+  fs.mkdirSync(dir, { recursive: true, mode: DIR_MODE });
+  const tmp = `${file}.tmp.${process.pid}`;
+  const payload = JSON.stringify({ schemaVersion: SCHEMA_VERSION, entries: store.entries }, null, 2) + '\n';
+  fs.writeFileSync(tmp, payload, { mode: FILE_MODE });
+  fs.renameSync(tmp, file);
+  try {
+    fs.chmodSync(file, FILE_MODE);
+  } catch {
+    /* best-effort on platforms that ignore mode */
+  }
+}
+
+/**
+ * Validate a single user entry candidate. Throws on bad shape.
+ * Returns the normalized entry (trimmed strings, computed addedAt).
+ */
+export function validateEntry(candidate) {
+  if (!candidate || typeof candidate !== 'object') {
+    throw new Error('trust entry must be an object');
+  }
+  const required = ['id', 'issuer', 'identityRegexp'];
+  for (const key of required) {
+    const v = candidate[key];
+    if (typeof v !== 'string' || v.length === 0) {
+      throw new Error(`trust entry field "${key}" must be a non-empty string`);
+    }
+  }
+  if (!/^[a-z0-9][a-z0-9._-]{0,63}$/i.test(candidate.id)) {
+    throw new Error(
+      `trust entry id "${candidate.id}" must match /^[a-z0-9][a-z0-9._-]{0,63}$/i`,
+    );
+  }
+  // Validate the identityRegexp parses as JS regex (cosign uses a similar
+  // RE2-ish dialect; this catches the obvious garbage while letting valid
+  // sigstore patterns through).
+  try {
+    new RegExp(candidate.identityRegexp);
+  } catch (err) {
+    throw new Error(`trust entry identityRegexp is not a valid regex: ${err.message}`);
+  }
+  return {
+    id: candidate.id,
+    publisher: typeof candidate.publisher === 'string' ? candidate.publisher : '',
+    issuer: candidate.issuer,
+    identityRegexp: candidate.identityRegexp,
+    description: typeof candidate.description === 'string' ? candidate.description : '',
+    addedAt: typeof candidate.addedAt === 'string' && candidate.addedAt
+      ? candidate.addedAt
+      : new Date().toISOString(),
+  };
+}
+
+function isHardcodedId(id) {
+  return TRUSTED_IDENTITIES.some((e) => e.id === id);
+}
+
+/**
+ * Add a user trust entry. Refuses to shadow a hardcoded id.
+ * Returns the normalized entry that was written.
+ */
+export function addUserTrust(candidate, opts = {}) {
+  const entry = validateEntry(candidate);
+  if (isHardcodedId(entry.id)) {
+    const e = new Error(
+      `cannot add "${entry.id}" — id collides with a hardcoded trust root and would shadow it`,
+    );
+    e.code = 'ETRUSTSHADOW';
+    throw e;
+  }
+  const store = readTrustStore(opts);
+  const existing = store.entries.findIndex((x) => x.id === entry.id);
+  if (existing >= 0) {
+    store.entries[existing] = entry;
+  } else {
+    store.entries.push(entry);
+  }
+  writeTrustStore(store, opts);
+  return entry;
+}
+
+/**
+ * Remove a user trust entry by id. Refuses to remove hardcoded entries.
+ * Returns true on success, false if the id was not in the user store.
+ */
+export function removeUserTrust(id, opts = {}) {
+  if (typeof id !== 'string' || id.length === 0) {
+    throw new Error('removeUserTrust: id must be a non-empty string');
+  }
+  if (isHardcodedId(id)) {
+    const e = new Error(`cannot remove "${id}" — hardcoded trust roots are not removable`);
+    e.code = 'ETRUSTHARDCODED';
+    throw e;
+  }
+  const store = readTrustStore(opts);
+  const before = store.entries.length;
+  store.entries = store.entries.filter((x) => x.id !== id);
+  if (store.entries.length === before) return false;
+  writeTrustStore(store, opts);
+  return true;
+}
+
+/**
+ * Combined view: hardcoded entries followed by user entries, each tagged
+ * with `source` and `removable`. Used by `pgserve trust list`.
+ */
+export function listAllTrust(opts = {}) {
+  const hardcoded = listHardcodedTrust();
+  const store = readTrustStore(opts);
+  const user = store.entries.map((entry) => ({ ...entry, source: 'user', removable: true }));
+  return [...hardcoded, ...user];
+}
+
+export const __testInternals = Object.freeze({ SCHEMA_VERSION, FILE_MODE, DIR_MODE });

--- a/tests/cli/trust.test.js
+++ b/tests/cli/trust.test.js
@@ -1,0 +1,69 @@
+/**
+ * Tests for the `pgserve trust` CLI flag parser.
+ *
+ * Full subverb behavior (add/remove/list) is exercised by
+ * tests/cosign/trust-store.test.js against the underlying module so we do
+ * not need to spawn child processes here. This file just locks in the
+ * argv-shape contract.
+ */
+
+import { test, expect, describe } from 'bun:test';
+import { __testInternals, runTrust } from '../../src/commands/trust.js';
+
+const { parseFlags } = __testInternals;
+
+describe('parseFlags', () => {
+  test('--json toggles json output', () => {
+    expect(parseFlags(['list', '--json']).json).toBe(true);
+  });
+
+  test('--issuer <url> consumes one positional', () => {
+    const o = parseFlags(['add', 'fork', '--issuer', 'https://x', '--identity-regexp', '.+']);
+    expect(o.positional).toEqual(['add', 'fork']);
+    expect(o.flags.issuer).toBe('https://x');
+    expect(o.flags['identity-regexp']).toBe('.+');
+  });
+
+  test('value-less flag (--help) sets boolean true', () => {
+    const o = parseFlags(['--help']);
+    expect(o.flags.help).toBe(true);
+  });
+
+  test('two consecutive --flags treats first as boolean', () => {
+    const o = parseFlags(['--json', '--help']);
+    expect(o.json).toBe(true);
+    expect(o.flags.help).toBe(true);
+  });
+});
+
+describe('runTrust dispatch', () => {
+  test('no args prints USAGE and exits non-zero', async () => {
+    const code = await runTrust([]);
+    expect(code).toBe(1);
+  });
+
+  test('--help exits 0', async () => {
+    const code = await runTrust(['--help']);
+    expect(code).toBe(0);
+  });
+
+  test('unknown subverb exits 1', async () => {
+    const code = await runTrust(['nope', '--json']);
+    expect(code).toBe(1);
+  });
+
+  test('add without id exits 1', async () => {
+    const code = await runTrust(['add', '--json']);
+    expect(code).toBe(1);
+  });
+
+  test('add without --issuer exits 1', async () => {
+    const code = await runTrust(['add', 'fork', '--identity-regexp', '.+', '--json']);
+    expect(code).toBe(1);
+  });
+
+  test('remove without id exits 1', async () => {
+    const code = await runTrust(['remove', '--json']);
+    expect(code).toBe(1);
+  });
+});

--- a/tests/cosign/trust-store.test.js
+++ b/tests/cosign/trust-store.test.js
@@ -189,6 +189,90 @@ describe('removeUserTrust', () => {
   });
 });
 
+describe('readTrustStore — per-entry validation (PR #87 review fix)', () => {
+  test('throws ETRUSTSTORE when an entry is missing required fields', () => {
+    fs.mkdirSync(path.join(homeDir, '.pgserve', 'trust'), { recursive: true });
+    fs.writeFileSync(
+      getTrustFilePath(homeDir),
+      JSON.stringify({ schemaVersion: 1, entries: [{}] }),
+    );
+    let caught;
+    try {
+      readTrustStore({ homeDir });
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeDefined();
+    expect(caught.code).toBe('ETRUSTSTORE');
+    expect(caught.message).toMatch(/entries\[0\]/);
+  });
+
+  test('throws ETRUSTSTORE when an entry has an empty id', () => {
+    fs.mkdirSync(path.join(homeDir, '.pgserve', 'trust'), { recursive: true });
+    fs.writeFileSync(
+      getTrustFilePath(homeDir),
+      JSON.stringify({
+        schemaVersion: 1,
+        entries: [{ id: '', issuer: 'x', identityRegexp: '.+' }],
+      }),
+    );
+    expect(() => readTrustStore({ homeDir })).toThrow(/entries\[0\]/);
+  });
+
+  test('accepts a valid populated entry', () => {
+    fs.mkdirSync(path.join(homeDir, '.pgserve', 'trust'), { recursive: true });
+    fs.writeFileSync(
+      getTrustFilePath(homeDir),
+      JSON.stringify({
+        schemaVersion: 1,
+        entries: [
+          { id: 'fork', issuer: 'https://i', identityRegexp: '.+', publisher: '' },
+        ],
+      }),
+    );
+    const store = readTrustStore({ homeDir });
+    expect(store.entries.length).toBe(1);
+  });
+});
+
+describe('case-insensitive id (PR #87 review fix)', () => {
+  test('validateEntry lowercases the id', () => {
+    const e = validateEntry({
+      id: 'FORK-Build',
+      issuer: 'https://i',
+      identityRegexp: '.+',
+    });
+    expect(e.id).toBe('fork-build');
+  });
+
+  test('addUserTrust refuses to shadow a hardcoded id with mixed case', () => {
+    let caught;
+    try {
+      addUserTrust(
+        {
+          id: 'AUTOMAGIK-genie-RELEASE',
+          issuer: 'https://i',
+          identityRegexp: '.+',
+        },
+        { homeDir },
+      );
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeDefined();
+    expect(caught.code).toBe('ETRUSTSHADOW');
+  });
+
+  test('removeUserTrust honors mixed-case input', () => {
+    addUserTrust(
+      { id: 'fork', issuer: 'https://i', identityRegexp: '.+' },
+      { homeDir },
+    );
+    expect(removeUserTrust('FORK', { homeDir })).toBe(true);
+    expect(readTrustStore({ homeDir }).entries.length).toBe(0);
+  });
+});
+
 describe('listAllTrust', () => {
   test('hardcoded entries appear first, all marked source/removable', () => {
     const list = listAllTrust({ homeDir });

--- a/tests/cosign/trust-store.test.js
+++ b/tests/cosign/trust-store.test.js
@@ -1,0 +1,216 @@
+/**
+ * Tests for the user-extensible cosign trust store (singleton G3 — `trust` verb).
+ */
+
+import { test, expect, describe, beforeEach, afterEach } from 'bun:test';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import {
+  readTrustStore,
+  writeTrustStore,
+  addUserTrust,
+  removeUserTrust,
+  listAllTrust,
+  validateEntry,
+  getTrustFilePath,
+  __testInternals,
+} from '../../src/cosign/trust-store.js';
+
+let homeDir;
+beforeEach(() => {
+  homeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pgserve-trust-test-'));
+});
+afterEach(() => {
+  if (homeDir && fs.existsSync(homeDir)) fs.rmSync(homeDir, { recursive: true, force: true });
+});
+
+describe('readTrustStore', () => {
+  test('returns empty store when file is missing', () => {
+    const store = readTrustStore({ homeDir });
+    expect(store.schemaVersion).toBe(__testInternals.SCHEMA_VERSION);
+    expect(store.entries).toEqual([]);
+  });
+
+  test('throws ETRUSTSTORE on invalid JSON', () => {
+    fs.mkdirSync(path.join(homeDir, '.pgserve', 'trust'), { recursive: true });
+    fs.writeFileSync(getTrustFilePath(homeDir), '{not-json');
+    expect(() => readTrustStore({ homeDir })).toThrow(/not valid JSON/);
+  });
+
+  test('throws ETRUSTSTORE on missing entries array', () => {
+    fs.mkdirSync(path.join(homeDir, '.pgserve', 'trust'), { recursive: true });
+    fs.writeFileSync(getTrustFilePath(homeDir), JSON.stringify({ schemaVersion: 1 }));
+    expect(() => readTrustStore({ homeDir })).toThrow(/missing the entries array/);
+  });
+
+  test('throws on unsupported schemaVersion', () => {
+    fs.mkdirSync(path.join(homeDir, '.pgserve', 'trust'), { recursive: true });
+    fs.writeFileSync(
+      getTrustFilePath(homeDir),
+      JSON.stringify({ schemaVersion: 99, entries: [] }),
+    );
+    expect(() => readTrustStore({ homeDir })).toThrow(/schemaVersion 99 unsupported/);
+  });
+});
+
+describe('writeTrustStore', () => {
+  test('creates the trust dir with mode 0700 and the file with 0600', () => {
+    writeTrustStore({ schemaVersion: 1, entries: [] }, { homeDir });
+    const file = getTrustFilePath(homeDir);
+    expect(fs.existsSync(file)).toBe(true);
+    const dirStat = fs.statSync(path.dirname(file));
+    const fileStat = fs.statSync(file);
+    expect((dirStat.mode & 0o777)).toBe(__testInternals.DIR_MODE);
+    expect((fileStat.mode & 0o777)).toBe(__testInternals.FILE_MODE);
+  });
+
+  test('writes valid JSON readable round-trip', () => {
+    const original = {
+      schemaVersion: 1,
+      entries: [
+        {
+          id: 'fork-build',
+          publisher: 'acme/fork',
+          issuer: 'https://token.actions.githubusercontent.com',
+          identityRegexp: '^https://github.com/acme/.*$',
+          description: 'fork build',
+          addedAt: '2026-05-08T12:00:00.000Z',
+        },
+      ],
+    };
+    writeTrustStore(original, { homeDir });
+    const round = readTrustStore({ homeDir });
+    expect(round.schemaVersion).toBe(1);
+    expect(round.entries).toEqual(original.entries);
+  });
+
+  test('rejects malformed input', () => {
+    expect(() => writeTrustStore({}, { homeDir })).toThrow(/store must be/);
+    expect(() => writeTrustStore({ entries: 'not-an-array' }, { homeDir })).toThrow();
+  });
+});
+
+describe('validateEntry', () => {
+  test('accepts a minimal valid entry', () => {
+    const e = validateEntry({
+      id: 'ok',
+      issuer: 'https://example.test/oidc',
+      identityRegexp: '^https://example/.+$',
+    });
+    expect(e.id).toBe('ok');
+    expect(e.publisher).toBe('');
+    expect(e.description).toBe('');
+    expect(typeof e.addedAt).toBe('string');
+  });
+
+  test('rejects empty id / issuer / identityRegexp', () => {
+    expect(() => validateEntry({ id: '', issuer: 'x', identityRegexp: 'x' })).toThrow();
+    expect(() => validateEntry({ id: 'x', issuer: '', identityRegexp: 'x' })).toThrow();
+    expect(() => validateEntry({ id: 'x', issuer: 'x', identityRegexp: '' })).toThrow();
+  });
+
+  test('rejects an id with disallowed chars', () => {
+    expect(() => validateEntry({ id: 'has space', issuer: 'x', identityRegexp: '.+' })).toThrow(/must match/);
+    expect(() => validateEntry({ id: '/leading-slash', issuer: 'x', identityRegexp: '.+' })).toThrow();
+  });
+
+  test('rejects an invalid regex', () => {
+    expect(() => validateEntry({ id: 'x', issuer: 'x', identityRegexp: '(' })).toThrow(/not a valid regex/);
+  });
+});
+
+describe('addUserTrust', () => {
+  test('adds a new entry and is idempotent on the same id (replace semantics)', () => {
+    const a = addUserTrust(
+      { id: 'fork', issuer: 'https://i', identityRegexp: '^https://github.com/acme/.*$' },
+      { homeDir },
+    );
+    expect(a.id).toBe('fork');
+    addUserTrust(
+      {
+        id: 'fork',
+        issuer: 'https://i2',
+        identityRegexp: '^https://github.com/acme/.*$',
+        description: 'updated',
+      },
+      { homeDir },
+    );
+    const store = readTrustStore({ homeDir });
+    expect(store.entries.length).toBe(1);
+    expect(store.entries[0].issuer).toBe('https://i2');
+    expect(store.entries[0].description).toBe('updated');
+  });
+
+  test('refuses to shadow a hardcoded id', () => {
+    let caught;
+    try {
+      addUserTrust(
+        {
+          id: 'automagik-genie-release',
+          issuer: 'https://i',
+          identityRegexp: '.+',
+        },
+        { homeDir },
+      );
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeDefined();
+    expect(caught.code).toBe('ETRUSTSHADOW');
+  });
+});
+
+describe('removeUserTrust', () => {
+  test('returns false when the id is unknown', () => {
+    expect(removeUserTrust('does-not-exist', { homeDir })).toBe(false);
+  });
+
+  test('removes a previously-added user entry', () => {
+    addUserTrust(
+      { id: 'fork', issuer: 'https://i', identityRegexp: '^https://github.com/acme/.*$' },
+      { homeDir },
+    );
+    expect(removeUserTrust('fork', { homeDir })).toBe(true);
+    const store = readTrustStore({ homeDir });
+    expect(store.entries.length).toBe(0);
+  });
+
+  test('refuses to remove a hardcoded id', () => {
+    let caught;
+    try {
+      removeUserTrust('automagik-genie-release', { homeDir });
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeDefined();
+    expect(caught.code).toBe('ETRUSTHARDCODED');
+  });
+});
+
+describe('listAllTrust', () => {
+  test('hardcoded entries appear first, all marked source/removable', () => {
+    const list = listAllTrust({ homeDir });
+    expect(list.length).toBeGreaterThan(0);
+    expect(list.every((e) => e.source === 'hardcoded' || e.source === 'user')).toBe(true);
+    expect(list.every((e) => typeof e.removable === 'boolean')).toBe(true);
+    // Hardcoded come first.
+    const firstUserIdx = list.findIndex((e) => e.source === 'user');
+    if (firstUserIdx >= 0) {
+      const lastHardIdx = list.map((e) => e.source).lastIndexOf('hardcoded');
+      expect(firstUserIdx).toBeGreaterThan(lastHardIdx);
+    }
+  });
+
+  test('reflects user additions', () => {
+    const before = listAllTrust({ homeDir });
+    addUserTrust(
+      { id: 'fork', issuer: 'https://i', identityRegexp: '^https://github.com/acme/.*$' },
+      { homeDir },
+    );
+    const after = listAllTrust({ homeDir });
+    expect(after.length).toBe(before.length + 1);
+    expect(after.find((e) => e.id === 'fork' && e.source === 'user' && e.removable)).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary

Second of four CLI verbs from the `pgserve-singleton-no-proxy` wish (Group 3). Manages the user-extensible cosign trust store at `~/.pgserve/trust/identities.json`, layered on top of the hardcoded `TRUSTED_IDENTITIES` constant.

- `src/cosign/trust-store.js` — atomic writer/reader, schema v1, mode 0700/0600, hardcoded-shadow refusal.
- `src/commands/trust.js` — `list` / `add <id>` / `remove <id>` subverbs with `--json` mode.
- Wrapper allowlist + dispatch wiring (mirrors `doctor` and `verify`).

## Files

- bin/pgserve-wrapper.cjs (allowlist)
- src/cli-install.cjs (dispatch)
- src/cosign/trust-store.js (new)
- src/commands/trust.js (new)
- tests/cosign/trust-store.test.js (new)
- tests/cli/trust.test.js (new)

## Test plan

- [x] bun test tests/cosign/trust-store.test.js tests/cli/trust.test.js → 28 pass / 0 fail
- [x] eslint src/ bin/ → clean
- [x] knip → clean
- [x] Smoke: `HOME=\$(mktemp -d) node bin/pgserve-wrapper.cjs trust list --json` returns the 3 hardcoded entries with `source: 'hardcoded', removable: false`.
- [x] Hardcoded-shadow: `addUserTrust({id: 'automagik-genie-release'})` throws `ETRUSTSHADOW`.
- [x] Hardcoded-removal: `removeUserTrust('automagik-genie-release')` throws `ETRUSTHARDCODED`.

## Cohort

Singleton G3 verb 2 of 4. Verb 1 (`doctor`) is in PR #86. Verbs 3/4 (`gc`, `provision`) come next; each ~150-300 LOC, separately shippable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)