### PR TITLE
fix(cosign): correct publisher field for pgserve + reconcile SHARED-DESIGN org refs

### DIFF
--- a/.genie/wishes/pgserve-singleton-no-proxy/SHARED-DESIGN.md
+++ b/.genie/wishes/pgserve-singleton-no-proxy/SHARED-DESIGN.md
@@ -67,7 +67,7 @@ Two outcomes, both persistent (no ephemeral, no TTL). Persistence is universal; 
 
 ### 2.4 Trust list (cosign tier)
 
-- **Hardcoded automagik-dev**: compiled into `pgserve` binary. Identities accepted by default: `https://github.com/automagik-dev/genie/.github/workflows/release.yml@refs/tags/v*`, `https://github.com/automagik/omni/.github/workflows/release.yml@refs/tags/v*`, `https://github.com/automagik/pgserve/.github/workflows/release.yml@refs/tags/v*`. Updates to this list propagate via `pgserve update`.
+- **Hardcoded automagik-dev**: compiled into `pgserve` binary. Identities accepted by default: `https://github.com/automagik-dev/genie/.github/workflows/release.yml@refs/tags/v*`, `https://github.com/automagik-dev/omni/.github/workflows/release.yml@refs/tags/v*`, `https://github.com/namastexlabs/pgserve/.github/workflows/release.yml@refs/tags/v*`. Updates to this list propagate via `pgserve update`.
 - **User self-sign**: `pgserve trust add --identity <issuer> --key <pubkey>` writes to `~/.pgserve/trust/identities.json`. HTTPS-self-signed analog: works locally for the operator, doesn't grant trust globally.
 - **Verification cadence**: HMAC-signed cache token at `$XDG_STATE_HOME/pgserve/verified/<fingerprint>.token` (web-session-style). Sliding expiry (1h idle, 7d max). Re-verify on binary mtime change. Steady-state connections pay 0ms; updates pay re-verify.
 

--- a/src/cosign/trust-list.js
+++ b/src/cosign/trust-list.js
@@ -49,7 +49,7 @@ export const TRUSTED_IDENTITIES = Object.freeze([
   }),
   Object.freeze({
     id: 'automagik-pgserve-release',
-    publisher: '@automagik/pgserve',
+    publisher: 'pgserve',
     issuer: SIGSTORE_GITHUB_ACTIONS_ISSUER,
     identityRegexp: '^https://github.com/namastexlabs/pgserve/.github/workflows/release.yml@refs/tags/v.*$',
     description: 'Namastex automagik pgserve release workflow (GitHub Actions OIDC)',


### PR DESCRIPTION
## Summary

Closes the two LOW residuals from QA-FINDINGS-PR96.md (post-merge audit of the trust-list org-correction hot-fix that landed as PR #96):

| Finding | File | Change |
|---------|------|--------|
| LOW-1 | `src/cosign/trust-list.js:52` | `publisher: '@automagik/pgserve'` → `publisher: 'pgserve'` |
| LOW-2 | `.genie/wishes/pgserve-singleton-no-proxy/SHARED-DESIGN.md:70` | `automagik/omni` → `automagik-dev/omni` + `automagik/pgserve` → `namastexlabs/pgserve` (matches what PR #96 wired into trust-list.js) |

Diff: 2 files, +2 / -2.

## Verification

- `npm view pgserve name` → `pgserve` (no scope) — confirms LOW-1 fix
- `npm view @automagik/omni name` → `@automagik/omni` — confirms the omni publisher field stays as-is
- PR #96 (merged 9c4cdf114793) updated trust-list.js identityRegexp values for omni + pgserve; this PR catches up the design-doc prose at line 70 to reflect those regexes

## Validation

- [x] `bun test --timeout 30000` — 564 pass / 3 skip / 0 fail
- [x] `bun run lint` — clean
- [x] `bun run deadcode` — clean (only pre-existing knip config hints)

## Out of scope (deliberate)

`SHARED-DESIGN.md` has additional `automagik/pgserve` (line 214) and `automagik/omni` (line 259) occurrences as section headers naming the repos. Not flagged in QA-FINDINGS-PR96.md and not corrected here per the tight-scope rule. If the broader doc reconciliation is wanted, file a separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)