### PR TITLE
fix(cosign): correct trust-list github org refs

### DIFF
--- a/src/cosign/trust-list.js
+++ b/src/cosign/trust-list.js
@@ -44,14 +44,14 @@ export const TRUSTED_IDENTITIES = Object.freeze([
     id: 'automagik-omni-release',
     publisher: '@automagik/omni',
     issuer: SIGSTORE_GITHUB_ACTIONS_ISSUER,
-    identityRegexp: '^https://github.com/automagik/omni/.github/workflows/release.yml@refs/tags/v.*$',
+    identityRegexp: '^https://github.com/automagik-dev/omni/.github/workflows/release.yml@refs/tags/v.*$',
     description: 'Namastex automagik omni release workflow (GitHub Actions OIDC)',
   }),
   Object.freeze({
     id: 'automagik-pgserve-release',
     publisher: '@automagik/pgserve',
     issuer: SIGSTORE_GITHUB_ACTIONS_ISSUER,
-    identityRegexp: '^https://github.com/automagik/pgserve/.github/workflows/release.yml@refs/tags/v.*$',
+    identityRegexp: '^https://github.com/namastexlabs/pgserve/.github/workflows/release.yml@refs/tags/v.*$',
     description: 'Namastex automagik pgserve release workflow (GitHub Actions OIDC)',
   }),
 ]);


### PR DESCRIPTION
## Summary

Two of the three hardcoded `TRUSTED_IDENTITIES` regexes in `src/cosign/trust-list.js` referenced GitHub orgs that don't host the actual release workflows. Without this fix, `pgserve verify` against any actually-signed pgserve binary fails — and the upcoming wave 2 G3 \"manifest LOCK 1\" verifier would freeze the broken values into every per-consumer manifest in perpetuity.

| publisher           | trust-list regex                  | actual repo          | status |
|---------------------|-----------------------------------|----------------------|--------|
| `@automagik/genie`  | `github.com/automagik-dev/genie/…`| `automagik-dev/genie`| ✅ correct (untouched) |
| `@automagik/omni`   | `github.com/automagik/omni/…`     | `automagik-dev/omni` | ❌ → **fixed** |
| `@automagik/pgserve`| `github.com/automagik/pgserve/…`  | `namastexlabs/pgserve`| ❌ → **fixed** |

Verified org names via `git remote -v` in `/repos/omni` and `/repos/pgserve`. The `release-publish.yml` workflow's `gh attestation verify --owner namastexlabs` already uses the correct owner — the bug was only in the in-process verifier (used by `pgserve verify` and the upcoming `pgserve create-app` LOCK 1 path).

## Why now

Surfaced during pre-flight audit of wave 4 G5 (`ENGINEER-AUDIT-G5.md`) while warming up on wave 2 G3 deliverables. **Held wave 2 G3 dispatch**: G3's manifest LOCK 1 verifier deep-clones `TRUSTED_IDENTITIES` at `pgserve create-app` time, so a wrong-regex live state would lock broken trust roots into every consumer's frozen manifest. Best to land before G3 starts coding.

## Test plan

- [x] `bun test tests/cosign/ tests/cli/trust.test.js tests/cli/verify.test.js` → 83 pass / 0 fail
- [x] `bun run lint` → clean
- [x] `bun run deadcode` → clean (only pre-existing knip config hints)
- [x] No test pins the literal regex string (verified via `grep -rn "automagik/omni\|automagik/pgserve" tests/` — only `tests/cli/verify.test.js:238` references `'@automagik/pgserve'` which is the npm package name field, not the regex)
- [ ] Optional: dogfood `pgserve verify` against a real signed binary (route to qa for smoke)

## Out of scope (follow-ups, not blockers)

- The `publisher: '@automagik/pgserve'` literal still lives in trust-list.js:52 even though the actual published npm package name is `pgserve` (no scope) per `npm view pgserve`. Worth a separate audit; not changed here per orchestrator's tight-scope instruction.
- Whether v2.5.0 needs a hot-republish to ship this fix to operators already on the broken trust list (Felipe-decision; coordinates with QA Phase 1 B1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal formatting in the cosign trust list configuration with no functional impact to system behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/namastexlabs/pgserve/pull/96)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->