### PR TITLE
fix(cli-install): drop process.exit(1) to fix CV103-2 stdio-pipe exit-code race (v2.6.2)

### DIFF
--- a/bin/pgserve-wrapper.cjs
+++ b/bin/pgserve-wrapper.cjs
@@ -88,8 +88,24 @@ if (__subcommand && __installSubcommands.has(__subcommand)) {
     result.then(
       (code) => process.exit(typeof code === 'number' ? code : 0),
       (err) => {
-        process.stderr.write(`pgserve: ${err?.message ?? err}\n`);
-        process.exit(1);
+        // CV103-2 (v2.6.2): the cli-install.cjs EADDRINUSE catch handler
+        // already wrote the message to stderr AND set process.exitCode = 1
+        // before throwing. If we ALSO write here we'd double-print, AND
+        // if we call process.exit(1) we re-introduce the stdio-pipe race
+        // the catch handler avoided by switching to exitCode + throw.
+        //
+        // Suppress the duplicate stderr write for already-handled error
+        // codes. Don't call process.exit() — Node will exit naturally
+        // once the event loop drains, using process.exitCode (which the
+        // throwing handler already set) so stderr flushes cleanly even
+        // under the piped-stdout / inherited-stderr shape that exposed
+        // the race (qa repro R6: `pgserve install | cat`).
+        if (err && err.code !== 'EADDRINUSE') {
+          process.stderr.write(`pgserve: ${err?.message ?? err}\n`);
+        }
+        if (process.exitCode === undefined || process.exitCode === 0) {
+          process.exitCode = 1;
+        }
       },
     );
     return;

--- a/src/cli-install.cjs
+++ b/src/cli-install.cjs
@@ -872,20 +872,24 @@ async function cmdInstall(args, ctx) {
   } catch (err) {
     if (err.code === 'EADDRINUSE') {
       process.stderr.write(`${err.message}\n`);
-      // Belt-and-suspenders for the QA loop-2/2 finding: in QA's test
-      // environment, the synchronous `process.exit(1)` path was
-      // observed to NOT terminate the process before the install
-      // function continued + resolved the wrapper's promise with
-      // undefined, which the wrapper then mapped to `process.exit(0)`.
-      // Three guarantees here:
-      //   1. process.exitCode = 1  → default exit code becomes 1 even
-      //      if explicit exit is somehow trapped/delayed
-      //   2. process.exit(1)       → force termination (preferred path)
-      //   3. throw err             → if exit is delayed, the async
-      //      function rejects, wrapper's rejection handler does its
-      //      own process.exit(1), guaranteeing non-zero exit
+      // CV103-2 (v2.6.2): drop the synchronous `process.exit(1)` here.
+      // QA's 9-variant repro on v2.6.1 isolated a stdio-pipe race:
+      // when stdout is piped (e.g. `pgserve install | cat`) but
+      // stderr is inherited, `process.exit(1)` runs Node's shutdown
+      // sequence faster than the libuv stderr buffer can flush, and
+      // Node has been observed to terminate with exit code 0 instead
+      // of 1. Node's own docs flag this:
+      //
+      //   process.exit() will force the process to exit as quickly as
+      //   possible … including I/O operations to process.stdout and
+      //   process.stderr.
+      //   (https://nodejs.org/api/process.html#processexitcode_1)
+      //
+      // Recommended pattern: set process.exitCode and let Node exit
+      // gracefully on its own once the event loop drains. We also
+      // throw so the wrapper's rejection handler can suppress its
+      // duplicate stderr write — see bin/pgserve-wrapper.cjs.
       process.exitCode = 1;
-      process.exit(1);
       throw err;
     }
     throw err;

--- a/tests/cli-install.test.js
+++ b/tests/cli-install.test.js
@@ -392,6 +392,63 @@ describe('pgserve install port pre-flight (B3 v2.6.1)', () => {
     }
   });
 
+  test('install --port <occupied> exit code 1 propagates under bash pipefail (CV103-2 R6 regression)', async () => {
+    // CV103-2 (v2.6.2): qa's 9-variant matrix on v2.6.1 isolated a
+    // stdio-pipe race in the EADDRINUSE catch handler. Synchronous
+    // `process.exit(1)` raced the libuv stderr flush under
+    // stdout-piped / stderr-inherited shapes (R6: `pgserve install | cat`),
+    // causing Node to terminate with exit code 0 instead of 1.
+    //
+    // Regression assertion: under bash's `set -o pipefail`, the
+    // pgserve pipeline element's exit code propagates as the overall
+    // pipeline status. With the v2.6.2 fix (drop process.exit(1),
+    // keep process.exitCode + throw), pgserve exits 1 and pipefail
+    // surfaces it.
+    const occupier = net.createServer();
+    await new Promise((resolve) => occupier.listen(0, '127.0.0.1', resolve));
+    const occupiedPort = occupier.address().port;
+    try {
+      const cmd = `set -o pipefail; "${process.execPath}" "${BIN}" install --port ${occupiedPort} | cat`;
+      const result = spawnSync('/bin/bash', ['-c', cmd], {
+        encoding: 'utf8',
+        env: {
+          ...process.env,
+          PGSERVE_TEST_SKIP_PORT_PREFLIGHT: '0',
+          PGSERVE_CONFIG_DIR: tmpHome,
+          PATH: `${stubBin.dir}:${process.env.PATH}`,
+        },
+      });
+      expect(result.status).toBe(1);
+    } finally {
+      await new Promise((resolve) => occupier.close(resolve));
+    }
+  });
+
+  test('install --port <occupied> exit code 1 visible via PIPESTATUS[0] (CV103-2 R6 regression)', async () => {
+    // Companion to the pipefail test above. Bash's PIPESTATUS array
+    // exposes each pipeline element's raw exit code regardless of
+    // pipefail. Asserting PIPESTATUS[0] == 1 tests the pgserve-side
+    // exit code directly, independent of the shell options.
+    const occupier = net.createServer();
+    await new Promise((resolve) => occupier.listen(0, '127.0.0.1', resolve));
+    const occupiedPort = occupier.address().port;
+    try {
+      const cmd = `"${process.execPath}" "${BIN}" install --port ${occupiedPort} | cat; echo "PIPESTATUS=\${PIPESTATUS[0]}"`;
+      const result = spawnSync('/bin/bash', ['-c', cmd], {
+        encoding: 'utf8',
+        env: {
+          ...process.env,
+          PGSERVE_TEST_SKIP_PORT_PREFLIGHT: '0',
+          PGSERVE_CONFIG_DIR: tmpHome,
+          PATH: `${stubBin.dir}:${process.env.PATH}`,
+        },
+      });
+      expect(result.stdout).toContain('PIPESTATUS=1');
+    } finally {
+      await new Promise((resolve) => occupier.close(resolve));
+    }
+  });
+
   test('install with NO --port flag refuses when default 5432 is already bound (B3 T1 contract)', async () => {
     // This mirrors QA-RECIPE-B3 T1: occupy 5432, then `pgserve install` with
     // no --port should refuse via the pre-flight, not exit 0. The default-


### PR DESCRIPTION
## Summary

Fixes CV103-2 (HIGH UX). On v2.6.1, `pgserve install | cat` (or any other stdout-piped/stderr-inherited shape) returns exit code 0 even though it printed an EADDRINUSE error — operators piping into shell tooling silently lose the failure signal.

Root cause is a Node.js stdio-flush race documented in [Node's own process.exit docs](https://nodejs.org/api/process.html#processexitcode_1):

> Calling `process.exit()` will force the process to exit as quickly as possible even if there are still asynchronous operations pending that have not yet completed fully, **including I/O operations to `process.stdout` and `process.stderr`.**

The synchronous `process.exit(1)` inside the EADDRINUSE catch handler ran Node's shutdown sequence faster than the libuv stderr buffer could flush, and Node terminated with exit code 0 instead of 1 under the specific stdio shape. Bug only fired with stdout-piped / stderr-inherited; bun-test spawnSync uses separate stderr pipes so CI never reproduced it (the lesson that PR #103 loop-2 missed).

## Fix shape

**Option A** from qa's diagnosis (`CV103-2-DIAGNOSIS-REPRO.md`), ~5 LOC across two files:

### `src/cli-install.cjs` EADDRINUSE catch handler
- Drop synchronous `process.exit(1)` (+ the now-unreachable `throw err` after it)
- Keep `process.exitCode = 1` — Node uses this on graceful exit
- Keep `throw err` so the wrapper's rejection handler fires
- Replace v2.6.1 belt-and-suspenders comment block with the CV103-2 explanation citing Node docs

### `bin/pgserve-wrapper.cjs` rejection handler
- Suppress the duplicate stderr write for `err.code === 'EADDRINUSE'` (catch handler already wrote the message before throwing)
- Drop `process.exit(1)` — re-introducing it would re-introduce the race. Defensive `process.exitCode = 1` assignment if the throwing code didn't already set one.

## QA's 9-variant repro matrix (from `CV103-2-DIAGNOSIS-REPRO.md`)

| # | Variant | v2.6.1 result | Expected post-fix |
|---|---------|---------------|-------------------|
| R1 | `pgserve install` (plain shell) | exit 1 ✓ | exit 1 ✓ |
| R6 | **`pgserve install \| cat`** | **exit 0 ✗ BUG** | **exit 1 ✓** |
| R7 | `pgserve install >out.txt 2>err.txt` | exit 1 ✓ | exit 1 ✓ |
| R8 | `pgserve install 2>&1 \| cat` | exit 1 ✓ | exit 1 ✓ |

QA will re-run the full 9-variant matrix on PR-built v2.6.2 candidate; expect R6 to flip to exit 1 (and the other 8 to remain exit 1).

## Regression tests

Added 2 tests to `tests/cli-install.test.js` that exercise the qa R6 shape:

```js
test('install --port <occupied> exit code 1 propagates under bash pipefail (CV103-2 R6 regression)', ...)
//   uses `set -o pipefail; pgserve install --port X | cat`; asserts pipeline exit status === 1

test('install --port <occupied> exit code 1 visible via PIPESTATUS[0] (CV103-2 R6 regression)', ...)
//   uses bash PIPESTATUS array to read pgserve's raw exit code; asserts stdout contains `PIPESTATUS=1`
```

Both tests pass on this branch. The PR #103 loop-2 test (`install --port <occupied> EADDRINUSE produces non-zero exit code`) ALSO continues to pass — the contract holds under both stdio shapes now.

## Validation

```
$ bun test --timeout 30000
 639 pass / 3 skip / 0 fail / 1862 expect() calls / 48 files / 31.01s

$ bun run lint
$ eslint src/ bin/    # clean

$ bun run deadcode
$ knip                # clean (only existing config hints)
```

The 2 new regression tests bring the cli-install suite from 37 to 39 tests.

## Test plan

- [ ] CI matrix passes
- [ ] QA re-runs the 9-variant matrix; R6 flips to exit 1
- [ ] Felipe merge once dogfood + reviews are clean

## Cross-references

- `CV103-2-DIAGNOSIS-REPRO.md` — qa's 9-variant repro + Option A proposal
- `CV103-2-EXIT-STRUCTURAL-TRACKER.md` — original deferral filing
- `QA-FINDINGS-PR103-LOOP2.md` — the loop-2 escalation that flagged the gap
- `feedback_production_stdio_shape.md` (engineer memory) — the lesson that the test rig must mirror operator stdio shape

## Lesson pinned

PR #103 loop-2 shipped the WRONG fix (added `process.exit(1)` as belt-and-suspenders) because bun test's spawnSync uses separate stderr pipes — the test rig couldn't see the bug under the stdio shape that triggered it. Memory rule pinned (`feedback_production_stdio_shape.md`): production verify recipes MUST run against the operator's exact stdio shape, not just the test runner's defaults.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed exit code propagation for `pgserve install` when a port is already in use, ensuring reliable error handling and output flushing in Bash pipelines.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/namastexlabs/pgserve/pull/105)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->