### PR TITLE
fix(verify-binary): resolveBundlePath fall-through to .intoto.jsonl + sibling provenance

### DIFF
--- a/src/cosign/verify-binary.js
+++ b/src/cosign/verify-binary.js
@@ -54,13 +54,56 @@ export function sha256File(filePath) {
 }
 
 /**
- * Resolve the sidecar bundle path for a given binary path. Convention:
- * `<binary>.bundle`. Operators that publish detached `.sig` + `.cert` can
- * regenerate a bundle with `cosign sign-blob --bundle <path>.bundle`; we
- * intentionally only support the bundle form to keep the surface narrow.
+ * Candidate sidecar bundle paths for a given binary path, in priority
+ * order. First existing file wins. When none exist, the first candidate
+ * (`<binary>.bundle`) is returned so the caller's existing
+ * `bundle-missing` error path keeps the same operator-facing message
+ * shape.
+ *
+ * Three conventions are accepted:
+ *
+ *   1. `<binary>.bundle` — `cosign sign-blob --bundle` default;
+ *      pgserve's own producer convention.
+ *   2. `<binary-stem>.intoto.jsonl` — slsa-github-generator
+ *      per-artifact provenance (writes `<artifact>.intoto.jsonl` when
+ *      provenance-name interpolates the artifact stem). The stem is
+ *      computed by stripping `.tgz` (the only archive ext used in the
+ *      automagik-cohort cosign trust loop today).
+ *   3. `<dirname>/provenance.intoto.jsonl` — slsa-github-generator
+ *      generic-provenance default (single sibling per release upload).
+ *      This is what `automagik-dev/genie` ships today (verified via
+ *      `gh release view` against v4.260508.3+).
+ *
+ * Why fall-through, not single-shape: CV-VERIFY-BUNDLE-NAMING (qa
+ * Wave-B-live finding 2026-05-09). pgserve's prior single-shape
+ * resolver returned literal `<binary>.bundle` and failed every
+ * `pgserve verify` against producer-side artifacts that ship per the
+ * standards-compliant `intoto.jsonl` conventions. Consumer-side
+ * fall-through preserves the producer's standards conformance instead
+ * of forcing every producer-side wave (A/B/C) into a non-standard
+ * `.bundle` rename.
+ */
+export function resolveBundleCandidates(binaryPath) {
+  const stem = binaryPath.replace(/\.tgz$/, '');
+  return [
+    `${binaryPath}.bundle`,
+    `${stem}.intoto.jsonl`,
+    path.join(path.dirname(binaryPath), 'provenance.intoto.jsonl'),
+  ];
+}
+
+/**
+ * Resolve the sidecar bundle path for a given binary path. Returns the
+ * first existing candidate; when none exist, returns the first
+ * candidate (`<binary>.bundle`) so the existing `bundle-missing` error
+ * path retains its operator-facing message shape.
+ *
+ * Callers that need the full candidate list (e.g. for diagnostics) can
+ * use `resolveBundleCandidates` directly.
  */
 export function resolveBundlePath(binaryPath) {
-  return `${binaryPath}.bundle`;
+  const candidates = resolveBundleCandidates(binaryPath);
+  return candidates.find((p) => fs.existsSync(p)) ?? candidates[0];
 }
 
 /**
@@ -189,10 +232,21 @@ export function verifyBinary(binaryPath, options = {}) {
 
   const bundlePath = options.bundlePath || resolveBundlePath(binaryPath);
   if (!fs.existsSync(bundlePath)) {
+    // CV-VERIFY-BUNDLE-NAMING (v2.6.3): when none of the three
+    // candidates exist, surface the full list in the error detail so
+    // operators see exactly which paths pgserve probed. The
+    // bundle-missing reason code is unchanged so any log-grep wired
+    // against it keeps working.
+    const probed = options.bundlePath
+      ? [bundlePath]
+      : resolveBundleCandidates(binaryPath);
     return {
       ok: false,
       reason: 'bundle-missing',
-      detail: `expected sigstore bundle at ${bundlePath} (run \`cosign sign-blob --bundle ${bundlePath} ${binaryPath}\` to attest)`,
+      detail:
+        `expected sigstore bundle for ${binaryPath} — probed: ${probed.join(', ')}. `
+        + `Pass --bundle <path> to override, or run `
+        + `\`cosign sign-blob --bundle ${binaryPath}.bundle ${binaryPath}\` to attest.`,
     };
   }
 

--- a/tests/cosign/verify-binary.test.js
+++ b/tests/cosign/verify-binary.test.js
@@ -17,7 +17,12 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 
-import { resolveBundlePath, sha256File, verifyBinary } from '../../src/cosign/verify-binary.js';
+import {
+  resolveBundleCandidates,
+  resolveBundlePath,
+  sha256File,
+  verifyBinary,
+} from '../../src/cosign/verify-binary.js';
 
 const FAKE_TRUST_LIST = [
   Object.freeze({
@@ -218,5 +223,109 @@ describe('verifyBinary — input validation', () => {
     });
     expect(r.ok).toBe(false);
     expect(r.reason).toBe('empty-trust-list');
+  });
+});
+
+describe('CV-VERIFY-BUNDLE-NAMING — resolveBundleCandidates (v2.6.3)', () => {
+  test('returns three candidates in priority order', () => {
+    const candidates = resolveBundleCandidates('/tmp/foo/bar.tgz');
+    expect(candidates).toHaveLength(3);
+    expect(candidates[0]).toBe('/tmp/foo/bar.tgz.bundle');
+    expect(candidates[1]).toBe('/tmp/foo/bar.intoto.jsonl');
+    expect(candidates[2]).toBe('/tmp/foo/provenance.intoto.jsonl');
+  });
+
+  test('strips trailing .tgz only (preserves other archive shapes verbatim in stem position)', () => {
+    const candidates = resolveBundleCandidates('/tmp/foo/bar.tar.gz');
+    expect(candidates[0]).toBe('/tmp/foo/bar.tar.gz.bundle');
+    // .tar.gz is not stripped (only .tgz is); stem stays as-is
+    expect(candidates[1]).toBe('/tmp/foo/bar.tar.gz.intoto.jsonl');
+    expect(candidates[2]).toBe('/tmp/foo/provenance.intoto.jsonl');
+  });
+
+  test('binary with no extension keeps its full name in candidate slots', () => {
+    const candidates = resolveBundleCandidates('/tmp/foo/postgres');
+    expect(candidates[0]).toBe('/tmp/foo/postgres.bundle');
+    expect(candidates[1]).toBe('/tmp/foo/postgres.intoto.jsonl');
+    expect(candidates[2]).toBe('/tmp/foo/provenance.intoto.jsonl');
+  });
+});
+
+describe('CV-VERIFY-BUNDLE-NAMING — resolveBundlePath fall-through (v2.6.3)', () => {
+  test('candidate 1 (`<binary>.bundle`) wins when present (preserves existing convention)', () => {
+    const binary = makeBinary('artifact-1.tgz', 'BODY');
+    fs.writeFileSync(`${binary}.bundle`, '{"shape":"bundle"}');
+    expect(resolveBundlePath(binary)).toBe(`${binary}.bundle`);
+  });
+
+  test('candidate 2 (`<stem>.intoto.jsonl`) wins when only that exists (per-artifact provenance)', () => {
+    const binary = makeBinary('artifact-2.tgz', 'BODY');
+    const stem = binary.replace(/\.tgz$/, '');
+    fs.writeFileSync(`${stem}.intoto.jsonl`, '{"shape":"intoto-stem"}');
+    expect(resolveBundlePath(binary)).toBe(`${stem}.intoto.jsonl`);
+  });
+
+  test('candidate 3 (`<dirname>/provenance.intoto.jsonl`) wins when only that exists (genie shape)', () => {
+    const binary = makeBinary('artifact-3.tgz', 'BODY');
+    const sibling = path.join(path.dirname(binary), 'provenance.intoto.jsonl');
+    fs.writeFileSync(sibling, '{"shape":"intoto-sibling"}');
+    expect(resolveBundlePath(binary)).toBe(sibling);
+  });
+
+  test('priority order: candidate 1 beats candidate 3 when both exist', () => {
+    const binary = makeBinary('artifact-4.tgz', 'BODY');
+    fs.writeFileSync(`${binary}.bundle`, '{"shape":"bundle"}');
+    const sibling = path.join(path.dirname(binary), 'provenance.intoto.jsonl');
+    fs.writeFileSync(sibling, '{"shape":"intoto-sibling"}');
+    // Candidate 1 (`.bundle`) takes priority — existing convention preserved.
+    expect(resolveBundlePath(binary)).toBe(`${binary}.bundle`);
+  });
+
+  test('priority order: candidate 2 beats candidate 3 when 1 absent and both 2+3 exist', () => {
+    const binary = makeBinary('artifact-5.tgz', 'BODY');
+    const stem = binary.replace(/\.tgz$/, '');
+    fs.writeFileSync(`${stem}.intoto.jsonl`, '{"shape":"intoto-stem"}');
+    const sibling = path.join(path.dirname(binary), 'provenance.intoto.jsonl');
+    fs.writeFileSync(sibling, '{"shape":"intoto-sibling"}');
+    expect(resolveBundlePath(binary)).toBe(`${stem}.intoto.jsonl`);
+  });
+
+  test('all candidates absent → returns candidate 1 (preserves bundle-missing error path)', () => {
+    const binary = makeBinary('artifact-6.tgz', 'BODY');
+    // No bundle/intoto files written.
+    expect(resolveBundlePath(binary)).toBe(`${binary}.bundle`);
+  });
+});
+
+describe('CV-VERIFY-BUNDLE-NAMING — verifyBinary bundle-missing detail enrichment (v2.6.3)', () => {
+  test('bundle-missing error lists all three probed paths when no override is set', () => {
+    const binary = makeBinary('artifact-missing.tgz', 'BODY');
+    // No bundle/intoto files written.
+    const result = verifyBinary(binary, {
+      cosignBin: path.join(stubBinDir, 'cosign'),
+      trustList: FAKE_TRUST_LIST,
+    });
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe('bundle-missing');
+    expect(result.detail).toContain(`${binary}.bundle`);
+    expect(result.detail).toContain(`.intoto.jsonl`);
+    expect(result.detail).toContain(`provenance.intoto.jsonl`);
+    // Hint must reference --bundle override since fall-through couldn't resolve.
+    expect(result.detail).toContain('--bundle');
+  });
+
+  test('bundle-missing error lists ONLY the override path when --bundle was passed', () => {
+    const binary = makeBinary('artifact-with-override.tgz', 'BODY');
+    const explicit = `${binary}.does-not-exist`;
+    const result = verifyBinary(binary, {
+      cosignBin: path.join(stubBinDir, 'cosign'),
+      trustList: FAKE_TRUST_LIST,
+      bundlePath: explicit,
+    });
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe('bundle-missing');
+    expect(result.detail).toContain(explicit);
+    // The auto-discovery probe paths should NOT appear when an override was given.
+    expect(result.detail).not.toContain('provenance.intoto.jsonl');
   });
 });


### PR DESCRIPTION
## Summary

Closes CV-VERIFY-BUNDLE-NAMING (NEW HIGH, qa Wave-B-live finding 2026-05-09). Consumer-side gap: `pgserve verify <genie-binary>` failed `bundle-missing` even when genie ships a valid sigstore bundle, because pgserve's `resolveBundlePath` returned literal `<binary>.bundle` as the sole candidate, while `automagik-dev/genie` (and slsa-github-generator-based producers in general) ship the bundle as `provenance.intoto.jsonl` per the Sigstore convention.

Option B (consumer-side fall-through) per qa + orchestrator recommendation. Single-file core change + 11 new unit tests. **Unblocks ALL three producer-side waves** (A pgserve self-trust, B genie-post-propagation, C omni-post-dispatch) end-to-end without cross-repo coordination.

## Fix

`resolveBundlePath` now tries three candidates in priority order, first existing wins:

| Priority | Path | Producer convention |
|----------|------|---------------------|
| 1 | `<binary>.bundle` | `cosign sign-blob --bundle` default; pgserve's own producer side |
| 2 | `<binary-stem>.intoto.jsonl` | slsa-github-generator per-artifact provenance |
| 3 | `<dirname>/provenance.intoto.jsonl` | slsa-github-generator generic-provenance default; **what genie ships today** |

When all three are absent, the resolver returns candidate 1 so the existing `bundle-missing` error path retains its shape (operator-facing message keeps the prior `.bundle`-named hint for the cosign sign-blob remediation).

A new export `resolveBundleCandidates(binaryPath)` returns the full three-element array for diagnostics.

## Bonus: enriched bundle-missing error detail

When the auto-discovery path fails to resolve any candidate, the `bundle-missing` reason's `detail` now lists ALL THREE probed paths so operators see exactly what pgserve looked for. When `--bundle <path>` was set explicitly, the detail lists ONLY the override path (no auto-discovery noise). The reason code is unchanged so log-grep against `bundle-missing` keeps working.

## Why Option B over Option A (cross-repo workflow renames)

1. **Single-repo PR; narrow blast radius** — no coordination across automagik-dev/genie / namastexlabs/pgserve / automagik-dev/omni release pipelines.
2. **Correct asymmetry**: the consumer adapts to producer-side standards-compliant naming, not the other way around. `provenance.intoto.jsonl` is the Sigstore-recommended sidecar shape; reversing it would put pgserve in opposition to upstream conventions.
3. **Unblocks all three waves end-to-end** without forcing each producer wave to also rename their release uploads.

## Composition test (qa's recommendation)

Per the orchestrator brief, after this fix lands qa can compose-test against the existing `automagik-dev/genie@v4.260509.2` artifact by passing `--certificate-identity-regexp` forced to `refs/heads/main` (env override or test-mode flag), bypassing the producer-side trigger fix in genie PR #1725 that hasn't propagated to a new release yet. If `verifyBinary` then PASSes the bundle-resolve, that proves the consumer-side fix is structurally correct INDEPENDENT of Wave B producer-side propagation.

## Tests

`tests/cosign/verify-binary.test.js` — 11 new tests:

- **`resolveBundleCandidates`** (3 tests): candidate ordering, `.tgz` stripping behavior, plain-binary names.
- **`resolveBundlePath` fall-through** (6 tests): each candidate winning when present in isolation; priority ordering when multiple present; all-absent → candidate 1 fallback.
- **`verifyBinary` bundle-missing detail** (2 tests): auto-discovery lists all three probed paths in the detail; explicit override lists only the override.

`bun test tests/cosign/verify-binary.test.js`: **20 pass / 53 expects** (was 9 / 27; +11 tests, +26 expects).

## Validation

```
$ bun test --timeout 30000
 650 pass / 3 skip / 0 fail / 1888 expect() calls / 48 files / 32.73s

$ bun run lint
$ eslint src/ bin/    # clean

$ bun run deadcode
$ knip                # clean (only existing config hints)
```

## Test plan

- [ ] CI matrix passes
- [ ] qa runs the composition test (forced identity-regex against v4.260509.2 with the `provenance.intoto.jsonl` sidecar) → expect `pgserve verify` to clear the bundle-missing gate and proceed to cosign verify-blob
- [ ] qa standard recipe sweep (S1-S4 against post-fix consumer)
- [ ] Felipe merge → consumer-side flexibility unlocked for all three waves

## Cross-references

- `QA-FINDINGS-WAVE-B-LIVE-V4-260509-3.md` — NEW HIGH section (qa repro evidence)
- `ENGINEER-NEXT-CV-VERIFY-BUNDLE-NAMING.md` — orchestrator filesystem brief with the Option A vs B reasoning
- `SIGNED-APP-PRE-FLIGHT-GENIE.md` (T24) — first quantitative surfacing of the artifact-naming gap
- genie PR #1725 (producer-side trigger fix; this PR is the matching consumer-side adapter)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Bundle sidecar discovery now recognizes multiple naming conventions and locations, improving compatibility with different deployment patterns.

* **Improvements**
  * Enhanced error diagnostics: bundle-missing error messages now display all candidate paths checked during discovery, aiding troubleshooting.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/namastexlabs/pgserve/pull/107)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->