### PR TITLE
feat(g3): pgserve create-app + manifest LOCK 1 cosign verifier (autopg-distribution-cutover-finalize)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,6 +134,37 @@ jobs:
       - name: Run gc/provision round-trip smoke
         run: bash tests/integration/gc-provision.test.sh
 
+  # autopg-distribution-cutover-finalize G3 — `pgserve create-app` +
+  # `pgserve verify --slug` lock-vs-live trust differential. Mirrors the
+  # gc/provision job above (continue-on-error + apt postgres). Skips
+  # gracefully if postgres binaries are missing.
+  test-integration-verify-slug-rotation:
+    name: Integration (verify --slug lock-vs-live rotation)
+    runs-on: ubuntu-latest
+    continue-on-error: true
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.11
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Install postgres client + server
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y postgresql postgresql-client
+          PG_BINDIR="$(pg_config --bindir 2>/dev/null || ls -d /usr/lib/postgresql/*/bin 2>/dev/null | tail -1)"
+          echo "$PG_BINDIR" >> "$GITHUB_PATH"
+
+      - name: Run create-app + verify --slug rotation smoke
+        run: bash tests/integration/verify-slug-rotation.test.sh
+
   # Test npx flow (user experience)
   test-npx:
     name: Test npx install

--- a/bin/pgserve-wrapper.cjs
+++ b/bin/pgserve-wrapper.cjs
@@ -66,6 +66,15 @@ const __installSubcommands = new Set([
   // src/commands/provision.js header for why). Pure node + child_process,
   // must skip bun probe.
   'provision',
+  // autopg-distribution-cutover-finalize (v2.6) — wish Group 3.
+  // `create-app` registers a consumer slug in autopg_meta + writes the
+  // per-consumer admin.json + manifest.json under ~/.autopg/<slug>/,
+  // freezing TRUSTED_IDENTITIES into locked_roots at create time. Pure
+  // node + psql shellout — must skip bun probe like the rest of the G3
+  // verbs. Adding here makes BOTH `pgserve create-app` and
+  // `autopg create-app` work via the same dispatcher (autopg-wrapper.cjs
+  // delegates to pgserve-wrapper.cjs per Decision #7).
+  'create-app',
 ]);
 if (__subcommand && __installSubcommands.has(__subcommand)) {
   const cli = require(path.join(__dirname, '..', 'src', 'cli-install.cjs'));

--- a/src/admin/admin-bootstrap.js
+++ b/src/admin/admin-bootstrap.js
@@ -1,0 +1,296 @@
+/**
+ * Per-consumer admin + manifest bootstrap.
+ *
+ * pgserve singleton (v2.6) — `autopg-distribution-cutover-finalize`
+ * wish, Group 3 (`pgserve create-app` + manifest LOCK 1) deliverable D2.
+ *
+ * Writes two files to disk for a registered consumer:
+ *
+ *   ~/.autopg/<sanitized-slug>/admin.json    (mode 0600)
+ *   ~/.autopg/<sanitized-slug>/manifest.json (mode 0600)
+ *
+ * The containing directory is `0700`. Both files are derived caches of
+ * the authoritative `autopg_meta` row; cache-recovery (when divergence
+ * is detected by future doctor surfaces) is the V1 manual story:
+ * operator deletes the per-consumer dir + re-runs `pgserve create-app
+ * <slug>` (idempotent; preserves `locked_roots` from the table).
+ *
+ * Schema:
+ *
+ *   admin.json      { slug, manifestPath, lockedRoots: [...],
+ *                     createdAt, lastUpdated }
+ *
+ *   manifest.json   { schemaVersion: 1, slug, lockedRoots: [...],
+ *                     createdAt, lastUpdated }
+ *
+ *   The two files share the `slug` + `lockedRoots` fields by design —
+ *   admin.json is the orchestrator-facing record, manifest.json is the
+ *   verifier-facing copy with an explicit `schemaVersion` for future
+ *   migrations.
+ *
+ * Orthogonality: this per-consumer admin.json sits ONE directory level
+ * deeper than the host-level `~/.autopg/admin.json` (owned by
+ * `canonical-pgserve-pm2-supervision` G1, src/lib/admin-json.js). They
+ * never collide; the host record is `~/.autopg/admin.json`, the
+ * per-consumer record is `~/.autopg/<slug>/admin.json`.
+ *
+ * Slug sanitization: REUSES `sanitizeSlug` from
+ * src/provision/db-naming.js — the same canonical helper used to build
+ * provision database/role names. This guarantees the per-consumer dir
+ * for `@demo/app` resolves to `~/.autopg/demo_app/`, matching whatever
+ * provision/gc derived from the same input.
+ *
+ * TOCTOU defense: after mkdir, the resolved path is verified to still
+ * land inside the canonical autopg root via `fs.realpathSync` — refuses
+ * to write through a symlink that points outside `~/.autopg/`. The
+ * file writes themselves use the standard tmp + rename + chmod pattern
+ * already in src/lib/admin-json.js.
+ */
+
+import fs from 'fs';
+import path from 'path';
+
+import { sanitizeSlug } from '../provision/db-naming.js';
+import { getDefaultConfigDir } from '../lib/admin-json.js';
+
+export const PER_CONSUMER_ADMIN_FILE = 'admin.json';
+export const PER_CONSUMER_MANIFEST_FILE = 'manifest.json';
+export const PER_CONSUMER_FILE_MODE = 0o600;
+export const PER_CONSUMER_DIR_MODE = 0o700;
+export const MANIFEST_SCHEMA_VERSION = 1;
+
+/**
+ * Resolve the per-consumer config directory for a given slug.
+ *
+ * `<configDir>/<sanitized-slug>` — defaults `<configDir>` to whatever
+ * `getDefaultConfigDir()` returns (`AUTOPG_CONFIG_DIR` >
+ * `PGSERVE_CONFIG_DIR` > `$HOME/.autopg`).
+ *
+ * Throws on empty/whitespace slug input — never silently coerce a bad
+ * slug to a flat path that would clobber the host-level admin.json or
+ * an unrelated consumer.
+ */
+export function getConsumerDir(slug, { configDir = getDefaultConfigDir() } = {}) {
+  if (typeof slug !== 'string' || slug.trim().length === 0) {
+    throw new TypeError('admin-bootstrap: slug must be a non-empty string');
+  }
+  const sanitized = sanitizeSlug(slug);
+  if (sanitized.length === 0) {
+    throw new TypeError(
+      `admin-bootstrap: slug "${slug}" sanitizes to empty; pick a slug `
+      + 'with at least one alphanumeric character',
+    );
+  }
+  return {
+    sanitized,
+    consumerDir: path.join(configDir, sanitized),
+    configDir,
+  };
+}
+
+export function getConsumerAdminPath(slug, opts) {
+  const { consumerDir } = getConsumerDir(slug, opts);
+  return path.join(consumerDir, PER_CONSUMER_ADMIN_FILE);
+}
+
+export function getConsumerManifestPath(slug, opts) {
+  const { consumerDir } = getConsumerDir(slug, opts);
+  return path.join(consumerDir, PER_CONSUMER_MANIFEST_FILE);
+}
+
+function ensureConfigRoot(configDir) {
+  if (!fs.existsSync(configDir)) {
+    fs.mkdirSync(configDir, { recursive: true, mode: PER_CONSUMER_DIR_MODE });
+  }
+}
+
+function ensureConsumerDir(configDir, consumerDir) {
+  ensureConfigRoot(configDir);
+  if (!fs.existsSync(consumerDir)) {
+    fs.mkdirSync(consumerDir, { recursive: true, mode: PER_CONSUMER_DIR_MODE });
+  }
+  // TOCTOU defense: refuse to write through a symlink that escapes the
+  // canonical config root. Resolve both the root and the consumer dir
+  // and assert containment.
+  let realRoot;
+  let realConsumer;
+  try {
+    realRoot = fs.realpathSync(configDir);
+    realConsumer = fs.realpathSync(consumerDir);
+  } catch (err) {
+    throw new Error(
+      `admin-bootstrap: failed to resolve real path for "${consumerDir}": ${err.message}`,
+    );
+  }
+  const rootWithSep = realRoot.endsWith(path.sep) ? realRoot : realRoot + path.sep;
+  if (realConsumer !== realRoot && !realConsumer.startsWith(rootWithSep)) {
+    const err = new Error(
+      `admin-bootstrap: refusing to write — "${consumerDir}" resolves to `
+      + `"${realConsumer}", which is outside config root "${realRoot}". `
+      + 'Possible symlink attack; remove the symlink and retry.',
+    );
+    err.code = 'EAUTOPGCONSUMERESCAPE';
+    err.consumerDir = consumerDir;
+    err.realConsumer = realConsumer;
+    err.configRoot = realRoot;
+    throw err;
+  }
+  fs.chmodSync(consumerDir, PER_CONSUMER_DIR_MODE);
+  return realConsumer;
+}
+
+function atomicWrite(filePath, body) {
+  const tmp = `${filePath}.tmp.${process.pid}`;
+  fs.writeFileSync(tmp, body, { mode: PER_CONSUMER_FILE_MODE });
+  fs.renameSync(tmp, filePath);
+  fs.chmodSync(filePath, PER_CONSUMER_FILE_MODE);
+}
+
+function jsonBody(payload) {
+  return `${JSON.stringify(payload, null, 2)}\n`;
+}
+
+function deepCloneRoots(lockedRoots) {
+  if (!Array.isArray(lockedRoots)) {
+    throw new TypeError('admin-bootstrap: lockedRoots must be an array');
+  }
+  // Use JSON round-trip to drop any Object.freeze wrappers AND defensively
+  // copy nested fields. TRUSTED_IDENTITIES entries are plain objects with
+  // string values — no Date / Buffer / function / undefined that would
+  // round-trip badly.
+  return JSON.parse(JSON.stringify(lockedRoots));
+}
+
+/**
+ * Compose the on-disk records for a consumer. Pure function — no fs.
+ *
+ * Used by `bootstrapConsumerAdmin` (which writes them) and by the
+ * doctor surface (which compares against on-disk + table state).
+ */
+export function buildConsumerRecords({ slug, lockedRoots, createdAt, lastUpdated, configDir }) {
+  const { sanitized, consumerDir } = getConsumerDir(slug, { configDir });
+  const manifestPath = path.join(consumerDir, PER_CONSUMER_MANIFEST_FILE);
+  const cloned = deepCloneRoots(lockedRoots);
+
+  const adminRecord = {
+    slug: sanitized,
+    manifestPath,
+    lockedRoots: cloned,
+    createdAt,
+    lastUpdated,
+  };
+
+  const manifestRecord = {
+    schemaVersion: MANIFEST_SCHEMA_VERSION,
+    slug: sanitized,
+    lockedRoots: cloned,
+    createdAt,
+    lastUpdated,
+  };
+
+  return {
+    consumerDir,
+    sanitized,
+    manifestPath,
+    adminRecord,
+    manifestRecord,
+  };
+}
+
+/**
+ * Write the per-consumer admin.json + manifest.json pair.
+ *
+ * Inputs:
+ *   - slug         the input slug (will be sanitized via sanitizeSlug)
+ *   - lockedRoots  array of TRUSTED_IDENTITIES-shaped entries (frozen
+ *                  at create-app time); deep-cloned before write
+ *   - createdAt    ISO 8601 string; on first create-app
+ *   - lastUpdated  ISO 8601 string; touched every create-app re-run
+ *
+ * Idempotent: callers that re-run `pgserve create-app <slug>` should
+ * leave `createdAt` untouched (read it back from the autopg_meta row,
+ * not regenerated) and only refresh `lastUpdated`. The verb in D3
+ * threads this through.
+ *
+ * Returns the written records + paths so the caller can echo them in
+ * logs or feed them to a downstream reporter.
+ */
+export function bootstrapConsumerAdmin({
+  slug,
+  lockedRoots,
+  createdAt,
+  lastUpdated,
+  configDir = getDefaultConfigDir(),
+} = {}) {
+  if (typeof createdAt !== 'string' || createdAt.length === 0) {
+    throw new TypeError('admin-bootstrap: createdAt must be a non-empty ISO 8601 string');
+  }
+  if (typeof lastUpdated !== 'string' || lastUpdated.length === 0) {
+    throw new TypeError('admin-bootstrap: lastUpdated must be a non-empty ISO 8601 string');
+  }
+
+  const { sanitized, consumerDir, adminRecord, manifestRecord } =
+    buildConsumerRecords({ slug, lockedRoots, createdAt, lastUpdated, configDir });
+
+  const realConsumerDir = ensureConsumerDir(configDir, consumerDir);
+  // Recompute the manifest path to live under the resolved real dir so
+  // the manifestPath stored in admin.json matches what we actually
+  // wrote, even if the consumerDir we computed above was a symlink
+  // alias of the canonical realConsumerDir.
+  const adminFilePath = path.join(realConsumerDir, PER_CONSUMER_ADMIN_FILE);
+  const manifestFilePath = path.join(realConsumerDir, PER_CONSUMER_MANIFEST_FILE);
+  adminRecord.manifestPath = manifestFilePath;
+
+  atomicWrite(manifestFilePath, jsonBody(manifestRecord));
+  atomicWrite(adminFilePath, jsonBody(adminRecord));
+
+  return {
+    sanitized,
+    consumerDir: realConsumerDir,
+    adminPath: adminFilePath,
+    manifestPath: manifestFilePath,
+    adminRecord,
+    manifestRecord,
+  };
+}
+
+/**
+ * Read the consumer admin.json. Returns the parsed object on success,
+ * `null` when the file is missing or unreadable. Mirrors the read
+ * semantics of `readAdminJson` in src/lib/admin-json.js — never throws
+ * on missing/broken file.
+ */
+export function readConsumerAdmin(slug, { configDir = getDefaultConfigDir() } = {}) {
+  const file = getConsumerAdminPath(slug, { configDir });
+  let raw;
+  try {
+    raw = fs.readFileSync(file, 'utf8');
+  } catch {
+    return null;
+  }
+  try {
+    const parsed = JSON.parse(raw);
+    return (parsed && typeof parsed === 'object') ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Read the consumer manifest.json. Same semantics as readConsumerAdmin.
+ */
+export function readConsumerManifest(slug, { configDir = getDefaultConfigDir() } = {}) {
+  const file = getConsumerManifestPath(slug, { configDir });
+  let raw;
+  try {
+    raw = fs.readFileSync(file, 'utf8');
+  } catch {
+    return null;
+  }
+  try {
+    const parsed = JSON.parse(raw);
+    return (parsed && typeof parsed === 'object') ? parsed : null;
+  } catch {
+    return null;
+  }
+}

--- a/src/cli-install.cjs
+++ b/src/cli-install.cjs
@@ -1304,6 +1304,13 @@ function dispatch(subcommand, args, ctx) {
       // idempotency-driven serialization (see provision.js header for
       // why no advisory lock). Pure node + psql shellout.
       return import('./commands/provision.js').then((mod) => mod.runProvision(args));
+    case 'create-app':
+      // autopg-distribution-cutover-finalize (v2.6) — wish Group 3.
+      // Registers a consumer slug + writes admin.json/manifest.json,
+      // freezing TRUSTED_IDENTITIES into autopg_meta.locked_roots at
+      // create time. Idempotent: re-runs touch last_updated only and
+      // preserve the original locked_roots snapshot (BRIEF v5 A6).
+      return import('./commands/create-app.js').then((mod) => mod.runCreateApp(args));
     default:
       throw new Error(`pgserve: dispatch called with unknown subcommand "${subcommand}"`);
   }

--- a/src/commands/create-app.js
+++ b/src/commands/create-app.js
@@ -1,0 +1,387 @@
+/**
+ * `pgserve create-app <slug>` — autopg-distribution-cutover-finalize G3 verb.
+ *
+ * Registers a consumer app with pgserve:
+ *   1. Bootstraps the `public.autopg_meta` table (idempotent IF NOT EXISTS).
+ *   2. INSERTs a row keyed by sanitized slug, freezing the current
+ *      `TRUSTED_IDENTITIES` snapshot into `locked_roots` JSONB at the
+ *      moment of creation (the LOCK).
+ *   3. Writes the per-consumer cache pair to disk:
+ *        ~/.autopg/<slug>/admin.json      (mode 0600)
+ *        ~/.autopg/<slug>/manifest.json   (mode 0600)
+ *      under a 0700 directory.
+ *
+ * Idempotency contract (BRIEF v5 A6):
+ *   On re-run with the same slug, the verb touches `last_updated` only.
+ *   It does NOT re-lock `locked_roots` to the current TRUSTED_IDENTITIES
+ *   — the original snapshot from first-create is preserved. This is what
+ *   makes the upgrade-after-trust-rotation invariant pass: an existing
+ *   slug's verifier continues to use its frozen lock even after operators
+ *   mutate the live trust list via `pgserve trust add` / `remove`.
+ *
+ * Composes:
+ *   - src/schema/autopg-meta.js          → bootstrapAutopgMeta + columns
+ *   - src/admin/admin-bootstrap.js       → bootstrapConsumerAdmin
+ *   - src/cosign/trust-list.js           → TRUSTED_IDENTITIES (the lock)
+ *   - src/lib/admin-json.js              → readAdminJson (port discovery)
+ *   - src/lib/pg-query.js                → pgQuery + quoteLiteral
+ *
+ * Exit codes:
+ *   0  registered (or no-op idempotent re-run)
+ *   1  user error (bad flags, empty slug, slug sanitizes to empty)
+ *   2  pgserve postmaster unreachable / cannot bootstrap autopg_meta
+ *   3  postgres error during create / select / update sequence
+ */
+
+import { readAdminJson } from '../lib/admin-json.js';
+import { bootstrapAutopgMeta } from '../schema/autopg-meta.js';
+import { bootstrapConsumerAdmin } from '../admin/admin-bootstrap.js';
+import { TRUSTED_IDENTITIES } from '../cosign/trust-list.js';
+import { pgQuery, quoteLiteral } from '../lib/pg-query.js';
+import { sanitizeSlug } from '../provision/db-naming.js';
+
+const USAGE = `Usage: pgserve create-app <slug> [options]
+
+  <slug>                   consumer slug (sanitized via sanitizeSlug;
+                           e.g. "@demo/app" -> "demo_app").
+
+  --port <N>               override the postgres port (default: read
+                           ~/.autopg/admin.json or 5432).
+  --json                   emit a JSON summary on stdout.
+  -h, --help               show this help.
+
+Idempotent: re-running with the same slug touches last_updated only.
+The locked_roots snapshot from first-create is preserved — this is what
+keeps existing consumers verifiable after operator-driven trust rotation.
+
+Source-of-truth split:
+  public.autopg_meta is authoritative.
+  The per-consumer admin.json + manifest.json are derived caches.
+  On divergence, re-run \`pgserve create-app <slug>\` to regenerate them
+  from the table (the v2.4 read-only doctor surface flags divergence;
+  --fix tiered modes are deferred to a future wave).`;
+
+function parseFlags(argv) {
+  const out = { json: false, port: undefined, positional: [] };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    switch (a) {
+      case '--json':
+        out.json = true;
+        break;
+      case '--help':
+      case '-h':
+        out.help = true;
+        break;
+      case '--port':
+      case '-p': {
+        const v = Number(argv[++i]);
+        if (!Number.isInteger(v) || v <= 0 || v > 65535) {
+          throw new Error('--port requires an integer in [1, 65535]');
+        }
+        out.port = v;
+        break;
+      }
+      default:
+        if (a.startsWith('--')) {
+          throw new Error(`unknown flag: ${a}`);
+        }
+        out.positional.push(a);
+    }
+  }
+  return out;
+}
+
+function resolvePort(opts) {
+  if (typeof opts.port === 'number') return opts.port;
+  try {
+    const admin = readAdminJson();
+    if (admin && Number.isInteger(admin.port) && admin.port > 0) return admin.port;
+  } catch {
+    /* admin.json absent — fall through */
+  }
+  return 5432;
+}
+
+/**
+ * Adapter: shape `pgQuery` to the node-postgres-compatible
+ * `client.query(sql)` contract that bootstrapAutopgMeta expects.
+ * Mirrors src/commands/provision.js#makePsqlClient.
+ */
+function makePsqlClient({ port, db }) {
+  return {
+    query: async (sql) => pgQuery({ sql, port, db }),
+  };
+}
+
+async function ensureAutopgMetaSchema({ port }) {
+  const client = makePsqlClient({ port, db: 'postgres' });
+  await bootstrapAutopgMeta(client);
+}
+
+/**
+ * Look up an existing autopg_meta row for the slug. Returns
+ * `{ slug, manifestPath, lockedRoots, createdAt, lastUpdated }` or null.
+ *
+ * `locked_roots` is JSONB; psql returns it as a JSON string, parsed
+ * here. Timestamps are returned as ISO 8601 (psql `TIMESTAMPTZ` default
+ * format); we re-emit them through `new Date().toISOString()` so the
+ * cache-write side gets a stable shape.
+ */
+function selectAutopgMetaRow({ port, slug }) {
+  const out = pgQuery({
+    sql: [
+      'SELECT',
+      "  slug,",
+      "  manifest_path,",
+      "  locked_roots::text,",
+      "  to_char(created_at AT TIME ZONE 'UTC', 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"'),",
+      "  to_char(last_updated AT TIME ZONE 'UTC', 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')",
+      'FROM public.autopg_meta',
+      `WHERE slug = ${quoteLiteral(slug)}`,
+      'LIMIT 1',
+    ].join('\n'),
+    port,
+    captureStdout: true,
+  });
+  if (!out) return null;
+  const [foundSlug, manifestPath, lockedRootsJson, createdAt, lastUpdated] = out.split('\t');
+  if (!foundSlug) return null;
+  let lockedRoots;
+  try {
+    lockedRoots = JSON.parse(lockedRootsJson);
+  } catch (err) {
+    const wrap = new Error(
+      `pgserve create-app: failed to parse locked_roots for slug "${foundSlug}": ${err.message}`,
+    );
+    wrap.cause = err;
+    throw wrap;
+  }
+  return {
+    slug: foundSlug,
+    manifestPath,
+    lockedRoots,
+    createdAt,
+    lastUpdated,
+  };
+}
+
+function insertAutopgMetaRow({ port, slug, manifestPath, lockedRoots, nowIso }) {
+  pgQuery({
+    sql: [
+      'INSERT INTO public.autopg_meta',
+      '  (slug, manifest_path, locked_roots, created_at, last_updated)',
+      'VALUES (',
+      `  ${quoteLiteral(slug)},`,
+      `  ${quoteLiteral(manifestPath)},`,
+      `  ${quoteLiteral(JSON.stringify(lockedRoots))}::jsonb,`,
+      `  ${quoteLiteral(nowIso)}::timestamptz,`,
+      `  ${quoteLiteral(nowIso)}::timestamptz`,
+      ')',
+    ].join('\n'),
+    port,
+  });
+}
+
+function touchAutopgMetaRow({ port, slug, manifestPath, nowIso }) {
+  // Update `last_updated` + `manifest_path` (the latter may have shifted
+  // if the operator re-ran with a different AUTOPG_CONFIG_DIR). Crucially
+  // does NOT touch `locked_roots` — that's the lock-preservation
+  // invariant per BRIEF v5 A6.
+  pgQuery({
+    sql: [
+      'UPDATE public.autopg_meta SET',
+      `  manifest_path = ${quoteLiteral(manifestPath)},`,
+      `  last_updated = ${quoteLiteral(nowIso)}::timestamptz`,
+      `WHERE slug = ${quoteLiteral(slug)}`,
+    ].join('\n'),
+    port,
+  });
+}
+
+function deepCloneRoots(lockedRoots) {
+  return JSON.parse(JSON.stringify(lockedRoots));
+}
+
+function emit({ json, summary, humanLines }) {
+  if (json) {
+    process.stdout.write(`${JSON.stringify(summary)}\n`);
+  } else {
+    for (const line of humanLines) process.stdout.write(`${line}\n`);
+  }
+}
+
+export async function runCreateApp(argv = []) {
+  let opts;
+  try {
+    opts = parseFlags(argv);
+  } catch (err) {
+    process.stderr.write(`pgserve create-app: ${err.message}\n\n${USAGE}\n`);
+    return 1;
+  }
+  if (opts.help) {
+    process.stdout.write(`${USAGE}\n`);
+    return 0;
+  }
+  const inputSlug = opts.positional[0];
+  if (typeof inputSlug !== 'string' || inputSlug.trim().length === 0) {
+    process.stderr.write(`pgserve create-app: <slug> is required\n\n${USAGE}\n`);
+    return 1;
+  }
+  const sanitized = sanitizeSlug(inputSlug);
+  if (sanitized.length === 0) {
+    process.stderr.write(
+      `pgserve create-app: slug "${inputSlug}" sanitizes to empty; pick a slug `
+      + 'with at least one alphanumeric character\n',
+    );
+    return 1;
+  }
+
+  const port = resolvePort(opts);
+  const summary = {
+    slug: sanitized,
+    inputSlug,
+    port,
+    action: 'unknown',
+  };
+
+  // Step 1 — bootstrap the autopg_meta table.
+  try {
+    await ensureAutopgMetaSchema({ port });
+  } catch (err) {
+    process.stderr.write(`pgserve create-app: cannot bootstrap autopg_meta: ${err.message}\n`);
+    summary.action = 'error';
+    summary.error = err.message;
+    if (opts.json) emit({ json: true, summary });
+    return 2;
+  }
+
+  // Step 2 — look for an existing row.
+  let existing;
+  try {
+    existing = selectAutopgMetaRow({ port, slug: sanitized });
+  } catch (err) {
+    process.stderr.write(`pgserve create-app: ${err.message}\n`);
+    summary.action = 'error';
+    summary.error = err.message;
+    if (opts.json) emit({ json: true, summary });
+    return 3;
+  }
+
+  const nowIso = new Date().toISOString();
+
+  if (existing) {
+    // Idempotent re-run path. Preserve `locked_roots` from the table
+    // (do NOT re-snapshot live TRUSTED_IDENTITIES — BRIEF v5 A6 lock
+    // preservation). Touch last_updated; rewrite the cache files.
+    let writeResult;
+    try {
+      writeResult = bootstrapConsumerAdmin({
+        slug: inputSlug,
+        lockedRoots: existing.lockedRoots,
+        createdAt: existing.createdAt,
+        lastUpdated: nowIso,
+      });
+    } catch (err) {
+      process.stderr.write(`pgserve create-app: failed to write cache files: ${err.message}\n`);
+      summary.action = 'error';
+      summary.error = err.message;
+      if (opts.json) emit({ json: true, summary });
+      return 1;
+    }
+
+    try {
+      touchAutopgMetaRow({
+        port,
+        slug: sanitized,
+        manifestPath: writeResult.manifestPath,
+        nowIso,
+      });
+    } catch (err) {
+      process.stderr.write(`pgserve create-app: ${err.message}\n`);
+      summary.action = 'error';
+      summary.error = err.message;
+      if (opts.json) emit({ json: true, summary });
+      return 3;
+    }
+
+    summary.action = 'touched';
+    summary.createdAt = existing.createdAt;
+    summary.lastUpdated = nowIso;
+    summary.lockedRoots = existing.lockedRoots;
+    summary.adminPath = writeResult.adminPath;
+    summary.manifestPath = writeResult.manifestPath;
+    emit({
+      json: opts.json,
+      summary,
+      humanLines: [
+        `pgserve create-app: slug "${sanitized}" already registered (touched).`,
+        `  locked_roots preserved (${existing.lockedRoots.length} entries from createdAt=${existing.createdAt})`,
+        `  admin:    ${writeResult.adminPath}`,
+        `  manifest: ${writeResult.manifestPath}`,
+      ],
+    });
+    return 0;
+  }
+
+  // Step 3 — fresh registration. Snapshot TRUSTED_IDENTITIES into the
+  // table + cache files. The deep-clone strips Object.freeze wrappers
+  // so the JSONB write is plain JSON.
+  const lockedRoots = deepCloneRoots(TRUSTED_IDENTITIES);
+
+  let writeResult;
+  try {
+    writeResult = bootstrapConsumerAdmin({
+      slug: inputSlug,
+      lockedRoots,
+      createdAt: nowIso,
+      lastUpdated: nowIso,
+    });
+  } catch (err) {
+    process.stderr.write(`pgserve create-app: failed to write cache files: ${err.message}\n`);
+    summary.action = 'error';
+    summary.error = err.message;
+    if (opts.json) emit({ json: true, summary });
+    return 1;
+  }
+
+  try {
+    insertAutopgMetaRow({
+      port,
+      slug: sanitized,
+      manifestPath: writeResult.manifestPath,
+      lockedRoots,
+      nowIso,
+    });
+  } catch (err) {
+    process.stderr.write(`pgserve create-app: ${err.message}\n`);
+    summary.action = 'error';
+    summary.error = err.message;
+    if (opts.json) emit({ json: true, summary });
+    return 3;
+  }
+
+  summary.action = 'created';
+  summary.createdAt = nowIso;
+  summary.lastUpdated = nowIso;
+  summary.lockedRoots = lockedRoots;
+  summary.adminPath = writeResult.adminPath;
+  summary.manifestPath = writeResult.manifestPath;
+  emit({
+    json: opts.json,
+    summary,
+    humanLines: [
+      `pgserve create-app: registered slug "${sanitized}".`,
+      `  locked_roots: snapshotted ${lockedRoots.length} entries from TRUSTED_IDENTITIES`,
+      `  admin:    ${writeResult.adminPath}`,
+      `  manifest: ${writeResult.manifestPath}`,
+    ],
+  });
+  return 0;
+}
+
+export const __testInternals = Object.freeze({
+  parseFlags,
+  resolvePort,
+  deepCloneRoots,
+});

--- a/src/commands/verify.js
+++ b/src/commands/verify.js
@@ -45,6 +45,8 @@ import {
   writeCacheToken,
 } from '../cosign/cache-token.js';
 import { sha256File, verifyBinary } from '../cosign/verify-binary.js';
+import { loadLockedRoots as loadLockedRootsImpl } from '../cosign/locked-roots.js';
+import { readAdminJson } from '../lib/admin-json.js';
 
 const EXIT_OK = 0;
 const EXIT_VERIFY_FAILED = 2;
@@ -110,6 +112,8 @@ function parseArgs(args) {
     cosignBin: null,
     allowFetch: false,
     noCache: false,
+    slug: null,
+    port: null,
   };
   for (let i = 0; i < args.length; i++) {
     const a = args[i];
@@ -119,6 +123,15 @@ function parseArgs(args) {
     else if (a === '--no-cache') opts.noCache = true;
     else if (a === '--bundle') opts.bundlePath = args[++i];
     else if (a === '--cosign-bin') opts.cosignBin = args[++i];
+    else if (a === '--slug') opts.slug = args[++i];
+    else if (a === '--port' || a === '-p') {
+      const v = Number(args[++i]);
+      if (!Number.isInteger(v) || v <= 0 || v > 65535) {
+        process.stderr.write('pgserve verify: --port requires an integer in [1, 65535]\n');
+        return { exit: EXIT_INVOCATION };
+      }
+      opts.port = v;
+    }
     else if (a === '--help' || a === '-h') {
       printHelp(process.stdout);
       return { exit: EXIT_OK };
@@ -134,6 +147,10 @@ function parseArgs(args) {
   }
   if (!opts.binaryPath) {
     printHelp(process.stderr);
+    return { exit: EXIT_INVOCATION };
+  }
+  if (opts.slug !== null && (typeof opts.slug !== 'string' || opts.slug.trim().length === 0)) {
+    process.stderr.write('pgserve verify: --slug requires a non-empty value\n');
     return { exit: EXIT_INVOCATION };
   }
   return { opts };
@@ -155,12 +172,19 @@ Options:
   --cosign-bin <path>    Override the cosign executable
   --allow-fetch          Allow downloading cosign if missing
   --no-cache             Never read or write the verified-cache token
+  --slug <slug>          Verify against the locked_roots snapshot for
+                         the named consumer slug from public.autopg_meta
+                         (frozen at \`pgserve create-app\` time). When
+                         omitted, the live TRUSTED_IDENTITIES list is used.
+  --port, -p <N>         Override the postgres port for --slug lookups
+                         (default: read ~/.autopg/admin.json or 5432)
   --help, -h             Show this help
 
 Exit codes:
   0  Verified (fresh or cache hit)
-  2  Verification failed
-  3  Invocation problem (missing binary/bundle/cosign/pretrusted key)
+  2  Verification failed (binary's identity not in trust list / locked roots)
+  3  Invocation problem (missing binary/bundle/cosign/pretrusted key,
+     unknown --slug, autopg_meta not bootstrapped)
 `);
 }
 
@@ -183,11 +207,30 @@ function emit({ json }, payload) {
   }
 }
 
+function resolveVerifyPort(opts) {
+  if (typeof opts.port === 'number') return opts.port;
+  try {
+    const admin = readAdminJson();
+    if (admin && Number.isInteger(admin.port) && admin.port > 0) return admin.port;
+  } catch {
+    /* admin.json absent — fall through */
+  }
+  return 5432;
+}
+
 /**
  * Run the verify command. `argv` is the bare argument list AFTER the
- * `verify` token. Returns an integer exit code.
+ * `verify` token.
+ *
+ * @param {string[]} argv
+ * @param {object} [deps]                       dependency injection seam
+ * @param {Function} [deps.loadLockedRoots]     test stub for the
+ *                                              autopg_meta loader; defaults
+ *                                              to the real psql shellout.
+ * @returns {number} exit code
  */
-export function runVerify(argv) {
+export function runVerify(argv, deps = {}) {
+  const loadLockedRoots = deps.loadLockedRoots || loadLockedRootsImpl;
   const parsed = parseArgs(argv);
   if (parsed.exit !== undefined) return parsed.exit;
   const opts = parsed.opts;
@@ -296,10 +339,55 @@ export function runVerify(argv) {
   }
 
   // ── Cosign path ──────────────────────────────────────────────────────
+  // --slug: load the frozen locked_roots from autopg_meta and pass them
+  // through as options.trustList so cosign verification runs against the
+  // create-app-time snapshot, not the live TRUSTED_IDENTITIES (BRIEF v5
+  // deliverable D4b — the manifest LOCK 1 invariant).
+  let slugTrustList;
+  let slugLockedAt;
+  if (opts.slug) {
+    try {
+      const port = resolveVerifyPort(opts);
+      const loaded = loadLockedRoots({ slug: opts.slug, port });
+      slugTrustList = loaded.lockedRoots;
+      slugLockedAt = loaded.createdAt;
+    } catch (err) {
+      // Map structured loader errors → invocation exit code (3). These
+      // are operator/setup problems, not "this binary is wrong" failures
+      // (which are exit code 2 — handled below by verifyBinary's
+      // empty-trust-list / no-matching-identity reasons).
+      if (
+        err.code === 'EAUTOPGMETAMISSING'
+        || err.code === 'EAUTOPGSLUGUNKNOWN'
+        || err.code === 'EAUTOPGLOCKEDPARSE'
+      ) {
+        emit(opts, {
+          ok: false,
+          reason: 'slug-lookup-failed',
+          detail: err.message,
+          slug: opts.slug,
+          loaderCode: err.code,
+        });
+        return EXIT_INVOCATION;
+      }
+      // Anything else (postgres unreachable, psql crash, etc.) is also
+      // an invocation problem — operator hasn't connected pgserve verify
+      // to a reachable postmaster.
+      emit(opts, {
+        ok: false,
+        reason: 'slug-lookup-failed',
+        detail: err.message,
+        slug: opts.slug,
+      });
+      return EXIT_INVOCATION;
+    }
+  }
+
   const result = verifyBinary(binaryPath, {
     cosignBin: opts.cosignBin || process.env.PGSERVE_COSIGN_BIN || undefined,
     bundlePath: opts.bundlePath || undefined,
     allowFetch: opts.allowFetch === true,
+    trustList: slugTrustList,
   });
 
   if (!result.ok) {
@@ -348,6 +436,8 @@ export function runVerify(argv) {
     cacheFile,
     bundle: result.bundle,
     cosignBin: result.cosignBin,
+    slug: opts.slug || undefined,
+    slugLockedAt: slugLockedAt || undefined,
   });
   return EXIT_OK;
 }

--- a/src/cosign/locked-roots.js
+++ b/src/cosign/locked-roots.js
@@ -1,0 +1,141 @@
+/**
+ * Locked-roots loader — reads `autopg_meta.locked_roots` for a slug.
+ *
+ * pgserve singleton (v2.6) — `autopg-distribution-cutover-finalize`
+ * wish, Group 3 (deliverable D4a). Companion to `pgserve verify --slug
+ * <slug>` (D4b): the verify verb passes the loaded `lockedRoots` as
+ * `options.trustList` to `verifyBinary()` so verification runs against
+ * the frozen-at-create-app snapshot, not the live `TRUSTED_IDENTITIES`.
+ *
+ * Why this is its own module:
+ *   - keeps create-app + verify decoupled (verify must not import
+ *     create-app's full verb code);
+ *   - lets tests stub the loader via dependency injection without
+ *     spinning up postgres;
+ *   - mirrors the cohort-canonical pattern of one psql-shellout file
+ *     per concern (provision/queries.js, gc/queries.js, etc.).
+ *
+ * Structured errors with stable `code` values let `pgserve verify`'s
+ * error-mapping layer pick the correct exit code:
+ *
+ *   EAUTOPGMETAMISSING  table doesn't exist (schema not bootstrapped on
+ *                       this postmaster — operator hasn't run any
+ *                       `pgserve create-app` yet) → invocation problem
+ *   EAUTOPGSLUGUNKNOWN  table exists but no row for slug → invocation
+ *                       problem; actionable message includes the
+ *                       remediation `pgserve create-app <slug>`
+ *   EAUTOPGLOCKEDPARSE  row exists but locked_roots JSONB is malformed
+ *                       (file rot / direct-mutation accident) →
+ *                       invocation problem
+ */
+
+import { pgQuery, quoteLiteral } from '../lib/pg-query.js';
+import { sanitizeSlug } from '../provision/db-naming.js';
+
+/**
+ * Load the locked-roots snapshot for a slug.
+ *
+ * @param {object} args
+ * @param {string} args.slug  raw or sanitized slug; sanitizeSlug runs
+ *                            inside so callers can pass either form.
+ * @param {number} [args.port=5432]
+ * @returns {{
+ *   slug: string,
+ *   lockedRoots: Array<object>,
+ *   createdAt: string,
+ *   lastUpdated: string,
+ *   manifestPath: string,
+ * }}
+ * @throws Error with `.code` set to one of EAUTOPGMETAMISSING /
+ *         EAUTOPGSLUGUNKNOWN / EAUTOPGLOCKEDPARSE on the structured
+ *         failure modes above; the underlying psql error otherwise.
+ */
+export function loadLockedRoots({ slug, port = 5432 } = {}) {
+  if (typeof slug !== 'string' || slug.trim().length === 0) {
+    throw new TypeError('loadLockedRoots: slug must be a non-empty string');
+  }
+  const sanitized = sanitizeSlug(slug);
+  if (sanitized.length === 0) {
+    const err = new Error(
+      `loadLockedRoots: slug "${slug}" sanitizes to empty; pick a slug `
+      + 'with at least one alphanumeric character',
+    );
+    err.code = 'EAUTOPGSLUGUNKNOWN';
+    throw err;
+  }
+
+  // Probe the table existence in the same query so we can disambiguate
+  // "table missing" from "row missing". `to_regclass` returns NULL when
+  // the relation is absent in the active search_path; we wrap the
+  // SELECT in a CTE that conditionally returns 'NO_TABLE' / 'NO_ROW' /
+  // the tab-separated payload. Plain text comes back via psql -At -F\t.
+  const sentinel = '__autopg_loaded__';
+  const sql = [
+    "WITH t AS (SELECT to_regclass('public.autopg_meta') AS rel)",
+    'SELECT',
+    "  CASE WHEN t.rel IS NULL THEN 'NO_TABLE' ELSE",
+    `    COALESCE((SELECT '${sentinel}\t' || locked_roots::text || '\t' ||`,
+    "             to_char(created_at AT TIME ZONE 'UTC', 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"') || '\t' ||",
+    "             to_char(last_updated AT TIME ZONE 'UTC', 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"') || '\t' ||",
+    '             manifest_path',
+    '             FROM public.autopg_meta',
+    `             WHERE slug = ${quoteLiteral(sanitized)} LIMIT 1), 'NO_ROW')`,
+    '  END AS payload',
+    'FROM t',
+  ].join('\n');
+
+  const out = pgQuery({ sql, port, captureStdout: true });
+
+  if (out === 'NO_TABLE') {
+    const err = new Error(
+      `loadLockedRoots: public.autopg_meta does not exist on this postmaster `
+      + '(no apps registered yet — run `pgserve create-app <slug>` to bootstrap)',
+    );
+    err.code = 'EAUTOPGMETAMISSING';
+    throw err;
+  }
+
+  if (out === 'NO_ROW' || !out.startsWith(`${sentinel}\t`)) {
+    const err = new Error(
+      `loadLockedRoots: no autopg_meta row for slug "${sanitized}" `
+      + `— run \`pgserve create-app ${sanitized}\` first`,
+    );
+    err.code = 'EAUTOPGSLUGUNKNOWN';
+    err.slug = sanitized;
+    throw err;
+  }
+
+  // Strip the sentinel + parse the four tab-separated fields.
+  const payload = out.slice(sentinel.length + 1);
+  const [lockedRootsJson, createdAt, lastUpdated, manifestPath] = payload.split('\t');
+
+  let lockedRoots;
+  try {
+    lockedRoots = JSON.parse(lockedRootsJson);
+  } catch (err) {
+    const wrap = new Error(
+      `loadLockedRoots: locked_roots JSONB for slug "${sanitized}" is malformed: ${err.message}`,
+    );
+    wrap.code = 'EAUTOPGLOCKEDPARSE';
+    wrap.slug = sanitized;
+    wrap.cause = err;
+    throw wrap;
+  }
+  if (!Array.isArray(lockedRoots)) {
+    const err = new Error(
+      `loadLockedRoots: locked_roots for slug "${sanitized}" is not a JSON array `
+      + `(got ${typeof lockedRoots})`,
+    );
+    err.code = 'EAUTOPGLOCKEDPARSE';
+    err.slug = sanitized;
+    throw err;
+  }
+
+  return {
+    slug: sanitized,
+    lockedRoots,
+    createdAt,
+    lastUpdated,
+    manifestPath,
+  };
+}

--- a/src/schema/autopg-meta.js
+++ b/src/schema/autopg-meta.js
@@ -1,0 +1,120 @@
+/**
+ * `autopg_meta` table bootstrap.
+ *
+ * pgserve singleton (v2.6) — `autopg-distribution-cutover-finalize`
+ * wish, Group 3 (`pgserve create-app` + manifest LOCK 1).
+ *
+ * Source-of-truth split (per wish Decision #2 / G3 deliverable 4):
+ *
+ *   `autopg_meta` is the single source of truth for "which apps are
+ *   registered with this pgserve instance + what cosign trust roots are
+ *   locked at create-app time." The per-consumer manifest file at
+ *   `~/.autopg/<sanitized-slug>/manifest.json` (and the sibling
+ *   `admin.json`) are derived caches; on divergence, the table wins.
+ *
+ *   The `--fix` mutation modes that would regenerate the cache files
+ *   from the table are NOT implemented in v2.4 read-only V1
+ *   (src/commands/doctor.js:440-442 prints "--fix tiered modes are not
+ *   implemented in v2.4"). Until those land, the cache-recovery story is
+ *   manual: operator deletes the per-consumer dir + re-runs
+ *   `pgserve create-app <slug>`. The verb is idempotent and preserves
+ *   the locked_roots already on the row (idempotent re-run touches
+ *   `last_updated` ONLY).
+ *
+ * Why a separate table from `pgserve_meta`: different lifecycle.
+ *   `pgserve_meta` is per-database (provision/gc cohort, fingerprint as
+ *   PK). `autopg_meta` is per-consumer-app (slug as PK), and an app can
+ *   exist before any of its DBs do. Splitting the tables keeps each
+ *   bootstrap genuinely additive + lets the wish Group 4/5 work
+ *   (per-consumer doctor surface) reach for autopg_meta without
+ *   crossing into pgserve_meta's invariants.
+ *
+ * Idempotency: every statement uses `IF NOT EXISTS` (table, indexes).
+ * Re-running on an already-bootstrapped database is a no-op.
+ */
+
+export const AUTOPG_META_TABLE = 'autopg_meta';
+
+/**
+ * Base columns owned by this module.
+ *
+ *   - slug:           PRIMARY KEY — the sanitized consumer slug
+ *                     (sanitizeSlug from src/provision/db-naming.js)
+ *   - manifest_path:  NOT NULL — absolute path to the cache manifest
+ *                     file at ~/.autopg/<slug>/manifest.json
+ *   - locked_roots:   NOT NULL — JSONB array shaped like
+ *                     TRUSTED_IDENTITIES entries, frozen-at-create
+ *   - created_at:     NOT NULL DEFAULT now() — set on insert
+ *   - last_updated:   NOT NULL DEFAULT now() — touched by every
+ *                     create-app re-run; locked_roots stays untouched
+ */
+export const AUTOPG_META_COLUMNS = Object.freeze([
+  'slug',
+  'manifest_path',
+  'locked_roots',
+  'created_at',
+  'last_updated',
+]);
+
+// Schema-qualified name. The doctor / verifier read paths probe
+// `to_regclass('public.autopg_meta')`; an unqualified CREATE TABLE
+// could land in a non-public schema if a non-default search_path is
+// configured on the active role, leaving subsequent reads unable to
+// find it. Match the qualification convention pgserve_meta uses.
+const QUALIFIED = `public.${AUTOPG_META_TABLE}`;
+
+/**
+ * Idempotent statements that CREATE the table + supporting indexes.
+ * Returned as an array so callers can run each one individually for
+ * clear error reporting (mirrors src/schema/pgserve-meta.js shape).
+ */
+export function getBootstrapStatements() {
+  return [
+    [
+      `CREATE TABLE IF NOT EXISTS ${QUALIFIED} (`,
+      '  slug          TEXT        PRIMARY KEY,',
+      '  manifest_path TEXT        NOT NULL,',
+      '  locked_roots  JSONB       NOT NULL,',
+      '  created_at    TIMESTAMPTZ NOT NULL DEFAULT now(),',
+      '  last_updated  TIMESTAMPTZ NOT NULL DEFAULT now()',
+      ')',
+    ].join('\n'),
+    `CREATE INDEX IF NOT EXISTS ${AUTOPG_META_TABLE}_last_updated_idx ON ${QUALIFIED} (last_updated)`,
+  ];
+}
+
+/**
+ * Single SQL string variant — convenient for embedding the bootstrap in
+ * a transaction or pg-init script.
+ */
+export function getBootstrapSQL() {
+  return `${getBootstrapStatements().join(';\n\n')};\n`;
+}
+
+/**
+ * Apply the bootstrap via a node-postgres-compatible client. The client
+ * must expose an async `query(sql)` method (matches both `pg.Client` and
+ * `pg.PoolClient`). Returns the list of statements executed.
+ *
+ * Statements run sequentially so a failure on the index half doesn't
+ * masquerade as success after the table half ran.
+ */
+export async function bootstrapAutopgMeta(client) {
+  if (!client || typeof client.query !== 'function') {
+    throw new TypeError('bootstrapAutopgMeta: client must expose an async query() method');
+  }
+  const statements = getBootstrapStatements();
+  for (const sql of statements) {
+    await client.query(sql);
+  }
+  return statements;
+}
+
+/**
+ * Predicate the doctor / verify read paths can call before deciding
+ * whether to query the table. Callers pass the result of
+ * `SELECT to_regclass('public.autopg_meta') IS NOT NULL`.
+ */
+export function tableExistsFromRegclass(toRegclassResult) {
+  return toRegclassResult === true;
+}

--- a/tests/admin/admin-bootstrap.test.js
+++ b/tests/admin/admin-bootstrap.test.js
@@ -1,0 +1,293 @@
+/**
+ * Tests for the per-consumer admin + manifest bootstrap (G3 D2).
+ *
+ * Uses a fresh tmp dir per test as the AUTOPG config root so we never
+ * touch the real `~/.autopg/`. No postgres + no network here — the
+ * end-to-end "create-app over psql" path lives in
+ * tests/cli/create-app.test.js + tests/integration/verify-slug-rotation.test.sh.
+ */
+
+import { test, expect, describe, beforeEach, afterEach } from 'bun:test';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+import {
+  PER_CONSUMER_ADMIN_FILE,
+  PER_CONSUMER_MANIFEST_FILE,
+  PER_CONSUMER_FILE_MODE,
+  PER_CONSUMER_DIR_MODE,
+  MANIFEST_SCHEMA_VERSION,
+  getConsumerDir,
+  getConsumerAdminPath,
+  getConsumerManifestPath,
+  buildConsumerRecords,
+  bootstrapConsumerAdmin,
+  readConsumerAdmin,
+  readConsumerManifest,
+} from '../../src/admin/admin-bootstrap.js';
+
+const SAMPLE_LOCKED_ROOTS = Object.freeze([
+  Object.freeze({
+    id: 'automagik-genie-release',
+    publisher: '@automagik/genie',
+    issuer: 'https://token.actions.githubusercontent.com',
+    identityRegexp: '^https://github.com/automagik-dev/genie/.github/workflows/release.yml@refs/tags/v.*$',
+    description: 'genie release',
+  }),
+]);
+
+const SAMPLE_CREATED_AT = '2026-05-09T18:00:00.000Z';
+const SAMPLE_LAST_UPDATED = '2026-05-09T18:00:00.000Z';
+
+let configDir;
+
+beforeEach(() => {
+  configDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pgserve-admin-test-'));
+});
+
+afterEach(() => {
+  if (configDir && fs.existsSync(configDir)) {
+    fs.rmSync(configDir, { recursive: true, force: true });
+  }
+});
+
+describe('exports', () => {
+  test('file/mode constants', () => {
+    expect(PER_CONSUMER_ADMIN_FILE).toBe('admin.json');
+    expect(PER_CONSUMER_MANIFEST_FILE).toBe('manifest.json');
+    expect(PER_CONSUMER_FILE_MODE).toBe(0o600);
+    expect(PER_CONSUMER_DIR_MODE).toBe(0o700);
+    expect(MANIFEST_SCHEMA_VERSION).toBe(1);
+  });
+});
+
+describe('getConsumerDir', () => {
+  test('joins sanitized slug under configDir (flat — never nested)', () => {
+    const result = getConsumerDir('demo', { configDir });
+    expect(result.sanitized).toBe('demo');
+    expect(result.consumerDir).toBe(path.join(configDir, 'demo'));
+  });
+
+  test('sanitizes scoped npm names like @demo/app to demo_app', () => {
+    const result = getConsumerDir('@demo/app', { configDir });
+    expect(result.sanitized).toBe('demo_app');
+    expect(result.consumerDir).toBe(path.join(configDir, 'demo_app'));
+  });
+
+  test('throws on empty / whitespace slug', () => {
+    expect(() => getConsumerDir('', { configDir })).toThrow(TypeError);
+    expect(() => getConsumerDir('   ', { configDir })).toThrow(TypeError);
+  });
+
+  test('throws on slug that sanitizes to empty (all-symbols)', () => {
+    expect(() => getConsumerDir('!!!', { configDir })).toThrow(/sanitizes to empty/);
+  });
+
+  test('throws on non-string slug', () => {
+    expect(() => getConsumerDir(123, { configDir })).toThrow(TypeError);
+    expect(() => getConsumerDir(null, { configDir })).toThrow(TypeError);
+  });
+});
+
+describe('getConsumerAdminPath / getConsumerManifestPath', () => {
+  test('admin path points at <slug>/admin.json', () => {
+    const p = getConsumerAdminPath('demo', { configDir });
+    expect(p).toBe(path.join(configDir, 'demo', 'admin.json'));
+  });
+
+  test('manifest path points at <slug>/manifest.json', () => {
+    const p = getConsumerManifestPath('demo', { configDir });
+    expect(p).toBe(path.join(configDir, 'demo', 'manifest.json'));
+  });
+});
+
+describe('buildConsumerRecords (pure)', () => {
+  test('produces admin + manifest records with shared slug + lockedRoots', () => {
+    const result = buildConsumerRecords({
+      slug: '@demo/app',
+      lockedRoots: SAMPLE_LOCKED_ROOTS,
+      createdAt: SAMPLE_CREATED_AT,
+      lastUpdated: SAMPLE_LAST_UPDATED,
+      configDir,
+    });
+
+    expect(result.sanitized).toBe('demo_app');
+    expect(result.adminRecord.slug).toBe('demo_app');
+    expect(result.manifestRecord.slug).toBe('demo_app');
+    expect(result.adminRecord.lockedRoots).toEqual(result.manifestRecord.lockedRoots);
+    expect(result.manifestRecord.schemaVersion).toBe(1);
+  });
+
+  test('deep-clones lockedRoots so frozen inputs become mutable outputs', () => {
+    const result = buildConsumerRecords({
+      slug: 'demo',
+      lockedRoots: SAMPLE_LOCKED_ROOTS,
+      createdAt: SAMPLE_CREATED_AT,
+      lastUpdated: SAMPLE_LAST_UPDATED,
+      configDir,
+    });
+    // The inputs are Object.frozen; clones must NOT be.
+    expect(Object.isFrozen(result.adminRecord.lockedRoots)).toBe(false);
+    expect(Object.isFrozen(result.adminRecord.lockedRoots[0])).toBe(false);
+    // And mutating the clone must NOT affect the input.
+    result.adminRecord.lockedRoots[0].id = 'mutated';
+    expect(SAMPLE_LOCKED_ROOTS[0].id).toBe('automagik-genie-release');
+  });
+
+  test('throws when lockedRoots is not an array', () => {
+    expect(() => buildConsumerRecords({
+      slug: 'demo',
+      lockedRoots: 'not-an-array',
+      createdAt: SAMPLE_CREATED_AT,
+      lastUpdated: SAMPLE_LAST_UPDATED,
+      configDir,
+    })).toThrow(TypeError);
+  });
+});
+
+describe('bootstrapConsumerAdmin (write path)', () => {
+  function read(filePath) {
+    return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+  }
+
+  test('writes both files with mode 0600 + dir 0700', () => {
+    const result = bootstrapConsumerAdmin({
+      slug: 'demo',
+      lockedRoots: SAMPLE_LOCKED_ROOTS,
+      createdAt: SAMPLE_CREATED_AT,
+      lastUpdated: SAMPLE_LAST_UPDATED,
+      configDir,
+    });
+
+    const dirStat = fs.statSync(result.consumerDir);
+    const adminStat = fs.statSync(result.adminPath);
+    const manifestStat = fs.statSync(result.manifestPath);
+
+    expect(dirStat.mode & 0o777).toBe(0o700);
+    expect(adminStat.mode & 0o777).toBe(0o600);
+    expect(manifestStat.mode & 0o777).toBe(0o600);
+
+    const onDiskAdmin = read(result.adminPath);
+    const onDiskManifest = read(result.manifestPath);
+
+    expect(onDiskAdmin.slug).toBe('demo');
+    expect(onDiskAdmin.lockedRoots).toEqual(JSON.parse(JSON.stringify(SAMPLE_LOCKED_ROOTS)));
+    expect(onDiskAdmin.manifestPath).toBe(result.manifestPath);
+    expect(onDiskManifest.schemaVersion).toBe(1);
+    expect(onDiskManifest.slug).toBe('demo');
+  });
+
+  test('idempotent re-run overwrites lastUpdated but body stays parseable', () => {
+    bootstrapConsumerAdmin({
+      slug: 'demo',
+      lockedRoots: SAMPLE_LOCKED_ROOTS,
+      createdAt: '2026-01-01T00:00:00.000Z',
+      lastUpdated: '2026-01-01T00:00:00.000Z',
+      configDir,
+    });
+
+    const result2 = bootstrapConsumerAdmin({
+      slug: 'demo',
+      lockedRoots: SAMPLE_LOCKED_ROOTS,
+      createdAt: '2026-01-01T00:00:00.000Z',
+      lastUpdated: '2026-05-09T18:00:00.000Z',
+      configDir,
+    });
+
+    const onDisk = read(result2.adminPath);
+    expect(onDisk.createdAt).toBe('2026-01-01T00:00:00.000Z');
+    expect(onDisk.lastUpdated).toBe('2026-05-09T18:00:00.000Z');
+  });
+
+  test('rejects empty lastUpdated / createdAt', () => {
+    expect(() => bootstrapConsumerAdmin({
+      slug: 'demo',
+      lockedRoots: SAMPLE_LOCKED_ROOTS,
+      createdAt: '',
+      lastUpdated: SAMPLE_LAST_UPDATED,
+      configDir,
+    })).toThrow(/createdAt/);
+
+    expect(() => bootstrapConsumerAdmin({
+      slug: 'demo',
+      lockedRoots: SAMPLE_LOCKED_ROOTS,
+      createdAt: SAMPLE_CREATED_AT,
+      lastUpdated: '',
+      configDir,
+    })).toThrow(/lastUpdated/);
+  });
+
+  test('per-consumer dir lives ONE level deep — never collides with host admin.json', () => {
+    bootstrapConsumerAdmin({
+      slug: 'demo',
+      lockedRoots: SAMPLE_LOCKED_ROOTS,
+      createdAt: SAMPLE_CREATED_AT,
+      lastUpdated: SAMPLE_LAST_UPDATED,
+      configDir,
+    });
+    // No file directly at <configDir>/admin.json was written by us.
+    expect(fs.existsSync(path.join(configDir, 'admin.json'))).toBe(false);
+    // The per-consumer file IS at <configDir>/<slug>/admin.json.
+    expect(fs.existsSync(path.join(configDir, 'demo', 'admin.json'))).toBe(true);
+  });
+
+  test('refuses to write through a symlink that escapes configDir (TOCTOU)', () => {
+    const escapeTarget = fs.mkdtempSync(path.join(os.tmpdir(), 'pgserve-escape-target-'));
+    try {
+      // Create the consumer dir as a symlink pointing OUTSIDE the
+      // canonical config root.
+      fs.mkdirSync(configDir, { recursive: true, mode: 0o700 });
+      fs.symlinkSync(escapeTarget, path.join(configDir, 'demo'));
+
+      let caught;
+      try {
+        bootstrapConsumerAdmin({
+          slug: 'demo',
+          lockedRoots: SAMPLE_LOCKED_ROOTS,
+          createdAt: SAMPLE_CREATED_AT,
+          lastUpdated: SAMPLE_LAST_UPDATED,
+          configDir,
+        });
+      } catch (err) {
+        caught = err;
+      }
+      expect(caught).toBeDefined();
+      expect(caught.code).toBe('EAUTOPGCONSUMERESCAPE');
+    } finally {
+      fs.rmSync(escapeTarget, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('readConsumerAdmin / readConsumerManifest', () => {
+  test('returns null when file is absent', () => {
+    expect(readConsumerAdmin('nonexistent', { configDir })).toBeNull();
+    expect(readConsumerManifest('nonexistent', { configDir })).toBeNull();
+  });
+
+  test('returns null when file is corrupt JSON', () => {
+    const dir = path.join(configDir, 'demo');
+    fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
+    fs.writeFileSync(path.join(dir, 'admin.json'), '{not json');
+    fs.writeFileSync(path.join(dir, 'manifest.json'), '{not json');
+    expect(readConsumerAdmin('demo', { configDir })).toBeNull();
+    expect(readConsumerManifest('demo', { configDir })).toBeNull();
+  });
+
+  test('round-trips a written record', () => {
+    bootstrapConsumerAdmin({
+      slug: 'demo',
+      lockedRoots: SAMPLE_LOCKED_ROOTS,
+      createdAt: SAMPLE_CREATED_AT,
+      lastUpdated: SAMPLE_LAST_UPDATED,
+      configDir,
+    });
+    const adminRead = readConsumerAdmin('demo', { configDir });
+    const manifestRead = readConsumerManifest('demo', { configDir });
+    expect(adminRead.slug).toBe('demo');
+    expect(adminRead.createdAt).toBe(SAMPLE_CREATED_AT);
+    expect(manifestRead.schemaVersion).toBe(1);
+    expect(manifestRead.lockedRoots[0].id).toBe('automagik-genie-release');
+  });
+});

--- a/tests/cli/create-app.test.js
+++ b/tests/cli/create-app.test.js
@@ -1,0 +1,121 @@
+/**
+ * Tests for `pgserve create-app` orchestration verb (G3 of
+ * `autopg-distribution-cutover-finalize`).
+ *
+ * Locks in:
+ *   - parseFlags shape (positional <slug> + --port + --json + --help)
+ *   - resolvePort fallback
+ *   - deepCloneRoots strips Object.freeze wrappers
+ *   - help / bad-flag / missing-slug exit codes
+ *
+ * Postgres-side integration ("does it actually INSERT into autopg_meta
+ * and write the cache files") is exercised by
+ * tests/integration/verify-slug-rotation.test.sh — that test stands up
+ * a real postmaster and runs the verb via the wrapper.
+ */
+
+import { test, expect, describe } from 'bun:test';
+import { __testInternals, runCreateApp } from '../../src/commands/create-app.js';
+
+const { parseFlags, resolvePort, deepCloneRoots } = __testInternals;
+
+describe('parseFlags', () => {
+  test('positional slug captured', () => {
+    const o = parseFlags(['demo']);
+    expect(o.positional).toEqual(['demo']);
+  });
+
+  test('scoped npm-style slug is captured verbatim (sanitization happens later)', () => {
+    const o = parseFlags(['@demo/app']);
+    expect(o.positional).toEqual(['@demo/app']);
+  });
+
+  test('--port <N> in valid range', () => {
+    expect(parseFlags(['--port', '15432']).port).toBe(15432);
+    expect(parseFlags(['-p', '5433']).port).toBe(5433);
+  });
+
+  test('--port rejects out-of-range or non-integer', () => {
+    expect(() => parseFlags(['--port', '0'])).toThrow();
+    expect(() => parseFlags(['--port', '70000'])).toThrow();
+    expect(() => parseFlags(['--port', 'abc'])).toThrow();
+  });
+
+  test('--json toggles JSON output', () => {
+    expect(parseFlags(['--json']).json).toBe(true);
+  });
+
+  test('--help / -h sets help', () => {
+    expect(parseFlags(['--help']).help).toBe(true);
+    expect(parseFlags(['-h']).help).toBe(true);
+  });
+
+  test('slug + flags combine', () => {
+    const o = parseFlags(['my-app', '--port', '5433', '--json']);
+    expect(o.positional).toEqual(['my-app']);
+    expect(o.port).toBe(5433);
+    expect(o.json).toBe(true);
+  });
+
+  test('unknown flag throws', () => {
+    expect(() => parseFlags(['--what'])).toThrow(/unknown flag/);
+  });
+});
+
+describe('resolvePort', () => {
+  test('explicit --port wins', () => {
+    expect(resolvePort({ port: 9999 })).toBe(9999);
+  });
+
+  test('falls back to a valid integer in [1, 65535]', () => {
+    const port = resolvePort({});
+    expect(Number.isInteger(port)).toBe(true);
+    expect(port).toBeGreaterThan(0);
+    expect(port).toBeLessThanOrEqual(65535);
+  });
+});
+
+describe('deepCloneRoots', () => {
+  test('strips Object.freeze wrappers', () => {
+    const frozen = Object.freeze([
+      Object.freeze({ id: 'a', publisher: '@x/y' }),
+    ]);
+    const cloned = deepCloneRoots(frozen);
+    expect(Object.isFrozen(cloned)).toBe(false);
+    expect(Object.isFrozen(cloned[0])).toBe(false);
+    expect(cloned[0].id).toBe('a');
+  });
+
+  test('produces an independent copy (mutation does not affect input)', () => {
+    const frozen = Object.freeze([{ id: 'a' }]);
+    const cloned = deepCloneRoots(frozen);
+    cloned[0].id = 'mutated';
+    expect(frozen[0].id).toBe('a');
+  });
+});
+
+describe('runCreateApp CLI surface', () => {
+  test('--help exits 0 without touching postgres', async () => {
+    const code = await runCreateApp(['--help']);
+    expect(code).toBe(0);
+  });
+
+  test('bad flag exits 1', async () => {
+    const code = await runCreateApp(['--what']);
+    expect(code).toBe(1);
+  });
+
+  test('missing slug exits 1', async () => {
+    const code = await runCreateApp([]);
+    expect(code).toBe(1);
+  });
+
+  test('all-symbol slug (sanitizes to empty) exits 1', async () => {
+    const code = await runCreateApp(['!!!']);
+    expect(code).toBe(1);
+  });
+
+  // The "actually registers a slug + writes cache files + INSERTs into
+  // autopg_meta" path requires a running postmaster — covered by
+  // tests/integration/verify-slug-rotation.test.sh.
+});

--- a/tests/cli/verify-slug.test.js
+++ b/tests/cli/verify-slug.test.js
@@ -1,0 +1,188 @@
+/**
+ * Tests for `pgserve verify --slug <slug>` (G3 D4b —
+ * autopg-distribution-cutover-finalize).
+ *
+ * Drives `runVerify(argv, deps)` directly with a stubbed loadLockedRoots
+ * so we don't need a running postmaster. The happy path (slug found ->
+ * lockedRoots passed as options.trustList -> verifyBinary called with
+ * the override) is exercised end-to-end by the integration test
+ * tests/integration/verify-slug-rotation.test.sh, which spins up real
+ * postgres + runs the wrapper.
+ *
+ * Coverage here:
+ *   - --slug parse + value validation
+ *   - --port parse + value validation
+ *   - exit-3 mapping for EAUTOPGSLUGUNKNOWN / EAUTOPGMETAMISSING /
+ *     EAUTOPGLOCKEDPARSE
+ *   - exit-3 fallback for any other loader exception
+ *   - --slug omitted -> live TRUSTED_IDENTITIES path (no loader call)
+ */
+
+import { test, expect, describe, beforeEach, afterEach } from 'bun:test';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { runVerify } from '../../src/commands/verify.js';
+
+let tmpBinDir;
+let tmpStateRoot;
+let stderrBuf;
+let stdoutBuf;
+let originalStderrWrite;
+let originalStdoutWrite;
+let originalXdgStateHome;
+
+beforeEach(() => {
+  tmpBinDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pgserve-verify-slug-bin-'));
+  tmpStateRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'pgserve-verify-slug-state-'));
+  originalXdgStateHome = process.env.XDG_STATE_HOME;
+  process.env.XDG_STATE_HOME = tmpStateRoot;
+  stderrBuf = [];
+  stdoutBuf = [];
+  originalStderrWrite = process.stderr.write.bind(process.stderr);
+  originalStdoutWrite = process.stdout.write.bind(process.stdout);
+  process.stderr.write = (chunk) => { stderrBuf.push(String(chunk)); return true; };
+  process.stdout.write = (chunk) => { stdoutBuf.push(String(chunk)); return true; };
+});
+
+afterEach(() => {
+  process.stderr.write = originalStderrWrite;
+  process.stdout.write = originalStdoutWrite;
+  if (originalXdgStateHome === undefined) delete process.env.XDG_STATE_HOME;
+  else process.env.XDG_STATE_HOME = originalXdgStateHome;
+  fs.rmSync(tmpBinDir, { recursive: true, force: true });
+  fs.rmSync(tmpStateRoot, { recursive: true, force: true });
+});
+
+function makeBinary(name = 'postgres') {
+  const file = path.join(tmpBinDir, name);
+  fs.writeFileSync(file, 'BINARY');
+  fs.chmodSync(file, 0o755);
+  // bundle sidecar — verifyBinary refuses without one even if cosign is missing.
+  fs.writeFileSync(`${file}.bundle`, '{"fake":"bundle"}');
+  return file;
+}
+
+describe('--slug flag parsing', () => {
+  test('--slug with no value (next-arg empty) exits 3', () => {
+    const binary = makeBinary();
+    const code = runVerify([binary, '--slug', '']);
+    expect(code).toBe(3);
+    expect(stderrBuf.join('')).toMatch(/--slug requires a non-empty value/);
+  });
+
+  test('--slug with whitespace-only value exits 3', () => {
+    const binary = makeBinary();
+    const code = runVerify([binary, '--slug', '   ']);
+    expect(code).toBe(3);
+  });
+
+  test('--port with non-integer exits 3', () => {
+    const binary = makeBinary();
+    const code = runVerify([binary, '--port', 'abc']);
+    expect(code).toBe(3);
+  });
+
+  test('--port out of range exits 3', () => {
+    const binary = makeBinary();
+    const code = runVerify([binary, '--port', '70000']);
+    expect(code).toBe(3);
+  });
+});
+
+describe('--slug error mapping', () => {
+  test('EAUTOPGSLUGUNKNOWN -> exit 3 with structured stderr', () => {
+    const binary = makeBinary();
+    const stub = () => {
+      const err = new Error('no autopg_meta row for slug "demo"');
+      err.code = 'EAUTOPGSLUGUNKNOWN';
+      throw err;
+    };
+    const code = runVerify(
+      [binary, '--slug', 'demo', '--no-cache'],
+      { loadLockedRoots: stub },
+    );
+    expect(code).toBe(3);
+    const stderr = stderrBuf.join('');
+    expect(stderr).toMatch(/slug-lookup-failed/);
+    expect(stderr).toMatch(/no autopg_meta row for slug "demo"/);
+  });
+
+  test('EAUTOPGMETAMISSING -> exit 3 (table not bootstrapped)', () => {
+    const binary = makeBinary();
+    const stub = () => {
+      const err = new Error('autopg_meta does not exist');
+      err.code = 'EAUTOPGMETAMISSING';
+      throw err;
+    };
+    const code = runVerify(
+      [binary, '--slug', 'demo', '--no-cache'],
+      { loadLockedRoots: stub },
+    );
+    expect(code).toBe(3);
+  });
+
+  test('EAUTOPGLOCKEDPARSE -> exit 3 (malformed JSONB)', () => {
+    const binary = makeBinary();
+    const stub = () => {
+      const err = new Error('locked_roots is malformed');
+      err.code = 'EAUTOPGLOCKEDPARSE';
+      throw err;
+    };
+    const code = runVerify(
+      [binary, '--slug', 'demo', '--no-cache'],
+      { loadLockedRoots: stub },
+    );
+    expect(code).toBe(3);
+  });
+
+  test('unknown loader exception -> exit 3 (postgres unreachable, etc.)', () => {
+    const binary = makeBinary();
+    const stub = () => {
+      throw new Error('connection refused');
+    };
+    const code = runVerify(
+      [binary, '--slug', 'demo', '--no-cache'],
+      { loadLockedRoots: stub },
+    );
+    expect(code).toBe(3);
+  });
+
+  test('--json mode emits JSON error payload to stdout (not stderr)', () => {
+    const binary = makeBinary();
+    const stub = () => {
+      const err = new Error('not found');
+      err.code = 'EAUTOPGSLUGUNKNOWN';
+      throw err;
+    };
+    const code = runVerify(
+      [binary, '--slug', 'demo', '--no-cache', '--json'],
+      { loadLockedRoots: stub },
+    );
+    expect(code).toBe(3);
+    const out = stdoutBuf.join('');
+    const parsed = JSON.parse(out);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.reason).toBe('slug-lookup-failed');
+    expect(parsed.slug).toBe('demo');
+    expect(parsed.loaderCode).toBe('EAUTOPGSLUGUNKNOWN');
+  });
+});
+
+describe('--slug omitted', () => {
+  test('does not call the loader (live TRUSTED_IDENTITIES path)', () => {
+    const binary = makeBinary();
+    let loaderCalled = false;
+    const stub = () => {
+      loaderCalled = true;
+      return { lockedRoots: [] };
+    };
+    // We pass --no-cache + an absent cosign to make verifyBinary fail fast
+    // without a real cosign on PATH. The point of this test is that the
+    // loader is not invoked when --slug is absent — exit code semantics
+    // are verifyBinary's territory and covered by tests/cli/verify.test.js.
+    runVerify([binary, '--no-cache'], { loadLockedRoots: stub });
+    expect(loaderCalled).toBe(false);
+  });
+});

--- a/tests/cosign/manifest-lock.test.js
+++ b/tests/cosign/manifest-lock.test.js
@@ -1,0 +1,41 @@
+/**
+ * Tests for the locked-roots loader (G3 D4a — autopg-distribution-cutover-finalize).
+ *
+ * The loader's happy path is a psql shellout, exercised by the integration
+ * test at tests/integration/verify-slug-rotation.test.sh. The unit tests
+ * here cover the input-validation branches that DON'T need postgres —
+ * empty slug, all-symbol slug, the structured error shape callers rely
+ * on for exit-code mapping.
+ */
+
+import { test, expect, describe } from 'bun:test';
+import { loadLockedRoots } from '../../src/cosign/locked-roots.js';
+
+describe('loadLockedRoots — pre-postgres validation', () => {
+  test('throws TypeError on empty slug', () => {
+    expect(() => loadLockedRoots({ slug: '' })).toThrow(TypeError);
+    expect(() => loadLockedRoots({ slug: '   ' })).toThrow(TypeError);
+  });
+
+  test('throws TypeError on missing slug', () => {
+    expect(() => loadLockedRoots({})).toThrow(TypeError);
+    expect(() => loadLockedRoots()).toThrow(TypeError);
+  });
+
+  test('throws TypeError on non-string slug', () => {
+    expect(() => loadLockedRoots({ slug: 123 })).toThrow(TypeError);
+    expect(() => loadLockedRoots({ slug: null })).toThrow(TypeError);
+  });
+
+  test('throws structured error with code EAUTOPGSLUGUNKNOWN on all-symbol slug', () => {
+    let caught;
+    try {
+      loadLockedRoots({ slug: '!!!' });
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeDefined();
+    expect(caught.code).toBe('EAUTOPGSLUGUNKNOWN');
+    expect(caught.message).toMatch(/sanitizes to empty/);
+  });
+});

--- a/tests/integration/verify-slug-rotation.test.sh
+++ b/tests/integration/verify-slug-rotation.test.sh
@@ -1,0 +1,302 @@
+#!/usr/bin/env bash
+#
+# verify-slug-rotation.test.sh — round-trip integration smoke for
+# `pgserve create-app` + `pgserve verify --slug` (G3 D5,
+# autopg-distribution-cutover-finalize).
+#
+# Exercises the lock-vs-live trust differential that is the WHOLE point
+# of the manifest LOCK 1 design:
+#
+#   1) start an ephemeral postgres on a high port
+#   2) `pgserve create-app demo --port $PORT` — registers slug; freezes
+#      whatever TRUSTED_IDENTITIES is live at this moment into
+#      autopg_meta.locked_roots
+#   3) Direct UPDATE to autopg_meta.locked_roots — replaces the freshly
+#      frozen list with a SYNTHETIC identity ("FROZEN-LOCK"). This is
+#      our test's stand-in for "operator-driven trust rotation has
+#      since happened to live TRUSTED_IDENTITIES, and the slug's lock
+#      is now divergent from live". The frozen lock is what verify
+#      --slug should consult.
+#   4) Stub cosign on PATH succeeds ONLY when the identity-regex passed
+#      is `^FROZEN-LOCK$` AND the binary's first bytes are `FROZEN-LOCK`.
+#      Anything else: exit non-zero. This makes the test discriminate
+#      between "verify consulted the lock" and "verify consulted live
+#      TRUSTED_IDENTITIES" by the cosign call's identity-regex argv.
+#   5) Run THREE verify scenarios:
+#        a) FROZEN-LOCK binary + --slug demo  → exit 0 (lock matched)
+#        b) LIVE-IDENTITY binary + --slug demo → exit 2 (lock rejects)
+#        c) any binary + --slug nonexistent_slug → exit 3 (invocation —
+#           slug not registered; never reaches cosign)
+#   6) Assert autopg_meta has exactly 1 row for the slug + that
+#      idempotent re-run preserved locked_roots ("FROZEN-LOCK" stays;
+#      live TRUSTED_IDENTITIES does NOT clobber the frozen lock).
+#
+# Together those five steps cover BRIEF v5 acceptance criterion #5
+# (upgrade-after-trust-rotation against the frozen lock).
+#
+# Skips gracefully on hosts without postgres binaries on PATH so it can
+# be wired into the CI matrix as an optional / non-blocking job until
+# the GHA cache for embedded-postgres is warm.
+#
+# Exit codes:
+#   0  pass (or skipped because postgres binaries are missing)
+#   1  fail (assertion missed)
+#   2  invalid setup (binaries present but fixture broken)
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+PORT="${VERIFY_SLUG_TEST_PORT:-65433}"
+
+PASS=0
+FAIL=0
+
+ok()   { printf '    \xe2\x9c\x93 %s\n' "$*";          PASS=$((PASS + 1)); }
+bad()  { printf '    \xe2\x9c\x97 %s\n' "$*" >&2;      FAIL=$((FAIL + 1)); }
+note() { printf '    \xe2\x80\xa2 %s\n' "$*" >&2; }
+
+require_postgres() {
+  for bin in initdb pg_ctl psql; do
+    if ! command -v "$bin" >/dev/null 2>&1; then
+      note "$bin not on PATH — skipping (suite needs a postgres install)"
+      exit 0
+    fi
+  done
+}
+
+WORK_DIR=""
+PG_DATA=""
+PG_LOG=""
+SOCKET_DIR=""
+FAKE_HOME=""
+STUB_DIR=""
+PG_RUNNING=0
+
+# Bootstrap-password contract — see gc-provision.test.sh for the
+# rationale (CV-1 + the env-set-always shellout invariant from
+# src/lib/pg-query.js).
+export PGPASSWORD="${PGPASSWORD:-postgres}"
+
+cleanup() {
+  if [[ "$PG_RUNNING" -eq 1 && -n "$PG_DATA" ]]; then
+    pg_ctl -D "$PG_DATA" stop -m immediate -s >/dev/null 2>&1 || true
+  fi
+  if [[ "${KEEP_VERIFY_SLUG_TEST_DIR:-0}" -eq 1 ]]; then
+    note "KEEP_VERIFY_SLUG_TEST_DIR=1 — keeping $WORK_DIR"
+    return
+  fi
+  if [[ -n "$WORK_DIR" && -d "$WORK_DIR" ]]; then
+    rm -rf "$WORK_DIR"
+  fi
+}
+trap cleanup EXIT
+
+setup() {
+  require_postgres
+  WORK_DIR="$(mktemp -d -t pgserve-verify-slug-XXXXXX)"
+  PG_DATA="${WORK_DIR}/data"
+  PG_LOG="${WORK_DIR}/postgres.log"
+  SOCKET_DIR="${WORK_DIR}/socket"
+  FAKE_HOME="${WORK_DIR}/home"
+  STUB_DIR="${WORK_DIR}/stub-cosign"
+
+  mkdir -p "$SOCKET_DIR" "$FAKE_HOME" "$STUB_DIR"
+
+  # initdb — see gc-provision.test.sh for the `-U postgres` rationale.
+  initdb -D "$PG_DATA" -U postgres --auth-local=trust --auth-host=trust -E UTF8 -A trust >/dev/null 2>&1 \
+    || { echo "initdb failed; check $PG_LOG" >&2; exit 2; }
+
+  cat >>"${PG_DATA}/postgresql.conf" <<EOF
+listen_addresses = '127.0.0.1'
+unix_socket_directories = '${SOCKET_DIR}'
+fsync = off
+synchronous_commit = off
+shared_buffers = 32MB
+EOF
+
+  pg_ctl -D "$PG_DATA" -l "$PG_LOG" -o "-p ${PORT}" -w start >/dev/null 2>&1 \
+    || { echo "pg_ctl start failed; check $PG_LOG" >&2; exit 2; }
+  PG_RUNNING=1
+
+  psql -h "$SOCKET_DIR" -p "$PORT" -U postgres -d postgres -c "SELECT 1" >/dev/null \
+    || { echo "psql connect failed" >&2; exit 2; }
+  ok "postgres up on port ${PORT} (data: ${PG_DATA})"
+}
+
+stage_stub_cosign() {
+  local node_path
+  node_path="$(command -v node)"
+  if [[ -z "$node_path" ]]; then
+    note "node not on PATH — cannot stage stub cosign"
+    exit 2
+  fi
+
+  cat >"${STUB_DIR}/cosign" <<COSIGN
+#!${node_path}
+const fs = require('node:fs');
+const args = process.argv.slice(2);
+// Log every cosign call for assertion replay if needed.
+const callLog = ${STUB_DIR@Q} + '/calls.log';
+fs.appendFileSync(callLog, JSON.stringify(args) + '\\n');
+if (args[0] !== 'verify-blob') process.exit(2);
+
+// Find --certificate-identity-regexp value + the trailing binary path.
+let regex = null;
+for (let i = 0; i < args.length; i++) {
+  if (args[i] === '--certificate-identity-regexp') regex = args[i + 1];
+}
+const binaryPath = args[args.length - 1];
+
+let body;
+try { body = fs.readFileSync(binaryPath, 'utf8'); } catch { process.exit(3); }
+
+// Test contract: the stub accepts ONLY when the identity-regex equals
+// the literal '^FROZEN-LOCK\$' AND the binary's first bytes are
+// 'FROZEN-LOCK'. Any other identity-regex (live TRUSTED_IDENTITIES
+// patterns) or any other binary content: reject.
+if (regex === '^FROZEN-LOCK\$' && body.startsWith('FROZEN-LOCK')) {
+  process.stdout.write('Verified OK\\n');
+  process.exit(0);
+}
+process.stderr.write('cosign-stub: rejected (regex=' + regex + ')\\n');
+process.exit(1);
+COSIGN
+  chmod +x "${STUB_DIR}/cosign"
+  ok "stub cosign staged at ${STUB_DIR}/cosign"
+}
+
+# Run a pgserve verb against the worktree's bin/, with HOME + PGHOST
+# redirected and the stub cosign prepended onto PATH.
+pgserve_run() {
+  HOME="$FAKE_HOME" \
+  PGHOST="$SOCKET_DIR" \
+  PATH="${STUB_DIR}:${PATH}" \
+    node "${REPO_ROOT}/bin/pgserve-wrapper.cjs" "$@"
+}
+
+run_create_app() {
+  pgserve_run create-app demo --port "$PORT" --json >"${WORK_DIR}/create-1.json" 2>"${WORK_DIR}/create-1.err" \
+    || { bad "create-app demo failed"; cat "${WORK_DIR}/create-1.err" >&2; return 1; }
+  ok "create-app demo succeeded (locked live TRUSTED_IDENTITIES)"
+
+  local row_count
+  row_count="$(psql -h "$SOCKET_DIR" -p "$PORT" -U postgres -d postgres -At -c \
+    "SELECT COUNT(*) FROM public.autopg_meta WHERE slug = 'demo'" 2>/dev/null || echo 0)"
+  if [[ "$row_count" != "1" ]]; then
+    bad "expected exactly 1 autopg_meta row for slug 'demo', got ${row_count}"
+    return 1
+  fi
+  ok "autopg_meta row exists for slug 'demo'"
+}
+
+mutate_locked_roots_to_synthetic() {
+  # Replace whatever was just frozen with a synthetic single-entry
+  # locked_roots that ONLY accepts the FROZEN-LOCK identity pattern.
+  # This is the test's stand-in for "operator rotated live
+  # TRUSTED_IDENTITIES; the slug's lock is now divergent". When verify
+  # --slug demo loads locked_roots, it gets THIS list, not live.
+  psql -h "$SOCKET_DIR" -p "$PORT" -U postgres -d postgres -c \
+    "UPDATE public.autopg_meta SET locked_roots = '[{\"id\":\"frozen-test\",\"publisher\":\"@test/frozen\",\"issuer\":\"https://token.actions.githubusercontent.com\",\"identityRegexp\":\"^FROZEN-LOCK\$\",\"description\":\"test\"}]'::jsonb WHERE slug = 'demo'" \
+    >/dev/null 2>&1 \
+    || { bad "failed to mutate autopg_meta.locked_roots"; return 1; }
+  ok "autopg_meta.locked_roots mutated to synthetic FROZEN-LOCK identity"
+}
+
+run_verify_frozen_lock_match() {
+  local binary="${WORK_DIR}/frozen-binary"
+  printf 'FROZEN-LOCK\nELF...' >"$binary"
+  printf '{"fake":"bundle"}' >"${binary}.bundle"
+
+  local rc=0
+  pgserve_run verify "$binary" --slug demo --port "$PORT" --no-cache --json \
+    >"${WORK_DIR}/verify-frozen.out" 2>"${WORK_DIR}/verify-frozen.err" \
+    || rc=$?
+  if [[ "$rc" -ne 0 ]]; then
+    bad "verify --slug demo against FROZEN-LOCK binary failed (rc=${rc})"
+    cat "${WORK_DIR}/verify-frozen.out" >&2
+    cat "${WORK_DIR}/verify-frozen.err" >&2
+    return 1
+  fi
+  ok "verify <FROZEN-LOCK binary> --slug demo exits 0 (matched the lock)"
+}
+
+run_verify_lock_rejects_live_identity() {
+  # Body deliberately starts with a string that is NOT 'FROZEN-LOCK',
+  # so the stub cosign would reject it under the FROZEN-LOCK identity-
+  # regex (which is what `--slug demo` selects). If the verify path
+  # incorrectly fell through to live TRUSTED_IDENTITIES, the stub
+  # would also reject (wrong identity-regex), so this assertion is
+  # robust either way.
+  local binary="${WORK_DIR}/live-binary"
+  printf 'LIVE-IDENTITY\nELF...' >"$binary"
+  printf '{"fake":"bundle"}' >"${binary}.bundle"
+
+  local rc=0
+  pgserve_run verify "$binary" --slug demo --port "$PORT" --no-cache --json \
+    >"${WORK_DIR}/verify-live.out" 2>"${WORK_DIR}/verify-live.err" \
+    || rc=$?
+  # Expect non-zero — verify rejection. Acceptance criterion #3 says
+  # "exits non-zero" so any rc >= 2 is acceptable. We assert >=2 to
+  # exclude exit-1 (which would be a bug — exit-1 is reserved for
+  # user-flag errors that never reach verify).
+  if [[ "$rc" -lt 2 ]]; then
+    bad "verify --slug demo against LIVE-IDENTITY binary should reject; got rc=${rc}"
+    cat "${WORK_DIR}/verify-live.out" >&2
+    cat "${WORK_DIR}/verify-live.err" >&2
+    return 1
+  fi
+  ok "verify <LIVE-IDENTITY binary> --slug demo exits ${rc} (>=2, lock rejected)"
+}
+
+run_verify_unknown_slug_exit_three() {
+  local binary="${WORK_DIR}/frozen-binary"
+  # Same FROZEN-LOCK binary — slug-unknown should fail BEFORE cosign is
+  # even invoked, regardless of the binary content.
+  local rc=0
+  pgserve_run verify "$binary" --slug nonexistent_slug --port "$PORT" --no-cache --json \
+    >"${WORK_DIR}/verify-unknown.out" 2>"${WORK_DIR}/verify-unknown.err" \
+    || rc=$?
+  if [[ "$rc" -ne 3 ]]; then
+    bad "verify --slug nonexistent_slug should exit 3 (invocation); got rc=${rc}"
+    cat "${WORK_DIR}/verify-unknown.out" >&2
+    cat "${WORK_DIR}/verify-unknown.err" >&2
+    return 1
+  fi
+  ok "verify <binary> --slug nonexistent_slug exits 3 (invocation; loader rejected)"
+}
+
+run_idempotent_create_app_preserves_lock() {
+  # Re-run create-app demo — must NOT clobber the synthetic locked_roots
+  # we placed earlier. Acceptance criterion #1 says the second run only
+  # touches last_updated.
+  pgserve_run create-app demo --port "$PORT" --json >"${WORK_DIR}/create-2.json" 2>"${WORK_DIR}/create-2.err" \
+    || { bad "second create-app demo failed"; cat "${WORK_DIR}/create-2.err" >&2; return 1; }
+  ok "second create-app demo succeeded (idempotent)"
+
+  local lock_id
+  lock_id="$(psql -h "$SOCKET_DIR" -p "$PORT" -U postgres -d postgres -At -c \
+    "SELECT locked_roots->0->>'id' FROM public.autopg_meta WHERE slug = 'demo'" 2>/dev/null || echo '')"
+  if [[ "$lock_id" != "frozen-test" ]]; then
+    bad "idempotent re-run clobbered locked_roots; expected id='frozen-test', got '${lock_id}'"
+    return 1
+  fi
+  ok "idempotent re-run preserved locked_roots (id='frozen-test')"
+}
+
+main() {
+  setup
+  stage_stub_cosign
+  run_create_app
+  mutate_locked_roots_to_synthetic
+  run_verify_frozen_lock_match
+  run_verify_lock_rejects_live_identity
+  run_verify_unknown_slug_exit_three
+  run_idempotent_create_app_preserves_lock
+
+  printf '\n  PASS: %d   FAIL: %d\n' "$PASS" "$FAIL"
+  if [[ "$FAIL" -gt 0 ]]; then
+    return 1
+  fi
+}
+
+main "$@"

--- a/tests/schema/autopg-meta.test.js
+++ b/tests/schema/autopg-meta.test.js
@@ -1,0 +1,155 @@
+/**
+ * Tests for the `autopg_meta` table bootstrap (G3 of
+ * `autopg-distribution-cutover-finalize`).
+ *
+ * Pure-shape tests against a fake client. The end-to-end "does the
+ * table actually get created" assertion lives in the create-app
+ * integration test alongside the verb itself.
+ */
+
+import { test, expect, describe } from 'bun:test';
+import {
+  AUTOPG_META_TABLE,
+  AUTOPG_META_COLUMNS,
+  getBootstrapStatements,
+  getBootstrapSQL,
+  bootstrapAutopgMeta,
+  tableExistsFromRegclass,
+} from '../../src/schema/autopg-meta.js';
+
+describe('exports', () => {
+  test('AUTOPG_META_TABLE is the canonical table name', () => {
+    expect(AUTOPG_META_TABLE).toBe('autopg_meta');
+  });
+
+  test('AUTOPG_META_COLUMNS lists the owned columns and is frozen', () => {
+    expect(Object.isFrozen(AUTOPG_META_COLUMNS)).toBe(true);
+    expect(AUTOPG_META_COLUMNS).toContain('slug');
+    expect(AUTOPG_META_COLUMNS).toContain('manifest_path');
+    expect(AUTOPG_META_COLUMNS).toContain('locked_roots');
+    expect(AUTOPG_META_COLUMNS).toContain('created_at');
+    expect(AUTOPG_META_COLUMNS).toContain('last_updated');
+    // pgserve_meta columns belong to a different table; never overlap.
+    expect(AUTOPG_META_COLUMNS).not.toContain('fingerprint');
+    expect(AUTOPG_META_COLUMNS).not.toContain('database_name');
+  });
+});
+
+describe('getBootstrapStatements', () => {
+  test('returns an array of idempotent statements', () => {
+    const statements = getBootstrapStatements();
+    expect(Array.isArray(statements)).toBe(true);
+    expect(statements.length).toBeGreaterThanOrEqual(2); // table + at least 1 index
+    for (const sql of statements) {
+      expect(typeof sql).toBe('string');
+      expect(sql.length).toBeGreaterThan(0);
+    }
+  });
+
+  test('first statement creates the table with IF NOT EXISTS', () => {
+    const [createTable] = getBootstrapStatements();
+    expect(createTable).toMatch(/CREATE TABLE IF NOT EXISTS public\.autopg_meta/);
+  });
+
+  test('table + indexes are schema-qualified to public', () => {
+    const sql = getBootstrapStatements().join(';');
+    expect(sql).toContain('public.autopg_meta');
+    expect(sql).not.toMatch(/CREATE TABLE IF NOT EXISTS autopg_meta(?!\w)/);
+    expect(sql).not.toMatch(/ON autopg_meta(?!\w)/);
+  });
+
+  test('table SQL declares the expected primary key + types', () => {
+    const [createTable] = getBootstrapStatements();
+    expect(createTable).toMatch(/slug\s+TEXT\s+PRIMARY KEY/);
+    expect(createTable).toMatch(/manifest_path\s+TEXT\s+NOT NULL/);
+    expect(createTable).toMatch(/locked_roots\s+JSONB\s+NOT NULL/);
+    expect(createTable).toMatch(/created_at\s+TIMESTAMPTZ\s+NOT NULL DEFAULT now\(\)/);
+    expect(createTable).toMatch(/last_updated\s+TIMESTAMPTZ\s+NOT NULL DEFAULT now\(\)/);
+  });
+
+  test('every index uses CREATE INDEX IF NOT EXISTS for idempotency', () => {
+    const indexStatements = getBootstrapStatements().slice(1);
+    expect(indexStatements.length).toBeGreaterThan(0);
+    for (const sql of indexStatements) {
+      expect(sql).toMatch(/CREATE INDEX IF NOT EXISTS/);
+    }
+  });
+
+  test('last_updated index exists (doctor + audit can sort by recency)', () => {
+    const sql = getBootstrapStatements().join(';');
+    expect(sql).toContain('autopg_meta_last_updated_idx');
+    expect(sql).toContain('(last_updated)');
+  });
+});
+
+describe('getBootstrapSQL', () => {
+  test('joins statements with semicolons + newlines and ends with ";\\n"', () => {
+    const sql = getBootstrapSQL();
+    expect(sql.endsWith(';\n')).toBe(true);
+    expect(sql).toContain(';\n\n');
+  });
+});
+
+describe('bootstrapAutopgMeta', () => {
+  function fakeClient() {
+    const calls = [];
+    return {
+      calls,
+      query: async (sql) => {
+        calls.push(sql);
+        return { rows: [], rowCount: 0 };
+      },
+    };
+  }
+
+  test('runs every statement on the supplied client in order', async () => {
+    const client = fakeClient();
+    const ran = await bootstrapAutopgMeta(client);
+    expect(ran).toEqual(getBootstrapStatements());
+    expect(client.calls).toEqual(getBootstrapStatements());
+  });
+
+  test('rejects clients that do not expose an async query()', async () => {
+    let caught;
+    try {
+      await bootstrapAutopgMeta(null);
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(TypeError);
+
+    let caught2;
+    try {
+      await bootstrapAutopgMeta({ query: 'not-a-function' });
+    } catch (err) {
+      caught2 = err;
+    }
+    expect(caught2).toBeInstanceOf(TypeError);
+  });
+
+  test('propagates client.query errors (no swallowing)', async () => {
+    const client = {
+      query: async () => {
+        throw new Error('boom');
+      },
+    };
+    let caught;
+    try {
+      await bootstrapAutopgMeta(client);
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeDefined();
+    expect(caught.message).toBe('boom');
+  });
+});
+
+describe('tableExistsFromRegclass', () => {
+  test('true only when the regclass query returned literal true', () => {
+    expect(tableExistsFromRegclass(true)).toBe(true);
+    expect(tableExistsFromRegclass(false)).toBe(false);
+    expect(tableExistsFromRegclass(null)).toBe(false);
+    expect(tableExistsFromRegclass(undefined)).toBe(false);
+    expect(tableExistsFromRegclass('t')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Group 3 of `autopg-distribution-cutover-finalize`: `pgserve create-app <slug>` registers a consumer + freezes the current `TRUSTED_IDENTITIES` snapshot into `autopg_meta.locked_roots` at create time, and `pgserve verify --slug <slug>` runs cosign verification against THAT frozen snapshot (not live `TRUSTED_IDENTITIES`). The lock-vs-live differential is what keeps existing consumers verifiable after operator-driven trust rotation.

Re-anchors after the dead `wave2-g3` ephemeral team. Fresh worktree off `origin/main` (commit 6594a2c, v2.6.1). Five commits, one per deliverable per BRIEF v5 + ORCHESTRATOR-RX deliverable order.

## Acceptance criteria (from WISH L142–L147)

- [x] `pgserve create-app <slug>` idempotent (second run touches `last_updated` only) — D3 implementation, asserted in D5 integration test.
- [x] Manifest file mode 0600; dir mode 0700 — D2 enforced via `fs.chmodSync` after atomic tmp+rename.
- [x] `pgserve verify <binary> --slug <slug>` against binary signed by identity NOT in locked roots → exits non-zero with clear error — D4b binding via `verifyBinary({ trustList: lockedRoots })`; D5 asserts exit ≥ 2.
- [x] `pgserve verify <binary> --slug <slug>` against binary signed by identity IN locked roots → exits 0 — D4b path; D5 asserts exit 0.
- [x] Integration test covers upgrade-after-trust-rotation: rotate `TRUSTED_IDENTITIES`, then verify against frozen lock STILL exits 0 — D5 simulates rotation by direct UPDATE of `autopg_meta.locked_roots` to a synthetic identity, then runs `pgserve verify --slug demo` and asserts exit 0 against the frozen lock.

## Spec resolutions threaded through (from BRIEF v5 + ORCHESTRATOR-RX)

| Question | Resolution | Where threaded |
|----------|------------|----------------|
| Q1 — pg connection sourcing | `readAdminJson` for port + `pgQuery` shellout (mirrors provision/gc) | `src/commands/create-app.js#resolvePort` + `src/cosign/locked-roots.js` |
| Q2 — autopg_meta bootstrap timing | `bootstrapAutopgMeta` first (idempotent IF NOT EXISTS), then INSERT/UPDATE | `src/commands/create-app.js#ensureAutopgMetaSchema` |
| Q3 — `verify --slug <unknown>` exit-code split | exit-3 for invocation problems (slug-not-registered, table-missing, malformed-JSONB); exit-2 for verify rejection (binary not in lock) | `src/cosign/locked-roots.js` (3 structured codes) → `src/commands/verify.js` (slug-lookup-failed → EXIT_INVOCATION) |
| Q5 — single dispatcher for `pgserve create-app` AND `autopg create-app` | Allowlist edit in `bin/pgserve-wrapper.cjs` only; `bin/autopg-wrapper.cjs` already delegates | Verified by smoke test + D5 integration runs |
| A2 — manifest path location | `~/.autopg/<slug>/manifest.json` (sibling of admin.json, same 0700 dir) | `src/admin/admin-bootstrap.js` |
| A4 — autopg_meta columns | `slug TEXT PK, manifest_path TEXT NOT NULL, locked_roots JSONB NOT NULL, created_at + last_updated TIMESTAMPTZ NOT NULL DEFAULT now()` + `last_updated` index | `src/schema/autopg-meta.js` |
| A6 — lock preservation on idempotent re-run | Re-run touches `last_updated` ONLY; `locked_roots` from first-create is preserved | `src/commands/create-app.js` (existing-row branch passes `existing.lockedRoots` back through, never re-snapshots `TRUSTED_IDENTITIES`); D5 asserts the synthetic id stays after second run |

## Wrapper allowlist trap (BRIEF v3 catch)

`'create-app'` added to the `__installSubcommands` Set in `bin/pgserve-wrapper.cjs:32-69` (sibling of `verify` / `doctor` / `trust` / `gc` / `provision` — all pure-node verbs that must skip the bun probe). Without this entry the verb falls through to the bun probe — wrong, because create-app is pure-node + child_process (psql shellout + filesystem writes). `bin/autopg-wrapper.cjs` is a 16-line delegator to `pgserve-wrapper.cjs` per Decision #7, so the allowlist edit is needed in ONE place only and BOTH `pgserve create-app` and `autopg create-app` work via the same dispatcher (smoke-tested both paths).

## Source-of-truth split + cache-recovery story (V1 read-only)

- `public.autopg_meta` is authoritative.
- The per-consumer `admin.json` + `manifest.json` are derived caches.
- Cache-recovery in v2.4 (read-only doctor): operator deletes the per-consumer dir + re-runs `pgserve create-app <slug>` to regenerate. The verb is idempotent and preserves `locked_roots` from the table on re-run, so the cache files end up identical to whatever was on the row.
- `pgserve doctor --fix` mutation modes (the originally proposed regenerator) are NOT implemented in v2.4 per `src/commands/doctor.js:440-442` and remain deferred to a future wave.

## TOCTOU defense

`src/admin/admin-bootstrap.js` resolves the consumer directory through `fs.realpathSync` after mkdir and asserts containment inside the canonical autopg config root. A symlink that escapes the root → `EAUTOPGCONSUMERESCAPE` error, no write. Verified via `fs.symlinkSync` to a foreign tmp dir in `tests/admin/admin-bootstrap.test.js`.

## Files changed

| File | Change | LOC |
|------|--------|-----|
| `src/schema/autopg-meta.js` | new (D1) | 121 |
| `src/admin/admin-bootstrap.js` | new (D2) | 268 |
| `src/commands/create-app.js` | new (D3) | 384 |
| `src/cosign/locked-roots.js` | new (D4a) | 142 |
| `src/commands/verify.js` | extended (D4b — `--slug` + `--port` + DI seam) | +60 / -4 |
| `bin/pgserve-wrapper.cjs` | extended (allowlist) | +13 |
| `src/cli-install.cjs` | extended (dispatch case) | +7 |
| `tests/schema/autopg-meta.test.js` | new (D1 — 13 tests) | 154 |
| `tests/admin/admin-bootstrap.test.js` | new (D2 — 19 tests, incl. symlink-escape) | 274 |
| `tests/cli/create-app.test.js` | new (D3 — 16 tests) | 119 |
| `tests/cosign/manifest-lock.test.js` | new (D4a — 4 tests) | 41 |
| `tests/cli/verify-slug.test.js` | new (D4b — 10 tests) | 173 |
| `tests/integration/verify-slug-rotation.test.sh` | new (D5 — round-trip) | 263 |
| `.github/workflows/ci.yml` | new CI job (D5 wiring) | +30 |

Total: ~1,950 LOC including tests + integration scaffold (slightly over the BRIEF's ~660 estimate; the extra is the test bench D5 + wiring + the symlink-escape coverage).

## Validation

```
$ bun test --timeout 30000
 637 pass / 3 skip / 0 fail / 1860 expect() calls / 48 files / 30.62s

$ bun run lint
$ eslint src/ bin/    # clean

$ bun run deadcode
$ knip                # clean (only existing config hints — unchanged)

$ bash tests/integration/verify-slug-rotation.test.sh
    • initdb not on PATH — skipping (suite needs a postgres install)
    # On CI hosts with postgres, the script asserts:
    #   ✓ create-app demo succeeded (locked live TRUSTED_IDENTITIES)
    #   ✓ autopg_meta row exists for slug 'demo'
    #   ✓ autopg_meta.locked_roots mutated to synthetic FROZEN-LOCK identity
    #   ✓ verify <FROZEN-LOCK binary> --slug demo exits 0 (matched the lock)
    #   ✓ verify <LIVE-IDENTITY binary> --slug demo exits ≥2 (lock rejected)
    #   ✓ verify <binary> --slug nonexistent_slug exits 3 (loader rejected)
    #   ✓ idempotent re-run preserved locked_roots (id='frozen-test')
```

## Test plan

- [ ] CI matrix passes — including the new `test-integration-verify-slug-rotation` continue-on-error job
- [ ] QA dogfood per BRIEF v5 acceptance criteria
- [ ] Bot reviewer triage (coderabbit / gemini / codex)
- [ ] Felipe merge once dogfood + reviews are clean

## Historical context

This PR replaces the dead `wave2-g3` ephemeral team's branch (full deliverable plan in `/home/genie/.genie/worktrees/pgserve/wave2-g3/ACK-wave2-g3.md` + `ORCHESTRATOR-RX.md`). After auto-resume:off + `genie done` + tmux pane-died killed the team-leader mid-flight, Felipe greenlit Option 3: engineer takes G3 directly. Fresh worktree off `origin/main` (not the stale wave2-g3 branch) per BRIEF guidance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)