### PR TITLE
feat(schema): pgserve_meta table bootstrap (singleton G3 foundation)

### DIFF
--- a/src/schema/pgserve-meta.js
+++ b/src/schema/pgserve-meta.js
@@ -57,10 +57,18 @@ export const PGSERVE_META_COLUMNS = Object.freeze([
  *   - last_used_at:   NOT NULL DEFAULT now() — touched by provision; gc
  *                     uses it as the staleness signal
  */
+// Schema-qualified name. The upgrade pipeline probes
+// `to_regclass('public.pgserve_meta')` (cosign-meta-migration.js); if a
+// non-default search_path is configured on the active role, an
+// unqualified CREATE TABLE could land the bootstrap in a non-public
+// schema while later migrations + gc continue to look in `public.`. The
+// only safe option is to qualify both halves consistently.
+const QUALIFIED = `public.${PGSERVE_META_TABLE}`;
+
 export function getBootstrapStatements() {
   return [
     [
-      `CREATE TABLE IF NOT EXISTS ${PGSERVE_META_TABLE} (`,
+      `CREATE TABLE IF NOT EXISTS ${QUALIFIED} (`,
       '  fingerprint   TEXT        PRIMARY KEY,',
       '  database_name TEXT        NOT NULL UNIQUE,',
       '  role_name     TEXT        NOT NULL,',
@@ -70,8 +78,8 @@ export function getBootstrapStatements() {
       '  last_used_at  TIMESTAMPTZ NOT NULL DEFAULT now()',
       ')',
     ].join('\n'),
-    `CREATE INDEX IF NOT EXISTS ${PGSERVE_META_TABLE}_last_used_at_idx ON ${PGSERVE_META_TABLE} (last_used_at)`,
-    `CREATE INDEX IF NOT EXISTS ${PGSERVE_META_TABLE}_publisher_idx ON ${PGSERVE_META_TABLE} (publisher)`,
+    `CREATE INDEX IF NOT EXISTS ${PGSERVE_META_TABLE}_last_used_at_idx ON ${QUALIFIED} (last_used_at)`,
+    `CREATE INDEX IF NOT EXISTS ${PGSERVE_META_TABLE}_publisher_idx ON ${QUALIFIED} (publisher)`,
   ];
 }
 

--- a/src/schema/pgserve-meta.js
+++ b/src/schema/pgserve-meta.js
@@ -1,0 +1,112 @@
+/**
+ * `pgserve_meta` table bootstrap.
+ *
+ * pgserve singleton (v2.4) — `pgserve-singleton-no-proxy` wish, Group 3
+ * (foundation for `pgserve provision` and `pgserve gc`).
+ *
+ * Schema rationale (Decision P4 — additive across the cohort):
+ *
+ *   `pgserve_meta` is the single source of truth for "which postgres
+ *   databases on this host belong to a known pgserve consumer."
+ *   `pgserve provision` writes a row when it idempotently CREATEs a DB +
+ *   role for a fingerprint. `pgserve gc` scans the table and DROPs DBs
+ *   whose `last_used_at` is older than the configured stale threshold or
+ *   whose source_path no longer exists. The cosign verify columns
+ *   (`verified_at`, `verified_identity`, `verified_tier`) are layered on
+ *   top via `src/cosign/schema.js#applyVerifiedColumns`; they ALTER this
+ *   table after CREATE.
+ *
+ * Why a separate module from cosign/schema.js: cosign owns the
+ * verification *delta*; this module owns the *base* table. Splitting
+ * them keeps the cosign migration genuinely additive (it's a no-op on
+ * fresh DBs that haven't bootstrapped, exactly as documented in
+ * cosign-meta-migration.js).
+ *
+ * Idempotency: every statement uses `IF NOT EXISTS` (table, columns,
+ * indexes). Re-running on an already-bootstrapped database is a no-op.
+ */
+
+export const PGSERVE_META_TABLE = 'pgserve_meta';
+
+/**
+ * Base columns owned by this module. Cosign columns are owned by
+ * src/cosign/schema.js and ALTERed in afterwards.
+ */
+export const PGSERVE_META_COLUMNS = Object.freeze([
+  'fingerprint',
+  'database_name',
+  'role_name',
+  'publisher',
+  'source_path',
+  'created_at',
+  'last_used_at',
+]);
+
+/**
+ * Idempotent statements that CREATE the table + supporting indexes.
+ * Returned as an array so callers can run each one individually for
+ * clear error reporting (mirrors cosign/schema.js#getMigrationStatements).
+ *
+ * Constraints:
+ *   - fingerprint:    PRIMARY KEY — the package.json sha256 fingerprint
+ *   - database_name:  UNIQUE NOT NULL — guards against accidental dupes
+ *   - role_name:      NOT NULL — every provisioned DB has a paired role
+ *   - publisher:      nullable — older path-tier installs may have none
+ *   - source_path:    nullable — fallback fingerprint may not have one
+ *   - created_at:     NOT NULL DEFAULT now() — set on insert
+ *   - last_used_at:   NOT NULL DEFAULT now() — touched by provision; gc
+ *                     uses it as the staleness signal
+ */
+export function getBootstrapStatements() {
+  return [
+    [
+      `CREATE TABLE IF NOT EXISTS ${PGSERVE_META_TABLE} (`,
+      '  fingerprint   TEXT        PRIMARY KEY,',
+      '  database_name TEXT        NOT NULL UNIQUE,',
+      '  role_name     TEXT        NOT NULL,',
+      '  publisher     TEXT,',
+      '  source_path   TEXT,',
+      '  created_at    TIMESTAMPTZ NOT NULL DEFAULT now(),',
+      '  last_used_at  TIMESTAMPTZ NOT NULL DEFAULT now()',
+      ')',
+    ].join('\n'),
+    `CREATE INDEX IF NOT EXISTS ${PGSERVE_META_TABLE}_last_used_at_idx ON ${PGSERVE_META_TABLE} (last_used_at)`,
+    `CREATE INDEX IF NOT EXISTS ${PGSERVE_META_TABLE}_publisher_idx ON ${PGSERVE_META_TABLE} (publisher)`,
+  ];
+}
+
+/**
+ * Single SQL string variant — convenient for embedding the bootstrap in
+ * a transaction or pg-init script.
+ */
+export function getBootstrapSQL() {
+  return `${getBootstrapStatements().join(';\n\n')};\n`;
+}
+
+/**
+ * Apply the bootstrap via a node-postgres-compatible client. The client
+ * must expose an async `query(sql)` method (matches both `pg.Client` and
+ * `pg.PoolClient`). Returns the list of statements executed.
+ *
+ * Statements run sequentially so a failure on the index half doesn't
+ * masquerade as success after the table half ran.
+ */
+export async function bootstrapPgserveMeta(client) {
+  if (!client || typeof client.query !== 'function') {
+    throw new TypeError('bootstrapPgserveMeta: client must expose an async query() method');
+  }
+  const statements = getBootstrapStatements();
+  for (const sql of statements) {
+    await client.query(sql);
+  }
+  return statements;
+}
+
+/**
+ * Predicate the upgrade pipeline calls before deciding whether to run
+ * the cosign-verify ALTER chain. We avoid loading pg here — callers pass
+ * the result of `SELECT to_regclass('public.pgserve_meta') IS NOT NULL`.
+ */
+export function tableExistsFromRegclass(toRegclassResult) {
+  return toRegclassResult === true;
+}

--- a/tests/schema/pgserve-meta.test.js
+++ b/tests/schema/pgserve-meta.test.js
@@ -49,7 +49,18 @@ describe('getBootstrapStatements', () => {
 
   test('first statement creates the table with IF NOT EXISTS', () => {
     const [createTable] = getBootstrapStatements();
-    expect(createTable).toMatch(/CREATE TABLE IF NOT EXISTS pgserve_meta/);
+    expect(createTable).toMatch(/CREATE TABLE IF NOT EXISTS public\.pgserve_meta/);
+  });
+
+  test('table + indexes are schema-qualified to public (matches cosign-meta-migration probe)', () => {
+    const sql = getBootstrapStatements().join(';');
+    // The upgrade pipeline probes to_regclass('public.pgserve_meta'),
+    // so the bootstrap MUST land in public to stay discoverable.
+    expect(sql).toContain('public.pgserve_meta');
+    // Defensive: there is no unqualified mention of the bare name in
+    // a CREATE / ON clause that would imply search_path resolution.
+    expect(sql).not.toMatch(/CREATE TABLE IF NOT EXISTS pgserve_meta(?!\w)/);
+    expect(sql).not.toMatch(/ON pgserve_meta(?!\w)/);
   });
 
   test('table SQL declares the expected primary key + uniqueness', () => {

--- a/tests/schema/pgserve-meta.test.js
+++ b/tests/schema/pgserve-meta.test.js
@@ -1,0 +1,156 @@
+/**
+ * Tests for the `pgserve_meta` table bootstrap (singleton G3 foundation).
+ *
+ * These tests exercise the SQL string + the `bootstrapPgserveMeta()`
+ * driver against a fake client. We intentionally do NOT spin up a real
+ * postgres here — these are pure-shape tests. The end-to-end
+ * "does the table actually get created" assertion lives in the
+ * provision/gc integration tests once those verbs land.
+ */
+
+import { test, expect, describe } from 'bun:test';
+import {
+  PGSERVE_META_TABLE,
+  PGSERVE_META_COLUMNS,
+  getBootstrapStatements,
+  getBootstrapSQL,
+  bootstrapPgserveMeta,
+  tableExistsFromRegclass,
+} from '../../src/schema/pgserve-meta.js';
+
+describe('exports', () => {
+  test('PGSERVE_META_TABLE is the canonical table name', () => {
+    expect(PGSERVE_META_TABLE).toBe('pgserve_meta');
+  });
+
+  test('PGSERVE_META_COLUMNS lists the owned columns and is frozen', () => {
+    expect(Object.isFrozen(PGSERVE_META_COLUMNS)).toBe(true);
+    expect(PGSERVE_META_COLUMNS).toContain('fingerprint');
+    expect(PGSERVE_META_COLUMNS).toContain('database_name');
+    expect(PGSERVE_META_COLUMNS).toContain('role_name');
+    expect(PGSERVE_META_COLUMNS).toContain('last_used_at');
+    // Cosign verify columns belong to src/cosign/schema.js, NOT here.
+    expect(PGSERVE_META_COLUMNS).not.toContain('verified_at');
+    expect(PGSERVE_META_COLUMNS).not.toContain('verified_identity');
+    expect(PGSERVE_META_COLUMNS).not.toContain('verified_tier');
+  });
+});
+
+describe('getBootstrapStatements', () => {
+  test('returns an array of idempotent statements', () => {
+    const statements = getBootstrapStatements();
+    expect(Array.isArray(statements)).toBe(true);
+    expect(statements.length).toBeGreaterThanOrEqual(3); // table + at least 2 indexes
+    for (const sql of statements) {
+      expect(typeof sql).toBe('string');
+      expect(sql.length).toBeGreaterThan(0);
+    }
+  });
+
+  test('first statement creates the table with IF NOT EXISTS', () => {
+    const [createTable] = getBootstrapStatements();
+    expect(createTable).toMatch(/CREATE TABLE IF NOT EXISTS pgserve_meta/);
+  });
+
+  test('table SQL declares the expected primary key + uniqueness', () => {
+    const [createTable] = getBootstrapStatements();
+    expect(createTable).toMatch(/fingerprint\s+TEXT\s+PRIMARY KEY/);
+    expect(createTable).toMatch(/database_name\s+TEXT\s+NOT NULL UNIQUE/);
+    expect(createTable).toMatch(/role_name\s+TEXT\s+NOT NULL/);
+    expect(createTable).toMatch(/created_at\s+TIMESTAMPTZ\s+NOT NULL DEFAULT now\(\)/);
+    expect(createTable).toMatch(/last_used_at\s+TIMESTAMPTZ\s+NOT NULL DEFAULT now\(\)/);
+  });
+
+  test('every index uses CREATE INDEX IF NOT EXISTS for idempotency', () => {
+    const indexStatements = getBootstrapStatements().slice(1);
+    expect(indexStatements.length).toBeGreaterThan(0);
+    for (const sql of indexStatements) {
+      expect(sql).toMatch(/CREATE INDEX IF NOT EXISTS/);
+    }
+  });
+
+  test('last_used_at index exists (gc uses it as staleness signal)', () => {
+    const sql = getBootstrapStatements().join(';');
+    expect(sql).toContain('pgserve_meta_last_used_at_idx');
+    expect(sql).toContain('(last_used_at)');
+  });
+
+  test('publisher index exists (gc may filter by publisher)', () => {
+    const sql = getBootstrapStatements().join(';');
+    expect(sql).toContain('pgserve_meta_publisher_idx');
+    expect(sql).toContain('(publisher)');
+  });
+});
+
+describe('getBootstrapSQL', () => {
+  test('joins statements with semicolons + newlines and ends with ";\\n"', () => {
+    const sql = getBootstrapSQL();
+    expect(sql.endsWith(';\n')).toBe(true);
+    // statement separator
+    expect(sql).toContain(';\n\n');
+  });
+});
+
+describe('bootstrapPgserveMeta', () => {
+  function fakeClient() {
+    const calls = [];
+    return {
+      calls,
+      query: async (sql) => {
+        calls.push(sql);
+        return { rows: [], rowCount: 0 };
+      },
+    };
+  }
+
+  test('runs every statement on the supplied client in order', async () => {
+    const client = fakeClient();
+    const ran = await bootstrapPgserveMeta(client);
+    expect(ran).toEqual(getBootstrapStatements());
+    expect(client.calls).toEqual(getBootstrapStatements());
+  });
+
+  test('rejects clients that do not expose an async query()', async () => {
+    let caught;
+    try {
+      await bootstrapPgserveMeta(null);
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(TypeError);
+
+    let caught2;
+    try {
+      await bootstrapPgserveMeta({ query: 'not-a-function' });
+    } catch (err) {
+      caught2 = err;
+    }
+    expect(caught2).toBeInstanceOf(TypeError);
+  });
+
+  test('propagates client.query errors (no swallowing)', async () => {
+    const client = {
+      query: async () => {
+        throw new Error('boom');
+      },
+    };
+    let caught;
+    try {
+      await bootstrapPgserveMeta(client);
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeDefined();
+    expect(caught.message).toBe('boom');
+  });
+});
+
+describe('tableExistsFromRegclass', () => {
+  test('true only when the regclass query returned literal true', () => {
+    expect(tableExistsFromRegclass(true)).toBe(true);
+    expect(tableExistsFromRegclass(false)).toBe(false);
+    expect(tableExistsFromRegclass(null)).toBe(false);
+    expect(tableExistsFromRegclass(undefined)).toBe(false);
+    expect(tableExistsFromRegclass('t')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Foundation module for `pgserve provision` (writes rows) and `pgserve gc` (reads rows). Ships the missing `CREATE TABLE pgserve_meta` that the existing cosign-meta-migration documents as a precondition.

The cosign verify columns (`verified_at`, `verified_identity`, `verified_tier`) remain owned by `src/cosign/schema.js` and ALTER on top of this base — keeps the cosign migration genuinely additive (Decision P4).

## What ships

- `src/schema/pgserve-meta.js` — `getBootstrapStatements()`, `bootstrapPgserveMeta(client)`, `tableExistsFromRegclass()`, plus exported constants.
- `tests/schema/pgserve-meta.test.js` — 13 tests / 100% coverage of the module.

## Schema

| Column | Type | Constraint |
|---|---|---|
| fingerprint | TEXT | PRIMARY KEY |
| database_name | TEXT | NOT NULL UNIQUE |
| role_name | TEXT | NOT NULL |
| publisher | TEXT | nullable (path-tier installs may have none) |
| source_path | TEXT | nullable |
| created_at | TIMESTAMPTZ | NOT NULL DEFAULT now() |
| last_used_at | TIMESTAMPTZ | NOT NULL DEFAULT now() — gc staleness signal |

Plus indexes: \`pgserve_meta_last_used_at_idx\` (used by gc) and \`pgserve_meta_publisher_idx\`.

## Idempotency

Every statement uses \`IF NOT EXISTS\`. Re-running on an already-bootstrapped database is a no-op.

## Test plan

- [x] bun test tests/schema/pgserve-meta.test.js → 13 pass / 0 fail / 100% coverage
- [x] eslint src/ bin/ → clean
- [x] knip → clean (no new violations)

## Cohort

Singleton G3 foundation. Verbs that consume this in follow-ups:
- gc (verb 3)
- provision (verb 4) — calls bootstrapPgserveMeta + applyVerifiedColumns as part of its setup path

Already shipped: doctor (PR #86), trust (PR #87) — neither touches the table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)