### PR TITLE
feat(g2): integration test scaffold + queries rename + CI matrix wire

### DIFF
--- a/.genie/wishes/autopg-distribution-cutover-finalize/WISH.md
+++ b/.genie/wishes/autopg-distribution-cutover-finalize/WISH.md
@@ -125,6 +125,9 @@ bash tests/integration/gc-provision.test.sh
 
 **depends-on:** none (can ship in parallel with G1)
 
+**Implementation history (2026-05-09):**
+PR #94 shipped deliverables 1+2 partially — the dedup work landed but `src/gc/pg-queries.js` was kept as a 200-line re-exporter rather than deleted (spirit of single-source-of-truth met; letter of WISH violated). Deliverables 3 (test rename), 4 (integration scaffold), and 5 (CI matrix wire) deferred. PR #97 (g2-followup) completes deliverables 1–5: drops the re-exporter (gc imports `pgQuery`/`quoteIdent`/`quoteLiteral` directly from `src/lib/pg-query.js`; relocates gc-specific helpers to `src/gc/queries.js`), renames `tests/gc/pg-queries.test.js` → `tests/gc/queries.test.js`, adds `tests/integration/gc-provision.test.sh` (graceful-skip when postgres binaries absent), and wires `test-integration-gc-provision` job in `.github/workflows/ci.yml` (continue-on-error: true until GHA cache is warm). Audit trail: QA-FINDINGS-1-2.md (PR #94 PARTIAL verdict, 5 findings G2-1 through G2-5).
+
 ---
 
 ### Group 3: pgserve create-app + manifest LOCK 1 cosign verifier (Cutover G5)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,6 +101,39 @@ jobs:
           ./dist/pgserve --help
           echo "Build successful!"
 
+  # Optional: integration smoke for `pgserve provision` + `pgserve gc`.
+  # Wired as a non-blocking matrix until the GHA cache for postgres
+  # binaries is warm. The script itself skips gracefully if initdb /
+  # pg_ctl / psql are not on PATH, so this job is also a no-op on hosts
+  # that don't have postgres installed.
+  test-integration-gc-provision:
+    name: Integration (gc + provision round-trip)
+    runs-on: ubuntu-latest
+    continue-on-error: true
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.11
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Install postgres client + server
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y postgresql postgresql-client
+          # Make sure initdb / pg_ctl / psql resolve on $PATH for the script.
+          PG_BINDIR="$(pg_config --bindir 2>/dev/null || ls -d /usr/lib/postgresql/*/bin 2>/dev/null | tail -1)"
+          echo "$PG_BINDIR" >> "$GITHUB_PATH"
+
+      - name: Run gc/provision round-trip smoke
+        run: bash tests/integration/gc-provision.test.sh
+
   # Test npx flow (user experience)
   test-npx:
     name: Test npx install

--- a/src/commands/gc.js
+++ b/src/commands/gc.js
@@ -6,7 +6,7 @@
  * The 240-orphan-disease fix from the v1.0 mission. Composes:
  *   - src/gc/orphan-detection.js#classifyOrphans  — pure classifier
  *   - src/gc/audit-log.js#writeGcAudit            — JSON-lines audit
- *   - src/gc/pg-queries.js                        — psql shellouts
+ *   - src/gc/queries.js                           — gc-specific psql queries
  *   - src/lib/admin-json.js                       — port discovery
  *
  * Defaults:
@@ -38,7 +38,7 @@ import {
   selectActiveDbs,
   dropDatabase,
   deleteMetaRow,
-} from '../gc/pg-queries.js';
+} from '../gc/queries.js';
 import fs from 'node:fs';
 
 const DEFAULT_STALE_AFTER_DAYS = 30;

--- a/src/gc/queries.js
+++ b/src/gc/queries.js
@@ -9,10 +9,12 @@
  * specific SELECT / DROP queries gc runs against `pgserve_meta` +
  * `pg_database` + `pg_stat_activity`.
  *
- * Earlier shape (PR #91) inlined its own `pgQuery` because the shared
- * lib didn't exist on main yet — PR #92 added `src/lib/pg-query.js`,
- * and the `autopg-distribution-cutover-finalize` G2 dedup (this file's
- * commit) deletes the inline copy and imports the shared one.
+ * History: PR #91 inlined its own `pgQuery`; PR #92 extracted the
+ * canonical primitive to `src/lib/pg-query.js`; the
+ * `autopg-distribution-cutover-finalize` G2 dedup PR (#94) collapsed
+ * the gc-side copy into a re-exporter at `src/gc/pg-queries.js`. This
+ * file is the G2-followup destination — gc-specific helpers only,
+ * primitives consumed via direct imports from `src/lib/pg-query.js`.
  *
  * DROP DATABASE caveat: postgres refuses `DROP DATABASE <db>` when
  * sessions are connected. We `pg_terminate_backend()` everything
@@ -28,11 +30,6 @@ const DEFAULT_PORT = PG_QUERY_DEFAULTS.port;
 const DEFAULT_DB = PG_QUERY_DEFAULTS.db;
 
 const SYSTEM_DBS = new Set(['template0', 'template1', 'postgres']);
-
-// Re-export the shared primitive so existing callers that imported
-// `pgQuery` from `src/gc/pg-queries.js` keep working without churn.
-// Future PRs can switch them to import directly from `src/lib/pg-query.js`.
-export { pgQuery };
 
 /**
  * SELECT every row from `pgserve_meta`. Returns an array of plain
@@ -187,10 +184,6 @@ export function deleteMetaRow({ fingerprint, port = DEFAULT_PORT } = {}) {
     sql: `DELETE FROM public.${PGSERVE_META_TABLE} WHERE fingerprint = ${quoteLiteral(fingerprint)}`,
   });
 }
-
-// quoteIdent + quoteLiteral are imported from `src/lib/pg-query.js` —
-// the dedup keeps gc and provision quoting identical (same primitive,
-// same defensive escapes).
 
 export const __testInternals = Object.freeze({
   quoteIdent,

--- a/tests/cli/gc.test.js
+++ b/tests/cli/gc.test.js
@@ -3,8 +3,8 @@
  *
  * The verb's purity-side (orphan classifier + audit log) is exercised by
  * tests/gc/orphan-detection.test.js + tests/gc/audit-log.test.js.
- * pg-queries.js's psql shellout is exercised by
- * tests/gc/pg-queries.test.js. This file locks the CLI flag-parser +
+ * queries.js's psql shellout is exercised by
+ * tests/gc/queries.test.js. This file locks the CLI flag-parser +
  * resolvePort fallback contract.
  */
 

--- a/tests/gc/queries.test.js
+++ b/tests/gc/queries.test.js
@@ -3,19 +3,19 @@
  *
  * Deliberately scoped to the SQL-shape + identifier/literal-quoting
  * surface. The actual psql round-trip is exercised by integration tests
- * that spin up a real postgres in CI.
+ * that spin up a real postgres in CI (tests/integration/gc-provision.test.sh).
  */
 
 import { test, expect, describe } from 'bun:test';
 import {
-  pgQuery,
   selectMetaRows,
   selectExistingDbs,
   selectActiveDbs,
   dropDatabase,
   deleteMetaRow,
   __testInternals,
-} from '../../src/gc/pg-queries.js';
+} from '../../src/gc/queries.js';
+import { pgQuery } from '../../src/lib/pg-query.js';
 
 const { quoteIdent, quoteLiteral, SYSTEM_DBS, DEFAULT_PORT } = __testInternals;
 

--- a/tests/integration/gc-provision.test.sh
+++ b/tests/integration/gc-provision.test.sh
@@ -124,7 +124,7 @@ EOF
 
   # CREATE DATABASE postgres if pre-existing initdb's default differs;
   # provision's `db: 'postgres'` baseline assumes it's there.
-  psql -h "$SOCKET_DIR" -p "$PORT" -U "$USER" -d postgres -c "SELECT 1" >/dev/null \
+  psql -h "$SOCKET_DIR" -p "$PORT" -U postgres -d postgres -c "SELECT 1" >/dev/null \
     || { echo "psql connect failed" >&2; exit 2; }
   ok "postgres up on port ${PORT} (data: ${PG_DATA})"
 }
@@ -159,7 +159,7 @@ run_provision_twice() {
   ok "second provision succeeded (idempotent)"
 
   local meta_count
-  meta_count="$(psql -h "$SOCKET_DIR" -p "$PORT" -U "$USER" -d postgres -At -c \
+  meta_count="$(psql -h "$SOCKET_DIR" -p "$PORT" -U postgres -d postgres -At -c \
     'SELECT COUNT(*) FROM public.pgserve_meta' 2>/dev/null || echo 0)"
   if [[ "$meta_count" != "1" ]]; then
     bad "expected exactly 1 pgserve_meta row after idempotent re-provision, got ${meta_count}"
@@ -179,7 +179,7 @@ run_gc_dry_run_clean() {
     note "(non-fatal: summary key may differ; verifying via meta-row count instead)"
   fi
   local db_count
-  db_count="$(psql -h "$SOCKET_DIR" -p "$PORT" -U "$USER" -d postgres -At -c \
+  db_count="$(psql -h "$SOCKET_DIR" -p "$PORT" -U postgres -d postgres -At -c \
     "SELECT COUNT(*) FROM pg_database WHERE datname LIKE 'pgserve_%'" 2>/dev/null || echo 0)"
   if [[ "$db_count" != "1" ]]; then
     bad "gc --dry-run should not have dropped anything; expected 1 pgserve_* DB, got ${db_count}"
@@ -200,9 +200,9 @@ run_gc_apply() {
     || { bad "gc --apply failed (see gc-apply.err)"; cat "${WORK_DIR}/gc-apply.err" >&2; return 1; }
 
   local db_count meta_count
-  db_count="$(psql -h "$SOCKET_DIR" -p "$PORT" -U "$USER" -d postgres -At -c \
+  db_count="$(psql -h "$SOCKET_DIR" -p "$PORT" -U postgres -d postgres -At -c \
     "SELECT COUNT(*) FROM pg_database WHERE datname LIKE 'pgserve_%'" 2>/dev/null || echo 0)"
-  meta_count="$(psql -h "$SOCKET_DIR" -p "$PORT" -U "$USER" -d postgres -At -c \
+  meta_count="$(psql -h "$SOCKET_DIR" -p "$PORT" -U postgres -d postgres -At -c \
     'SELECT COUNT(*) FROM public.pgserve_meta' 2>/dev/null || echo 0)"
 
   if [[ "$db_count" != "0" ]]; then

--- a/tests/integration/gc-provision.test.sh
+++ b/tests/integration/gc-provision.test.sh
@@ -100,7 +100,13 @@ setup() {
 }
 JSON
 
-  initdb -D "$PG_DATA" -U "$USER" --auth-local=trust --auth-host=trust -E UTF8 -A trust >/dev/null 2>&1 \
+  # `-U postgres` forces the bootstrap superuser to literal `postgres`.
+  # initdb's default is `$USER` (the OS user, e.g. `runner` on GitHub
+  # Actions); pgserve provision/gc shellouts use `-U postgres` (the
+  # canonical role from PG_QUERY_DEFAULTS) so without this override the
+  # cluster ships with a non-existent `postgres` role and every shellout
+  # fails with `FATAL: role "postgres" does not exist`.
+  initdb -D "$PG_DATA" -U postgres --auth-local=trust --auth-host=trust -E UTF8 -A trust >/dev/null 2>&1 \
     || { echo "initdb failed; check $PG_LOG" >&2; exit 2; }
 
   # Tighten config so the ephemeral postmaster is small + fast.
@@ -134,9 +140,11 @@ EOF
 # which only knows about `postmaster` / `--help` and exits with help-
 # print on anything else.
 pgserve_run() {
+  # PGUSER is intentionally NOT set here — pgQuery passes `-U postgres`
+  # explicitly via PG_QUERY_DEFAULTS, so an env-level override would
+  # only mask a real bug rather than reflect production semantics.
   HOME="$FAKE_HOME" \
   PGHOST="$SOCKET_DIR" \
-  PGUSER="$USER" \
     node "${REPO_ROOT}/bin/pgserve-wrapper.cjs" "$@"
 }
 

--- a/tests/integration/gc-provision.test.sh
+++ b/tests/integration/gc-provision.test.sh
@@ -125,11 +125,19 @@ EOF
 
 # Run a pgserve verb against the worktree's bin/, with HOME redirected
 # to the fake-home so the audit log lands somewhere we control.
+#
+# Routes through `bin/pgserve-wrapper.cjs` (the verb dispatcher), NOT
+# `bin/postgres-server.js` (the postmaster lifecycle entry). Provision
+# and gc are install-subcommands that the wrapper dispatches to
+# `src/cli-install.cjs#dispatch`; calling postgres-server.js directly
+# would skip dispatch and hit the postmaster's `parsePostmasterArgs`,
+# which only knows about `postmaster` / `--help` and exits with help-
+# print on anything else.
 pgserve_run() {
   HOME="$FAKE_HOME" \
   PGHOST="$SOCKET_DIR" \
   PGUSER="$USER" \
-    node "${REPO_ROOT}/bin/postgres-server.js" "$@"
+    node "${REPO_ROOT}/bin/pgserve-wrapper.cjs" "$@"
 }
 
 run_provision_twice() {

--- a/tests/integration/gc-provision.test.sh
+++ b/tests/integration/gc-provision.test.sh
@@ -1,0 +1,231 @@
+#!/usr/bin/env bash
+#
+# gc-provision.test.sh — round-trip integration smoke for `pgserve gc`
+# + `pgserve provision`. Singleton G3 dedup follow-up
+# (autopg-distribution-cutover-finalize G2 deliverable 4).
+#
+# Pipeline:
+#   1) start an ephemeral postgres on a high port (no system service)
+#   2) `pgserve provision <fingerprint>` — creates DB + role + meta row
+#   3) `pgserve provision <fingerprint>` again — idempotency check
+#      (still 1 DB, 1 role, 1 meta row)
+#   4) `pgserve gc --dry-run` — expect zero orphans (source path still
+#      present, meta row still recent)
+#   5) Delete the source path (`gc` orphan signal: source_path missing)
+#   6) `pgserve gc --apply` — expect exactly one DB dropped + one meta
+#      row removed
+#   7) Assert the gc audit log at $HOME/.pgserve/audit/gc-<DATE>.log
+#      contains start / skip / drop / finish actions
+#
+# Skips gracefully on hosts without postgres binaries on PATH so it can
+# be wired into the CI matrix as an optional / non-blocking job until
+# the GHA cache for embedded-postgres is warm.
+#
+# Exit codes:
+#   0  pass (or skipped because postgres binaries are missing)
+#   1  fail (assertion missed)
+#   2  invalid setup (binaries present but fixture broken)
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+PORT="${GC_PROVISION_TEST_PORT:-65432}"
+
+PASS=0
+FAIL=0
+
+ok()   { printf '    \xe2\x9c\x93 %s\n' "$*";          PASS=$((PASS + 1)); }
+bad()  { printf '    \xe2\x9c\x97 %s\n' "$*" >&2;      FAIL=$((FAIL + 1)); }
+note() { printf '    \xe2\x80\xa2 %s\n' "$*" >&2; }
+
+require_postgres() {
+  for bin in initdb pg_ctl psql; do
+    if ! command -v "$bin" >/dev/null 2>&1; then
+      note "$bin not on PATH — skipping (suite needs a postgres install)"
+      exit 0
+    fi
+  done
+}
+
+WORK_DIR=""
+PG_DATA=""
+PG_LOG=""
+SOCKET_DIR=""
+SOURCE_DIR=""
+FAKE_HOME=""
+PG_RUNNING=0
+
+cleanup() {
+  if [[ "$PG_RUNNING" -eq 1 && -n "$PG_DATA" ]]; then
+    pg_ctl -D "$PG_DATA" stop -m immediate -s >/dev/null 2>&1 || true
+  fi
+  if [[ "${KEEP_GC_PROVISION_TEST_DIR:-0}" -eq 1 ]]; then
+    note "KEEP_GC_PROVISION_TEST_DIR=1 — keeping $WORK_DIR"
+    return
+  fi
+  if [[ -n "$WORK_DIR" && -d "$WORK_DIR" ]]; then
+    rm -rf "$WORK_DIR"
+  fi
+}
+trap cleanup EXIT
+
+setup() {
+  require_postgres
+  WORK_DIR="$(mktemp -d -t pgserve-gc-provision-XXXXXX)"
+  PG_DATA="${WORK_DIR}/data"
+  PG_LOG="${WORK_DIR}/postgres.log"
+  SOCKET_DIR="${WORK_DIR}/socket"
+  SOURCE_DIR="${WORK_DIR}/source"
+  FAKE_HOME="${WORK_DIR}/home"
+
+  mkdir -p "$SOCKET_DIR" "$SOURCE_DIR" "$FAKE_HOME"
+
+  # Minimal package.json so the pgserve provision fingerprint resolver
+  # has something deterministic to read in $SOURCE_DIR.
+  cat >"${SOURCE_DIR}/package.json" <<'JSON'
+{
+  "name": "@autopg-test/gc-provision-fixture",
+  "version": "0.0.0-fixture"
+}
+JSON
+
+  initdb -D "$PG_DATA" -U "$USER" --auth-local=trust --auth-host=trust -E UTF8 -A trust >/dev/null 2>&1 \
+    || { echo "initdb failed; check $PG_LOG" >&2; exit 2; }
+
+  # Tighten config so the ephemeral postmaster is small + fast.
+  cat >>"${PG_DATA}/postgresql.conf" <<EOF
+listen_addresses = '127.0.0.1'
+unix_socket_directories = '${SOCKET_DIR}'
+fsync = off
+synchronous_commit = off
+shared_buffers = 32MB
+EOF
+
+  pg_ctl -D "$PG_DATA" -l "$PG_LOG" -o "-p ${PORT}" -w start >/dev/null 2>&1 \
+    || { echo "pg_ctl start failed; check $PG_LOG" >&2; exit 2; }
+  PG_RUNNING=1
+
+  # CREATE DATABASE postgres if pre-existing initdb's default differs;
+  # provision's `db: 'postgres'` baseline assumes it's there.
+  psql -h "$SOCKET_DIR" -p "$PORT" -U "$USER" -d postgres -c "SELECT 1" >/dev/null \
+    || { echo "psql connect failed" >&2; exit 2; }
+  ok "postgres up on port ${PORT} (data: ${PG_DATA})"
+}
+
+# Run a pgserve verb against the worktree's bin/, with HOME redirected
+# to the fake-home so the audit log lands somewhere we control.
+pgserve_run() {
+  HOME="$FAKE_HOME" \
+  PGHOST="$SOCKET_DIR" \
+  PGUSER="$USER" \
+    node "${REPO_ROOT}/bin/postgres-server.js" "$@"
+}
+
+run_provision_twice() {
+  cd "$SOURCE_DIR"
+  pgserve_run provision --port "$PORT" --json >"${WORK_DIR}/prov-1.json" 2>"${WORK_DIR}/prov-1.err" \
+    || { bad "first provision failed (see prov-1.err)"; cat "${WORK_DIR}/prov-1.err" >&2; return 1; }
+  ok "first provision succeeded"
+
+  pgserve_run provision --port "$PORT" --json >"${WORK_DIR}/prov-2.json" 2>"${WORK_DIR}/prov-2.err" \
+    || { bad "second provision (idempotency) failed (see prov-2.err)"; cat "${WORK_DIR}/prov-2.err" >&2; return 1; }
+  ok "second provision succeeded (idempotent)"
+
+  local meta_count
+  meta_count="$(psql -h "$SOCKET_DIR" -p "$PORT" -U "$USER" -d postgres -At -c \
+    'SELECT COUNT(*) FROM public.pgserve_meta' 2>/dev/null || echo 0)"
+  if [[ "$meta_count" != "1" ]]; then
+    bad "expected exactly 1 pgserve_meta row after idempotent re-provision, got ${meta_count}"
+    return 1
+  fi
+  ok "pgserve_meta row count = 1 after idempotent re-provision"
+}
+
+run_gc_dry_run_clean() {
+  cd "$SOURCE_DIR"
+  pgserve_run gc --port "$PORT" --json >"${WORK_DIR}/gc-dry.json" 2>"${WORK_DIR}/gc-dry.err" \
+    || { bad "gc --dry-run failed (see gc-dry.err)"; cat "${WORK_DIR}/gc-dry.err" >&2; return 1; }
+  if grep -qE '"orphans":\s*0|"orphan_count":\s*0|"droppedCount":\s*0' "${WORK_DIR}/gc-dry.json"; then
+    ok "gc --dry-run reports zero orphans (source path still present)"
+  else
+    note "gc --dry-run summary: $(cat "${WORK_DIR}/gc-dry.json")"
+    note "(non-fatal: summary key may differ; verifying via meta-row count instead)"
+  fi
+  local db_count
+  db_count="$(psql -h "$SOCKET_DIR" -p "$PORT" -U "$USER" -d postgres -At -c \
+    "SELECT COUNT(*) FROM pg_database WHERE datname LIKE 'pgserve_%'" 2>/dev/null || echo 0)"
+  if [[ "$db_count" != "1" ]]; then
+    bad "gc --dry-run should not have dropped anything; expected 1 pgserve_* DB, got ${db_count}"
+    return 1
+  fi
+  ok "gc --dry-run did not drop the live DB"
+}
+
+simulate_orphan() {
+  rm -rf "$SOURCE_DIR"
+  ok "source path removed (simulated orphan)"
+}
+
+run_gc_apply() {
+  # source path no longer exists, so cwd doesn't matter — pgserve gc
+  # operates on the postgres state, not the cwd.
+  pgserve_run gc --port "$PORT" --apply --json >"${WORK_DIR}/gc-apply.json" 2>"${WORK_DIR}/gc-apply.err" \
+    || { bad "gc --apply failed (see gc-apply.err)"; cat "${WORK_DIR}/gc-apply.err" >&2; return 1; }
+
+  local db_count meta_count
+  db_count="$(psql -h "$SOCKET_DIR" -p "$PORT" -U "$USER" -d postgres -At -c \
+    "SELECT COUNT(*) FROM pg_database WHERE datname LIKE 'pgserve_%'" 2>/dev/null || echo 0)"
+  meta_count="$(psql -h "$SOCKET_DIR" -p "$PORT" -U "$USER" -d postgres -At -c \
+    'SELECT COUNT(*) FROM public.pgserve_meta' 2>/dev/null || echo 0)"
+
+  if [[ "$db_count" != "0" ]]; then
+    bad "gc --apply did not drop the orphan DB; expected 0 pgserve_*, got ${db_count}"
+    return 1
+  fi
+  ok "gc --apply dropped the orphan database"
+
+  if [[ "$meta_count" != "0" ]]; then
+    bad "gc --apply did not delete the orphan meta row; expected 0, got ${meta_count}"
+    return 1
+  fi
+  ok "gc --apply deleted the orphan pgserve_meta row"
+}
+
+assert_audit_log_events() {
+  local audit_dir="${FAKE_HOME}/.pgserve/audit"
+  if [[ ! -d "$audit_dir" ]]; then
+    bad "audit dir not created at ${audit_dir}"
+    return 1
+  fi
+  local audit_files=("$audit_dir"/gc-*.log)
+  if [[ ! -f "${audit_files[0]}" ]]; then
+    bad "no gc-<DATE>.log audit file under ${audit_dir}"
+    return 1
+  fi
+  local audit_log="${audit_files[0]}"
+  for action in start skip drop finish; do
+    if ! grep -qE "\"action\":\s*\"${action}\"" "$audit_log"; then
+      bad "audit log missing action=${action} (file: ${audit_log})"
+      note "audit log contents:"
+      cat "$audit_log" >&2
+      return 1
+    fi
+    ok "audit log contains action=${action}"
+  done
+}
+
+main() {
+  setup
+  run_provision_twice
+  run_gc_dry_run_clean
+  simulate_orphan
+  run_gc_apply
+  assert_audit_log_events
+
+  printf '\n  PASS: %d   FAIL: %d\n' "$PASS" "$FAIL"
+  if [[ "$FAIL" -gt 0 ]]; then
+    return 1
+  fi
+}
+
+main "$@"

--- a/tests/integration/gc-provision.test.sh
+++ b/tests/integration/gc-provision.test.sh
@@ -55,6 +55,17 @@ SOURCE_DIR=""
 FAKE_HOME=""
 PG_RUNNING=0
 
+# Set PGPASSWORD to the conventional bootstrap value used by `pgserve
+# install` on fresh hosts. The CI matrix runs apt-installed postgres +
+# trust auth (per the postgresql.conf written below); when pgserve's
+# psql shellouts inherit our env, they need PGPASSWORD set so the
+# always-set-env contract from src/lib/pg-query.js doesn't pick up an
+# empty value. Mirrors what real fresh-install operators do per the
+# install docs. (Also matches the CV-1 hot-fix landing in PR #101 —
+# this export keeps the integration test independent of #101's merge
+# order so #97 isn't blocked on #101.)
+export PGPASSWORD="${PGPASSWORD:-postgres}"
+
 cleanup() {
   if [[ "$PG_RUNNING" -eq 1 && -n "$PG_DATA" ]]; then
     pg_ctl -D "$PG_DATA" stop -m immediate -s >/dev/null 2>&1 || true


### PR DESCRIPTION
## Summary

Closes the G2 follow-up gap surfaced by QA Phase 1.5 against PR #94. PR #94 shipped the `src/lib/pg-query.js` dedup but skipped: the integration smoke, the test rename to match the new file naming, and the CI wire-up. This PR lands all three plus the corresponding source-side rename.

| File | Change |
|------|--------|
| `tests/integration/gc-provision.test.sh` | **new** — round-trip integration smoke for `pgserve provision` + `pgserve gc`; skips gracefully when initdb/pg_ctl/psql aren't on PATH |
| `src/gc/queries.js` | **renamed** from `src/gc/pg-queries.js`; drops the `export { pgQuery }` re-export so consumers import primitives directly from `src/lib/pg-query.js` |
| `src/commands/gc.js` | Import path + module-doc updated to point at the new file |
| `tests/gc/queries.test.js` | **renamed** from `tests/gc/pg-queries.test.js`; `pgQuery` imported directly from `src/lib/pg-query.js` |
| `tests/cli/gc.test.js` | Module-doc references updated to match the renames |
| `.github/workflows/ci.yml` | New non-blocking job `test-integration-gc-provision` running the smoke on ubuntu-latest with apt-installed postgres |

## Validation

```text
bun test --timeout 30000          →  551 pass / 3 skip / 0 fail
bun run lint                       →  clean
bun run deadcode                   →  clean (only pre-existing knip hints)
```

Per the memory-pinned dev-install-safety rule (PR #96 era), `bun install` was run with `HOME=\$(mktemp -d) AUTOPG_SKIP_POSTINSTALL=1` so the operator's real `~/.autopg/data` was never touched during testing.

## Test plan

- [x] Targeted unit run: `bun test tests/gc/queries.test.js tests/cli/gc.test.js tests/lib/pg-query.test.js` — 36/36 pass
- [x] Full suite: `bun test --timeout 30000` — 551/551 pass
- [x] Lint + deadcode — clean
- [ ] CI matrix integration job: ubuntu-latest with apt postgres — non-blocking; results visible on PR runs
- [ ] Optional: dogfood by running `bash tests/integration/gc-provision.test.sh` locally on a host with postgres installed (route to qa for verify)

## Out of scope (handled separately)

- **WISH G2 spec text drift (G2-5)** — orchestrator handles inline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)