### PR TITLE
fix(verify-binary): support detached <tarball>.sig + <tarball>.cert format (WAVE-B-BUNDLE-FORMAT)

### DIFF
--- a/src/cosign/verify-binary.js
+++ b/src/cosign/verify-binary.js
@@ -107,6 +107,91 @@ export function resolveBundlePath(binaryPath) {
 }
 
 /**
+ * Detect detached cosign artifacts (`<binary>.sig` + `<binary>.cert`)
+ * for a binary. Returns `{ signature, certificate }` when both
+ * siblings exist; null otherwise.
+ *
+ * WAVE-B-BUNDLE-FORMAT (v2.6.3): cosign supports two output shapes for
+ * `cosign sign-blob`:
+ *
+ *   1. Bundled  — `--bundle <path>` writes a JSON envelope containing
+ *      sig + cert + tlog + bundle metadata. Verified via
+ *      `cosign verify-blob --bundle <path>`.
+ *   2. Detached — `--output-signature <sig> --output-certificate <cert>`
+ *      writes two sidecar files. Verified via
+ *      `cosign verify-blob --signature <sig> --certificate <cert>`.
+ *
+ * `automagik-dev/genie` (and many slsa-github-generator-driven release
+ * pipelines) emit the detached pair as their release-identity-bearing
+ * signature, alongside a separate `provenance.intoto.jsonl` carrying
+ * the SLSA generator's identity. Pre-fix pgserve only consumed bundled
+ * formats and silently failed `pgserve verify` against detached
+ * producers because `provenance.intoto.jsonl`'s cert subject doesn't
+ * match the consumer-side trust regex. This helper closes that gap on
+ * the consumer side per the asymmetric-cohort principle (Postel's Law:
+ * pgserve adapts to producer-side standards-compliant emit shapes).
+ *
+ * Priority semantics (used in verifyBinary):
+ *   - When a caller passes `options.bundlePath` explicitly, that wins.
+ *   - Otherwise, detached takes priority over bundle resolution when
+ *     both shapes' siblings exist for the same binary. Reasoning:
+ *     producer-explicit publishing of `<binary>.sig` + `<binary>.cert`
+ *     is the established cosign convention; preferring bundles
+ *     silently could mask producer-side regressions in a dual-emit
+ *     setup. Operators who specifically want bundle resolution can
+ *     pass `--bundle <path>` to override.
+ */
+export function resolveDetachedCosign(binaryPath) {
+  const signature = `${binaryPath}.sig`;
+  const certificate = `${binaryPath}.cert`;
+  if (fs.existsSync(signature) && fs.existsSync(certificate)) {
+    return { signature, certificate };
+  }
+  return null;
+}
+
+/**
+ * Compute the verification material pgserve will hand to cosign for a
+ * given binary, applying the priority rules documented on
+ * `resolveDetachedCosign`. Returned shapes:
+ *
+ *   { kind: 'bundle',   bundlePath, exists, probed: string[] }
+ *   { kind: 'detached', signature, certificate, exists, probed: string[] }
+ *
+ * `exists` is true iff every required sibling file is on disk. `probed`
+ * lists the paths inspected so the bundle-missing diagnostic can echo
+ * them back to operators.
+ */
+export function resolveVerificationMaterial(binaryPath, { bundlePath } = {}) {
+  if (bundlePath) {
+    return {
+      kind: 'bundle',
+      bundlePath,
+      exists: fs.existsSync(bundlePath),
+      probed: [bundlePath],
+    };
+  }
+  const detached = resolveDetachedCosign(binaryPath);
+  if (detached) {
+    return {
+      kind: 'detached',
+      signature: detached.signature,
+      certificate: detached.certificate,
+      exists: true,
+      probed: [detached.signature, detached.certificate],
+    };
+  }
+  const candidates = resolveBundleCandidates(binaryPath);
+  const found = candidates.find((p) => fs.existsSync(p));
+  return {
+    kind: 'bundle',
+    bundlePath: found ?? candidates[0],
+    exists: !!found,
+    probed: [...candidates, `${binaryPath}.sig`, `${binaryPath}.cert`],
+  };
+}
+
+/**
  * Resolve which `cosign` executable to use. Returns a string path or null
  * if no cosign is available and `allowFetch: false`.
  *
@@ -230,23 +315,23 @@ export function verifyBinary(binaryPath, options = {}) {
     return { ok: false, reason: 'binary-not-a-file', detail: binaryPath };
   }
 
-  const bundlePath = options.bundlePath || resolveBundlePath(binaryPath);
-  if (!fs.existsSync(bundlePath)) {
-    // CV-VERIFY-BUNDLE-NAMING (v2.6.3): when none of the three
-    // candidates exist, surface the full list in the error detail so
-    // operators see exactly which paths pgserve probed. The
+  const material = resolveVerificationMaterial(binaryPath, { bundlePath: options.bundlePath });
+  if (!material.exists) {
+    // CV-VERIFY-BUNDLE-NAMING (v2.6.3) + WAVE-B-BUNDLE-FORMAT (v2.6.3):
+    // when neither bundled siblings nor the detached `.sig`+`.cert` pair
+    // exist, surface the full probed list in the error detail so
+    // operators see exactly which paths pgserve inspected. The
     // bundle-missing reason code is unchanged so any log-grep wired
-    // against it keeps working.
-    const probed = options.bundlePath
-      ? [bundlePath]
-      : resolveBundleCandidates(binaryPath);
+    // against it keeps working; an explicit override via
+    // options.bundlePath narrows the probe list to just that path.
     return {
       ok: false,
       reason: 'bundle-missing',
       detail:
-        `expected sigstore bundle for ${binaryPath} — probed: ${probed.join(', ')}. `
+        `expected cosign verification material for ${binaryPath} — probed: ${material.probed.join(', ')}. `
         + `Pass --bundle <path> to override, or run `
-        + `\`cosign sign-blob --bundle ${binaryPath}.bundle ${binaryPath}\` to attest.`,
+        + `\`cosign sign-blob --bundle ${binaryPath}.bundle ${binaryPath}\` to attest `
+        + `(or use detached \`--output-signature ${binaryPath}.sig --output-certificate ${binaryPath}.cert\`).`,
     };
   }
 
@@ -279,7 +364,7 @@ export function verifyBinary(binaryPath, options = {}) {
     }
     const result = invokeCosign({
       cosignBin,
-      bundlePath,
+      material,
       binaryPath,
       identity,
     });
@@ -292,7 +377,10 @@ export function verifyBinary(binaryPath, options = {}) {
         tier: COSIGN_TIER,
         sha256,
         cosignBin,
-        bundle: bundlePath,
+        // Back-compat: callers reading `.bundle` still get a value
+        // (null when detached, the path when bundled).
+        bundle: material.kind === 'bundle' ? material.bundlePath : null,
+        material,
         identityChain,
       };
     }
@@ -308,10 +396,18 @@ export function verifyBinary(binaryPath, options = {}) {
   };
 }
 
-function invokeCosign({ cosignBin, bundlePath, binaryPath, identity }) {
+function invokeCosign({ cosignBin, material, binaryPath, identity }) {
+  // WAVE-B-BUNDLE-FORMAT (v2.6.3): dispatch on material.kind so cosign
+  // gets the matching argv shape — `--bundle <path>` for bundled
+  // sigstore JSON envelopes; `--signature <sig> --certificate <cert>`
+  // for detached cosign sign-blob output (genie's release-identity-
+  // bearing artifacts ship in this shape).
+  const materialArgs = material.kind === 'detached'
+    ? ['--signature', material.signature, '--certificate', material.certificate]
+    : ['--bundle', material.bundlePath];
   const args = [
     'verify-blob',
-    '--bundle', bundlePath,
+    ...materialArgs,
     '--certificate-identity-regexp', identity.identityRegexp,
     '--certificate-oidc-issuer', identity.issuer,
     binaryPath,

--- a/tests/cosign/verify-binary.test.js
+++ b/tests/cosign/verify-binary.test.js
@@ -20,6 +20,8 @@ import path from 'node:path';
 import {
   resolveBundleCandidates,
   resolveBundlePath,
+  resolveDetachedCosign,
+  resolveVerificationMaterial,
   sha256File,
   verifyBinary,
 } from '../../src/cosign/verify-binary.js';
@@ -327,5 +329,181 @@ describe('CV-VERIFY-BUNDLE-NAMING — verifyBinary bundle-missing detail enrichm
     expect(result.detail).toContain(explicit);
     // The auto-discovery probe paths should NOT appear when an override was given.
     expect(result.detail).not.toContain('provenance.intoto.jsonl');
+  });
+});
+
+describe('WAVE-B-BUNDLE-FORMAT — resolveDetachedCosign (v2.6.3)', () => {
+  test('returns null when neither sibling exists', () => {
+    const binary = makeBinary('detached-none.tgz', 'BODY');
+    expect(resolveDetachedCosign(binary)).toBeNull();
+  });
+
+  test('returns null when only .sig exists (cert missing)', () => {
+    const binary = makeBinary('detached-sig-only.tgz', 'BODY');
+    fs.writeFileSync(`${binary}.sig`, 'sig-bytes');
+    expect(resolveDetachedCosign(binary)).toBeNull();
+  });
+
+  test('returns null when only .cert exists (sig missing)', () => {
+    const binary = makeBinary('detached-cert-only.tgz', 'BODY');
+    fs.writeFileSync(`${binary}.cert`, 'cert-bytes');
+    expect(resolveDetachedCosign(binary)).toBeNull();
+  });
+
+  test('returns sig+cert paths when both exist', () => {
+    const binary = makeBinary('detached-both.tgz', 'BODY');
+    fs.writeFileSync(`${binary}.sig`, 'sig-bytes');
+    fs.writeFileSync(`${binary}.cert`, 'cert-bytes');
+    const result = resolveDetachedCosign(binary);
+    expect(result).toEqual({
+      signature: `${binary}.sig`,
+      certificate: `${binary}.cert`,
+    });
+  });
+});
+
+describe('WAVE-B-BUNDLE-FORMAT — resolveVerificationMaterial priority (v2.6.3)', () => {
+  test('explicit options.bundlePath wins over everything', () => {
+    const binary = makeBinary('material-explicit.tgz', 'BODY');
+    fs.writeFileSync(`${binary}.sig`, 'sig');
+    fs.writeFileSync(`${binary}.cert`, 'cert');
+    fs.writeFileSync(`${binary}.bundle`, '{"shape":"bundle"}');
+    const explicit = `${binary}.custom-bundle`;
+    fs.writeFileSync(explicit, '{"shape":"explicit-bundle"}');
+    const m = resolveVerificationMaterial(binary, { bundlePath: explicit });
+    expect(m.kind).toBe('bundle');
+    expect(m.bundlePath).toBe(explicit);
+    expect(m.exists).toBe(true);
+  });
+
+  test('detached pair wins over bundle when both exist (no override)', () => {
+    const binary = makeBinary('material-both-shapes.tgz', 'BODY');
+    fs.writeFileSync(`${binary}.sig`, 'sig');
+    fs.writeFileSync(`${binary}.cert`, 'cert');
+    fs.writeFileSync(`${binary}.bundle`, '{"shape":"bundle"}');
+    const m = resolveVerificationMaterial(binary);
+    expect(m.kind).toBe('detached');
+    expect(m.signature).toBe(`${binary}.sig`);
+    expect(m.certificate).toBe(`${binary}.cert`);
+    expect(m.exists).toBe(true);
+  });
+
+  test('falls back to bundle when only bundle siblings exist', () => {
+    const binary = makeBinary('material-bundle-only.tgz', 'BODY');
+    fs.writeFileSync(`${binary}.bundle`, '{"shape":"bundle"}');
+    const m = resolveVerificationMaterial(binary);
+    expect(m.kind).toBe('bundle');
+    expect(m.bundlePath).toBe(`${binary}.bundle`);
+    expect(m.exists).toBe(true);
+  });
+
+  test('returns kind=bundle with exists=false + full probe list when nothing exists', () => {
+    const binary = makeBinary('material-nothing.tgz', 'BODY');
+    const m = resolveVerificationMaterial(binary);
+    expect(m.kind).toBe('bundle');
+    expect(m.exists).toBe(false);
+    expect(m.bundlePath).toBe(`${binary}.bundle`);
+    // Probed list should include both bundle candidates AND detached siblings
+    // so the bundle-missing diagnostic can echo every place we looked.
+    expect(m.probed).toContain(`${binary}.bundle`);
+    expect(m.probed).toContain(`${binary}.sig`);
+    expect(m.probed).toContain(`${binary}.cert`);
+  });
+});
+
+describe('WAVE-B-BUNDLE-FORMAT — verifyBinary detached-format end-to-end (v2.6.3)', () => {
+  test('verifyBinary auto-detects detached format when sig+cert siblings exist', () => {
+    const binary = makeBinary('detached-e2e-pass.tgz', 'LEGIT_BINARY_v1\nBODY');
+    fs.writeFileSync(`${binary}.sig`, 'sig');
+    fs.writeFileSync(`${binary}.cert`, 'cert');
+    const result = verifyBinary(binary, {
+      cosignBin: path.join(stubBinDir, 'cosign'),
+      trustList: FAKE_TRUST_LIST,
+    });
+    expect(result.ok).toBe(true);
+    expect(result.material.kind).toBe('detached');
+    expect(result.material.signature).toBe(`${binary}.sig`);
+    expect(result.material.certificate).toBe(`${binary}.cert`);
+    // Back-compat: bundle field is null on detached path.
+    expect(result.bundle).toBeNull();
+    // Stub cosign should have been invoked with --signature/--certificate args
+    // (not --bundle).
+    const calls = readCallLog();
+    expect(calls.length).toBeGreaterThan(0);
+    const lastCall = calls[calls.length - 1];
+    expect(lastCall).toContain('--signature');
+    expect(lastCall).toContain('--certificate');
+    expect(lastCall).not.toContain('--bundle');
+  });
+
+  test('verifyBinary prefers detached format over bundle when both present', () => {
+    const binary = makeBinary('detached-priority.tgz', 'LEGIT_BINARY_v1\nBODY');
+    fs.writeFileSync(`${binary}.sig`, 'sig');
+    fs.writeFileSync(`${binary}.cert`, 'cert');
+    fs.writeFileSync(`${binary}.bundle`, '{"shape":"bundle"}');
+    const result = verifyBinary(binary, {
+      cosignBin: path.join(stubBinDir, 'cosign'),
+      trustList: FAKE_TRUST_LIST,
+    });
+    expect(result.ok).toBe(true);
+    expect(result.material.kind).toBe('detached');
+    expect(result.bundle).toBeNull();
+    const calls = readCallLog();
+    const lastCall = calls[calls.length - 1];
+    expect(lastCall).toContain('--signature');
+    expect(lastCall).not.toContain('--bundle');
+  });
+
+  test('verifyBinary falls back to bundle resolution when only bundle siblings exist', () => {
+    const binary = makeBinary('bundle-only.tgz', 'LEGIT_BINARY_v1\nBODY');
+    fs.writeFileSync(`${binary}.bundle`, '{"shape":"bundle"}');
+    const result = verifyBinary(binary, {
+      cosignBin: path.join(stubBinDir, 'cosign'),
+      trustList: FAKE_TRUST_LIST,
+    });
+    expect(result.ok).toBe(true);
+    expect(result.material.kind).toBe('bundle');
+    expect(result.bundle).toBe(`${binary}.bundle`);
+    const calls = readCallLog();
+    const lastCall = calls[calls.length - 1];
+    expect(lastCall).toContain('--bundle');
+    expect(lastCall).not.toContain('--signature');
+  });
+
+  test('verifyBinary correctly fails with bundle-missing when neither detached nor bundle exists', () => {
+    const binary = makeBinary('nothing.tgz', 'BODY');
+    const result = verifyBinary(binary, {
+      cosignBin: path.join(stubBinDir, 'cosign'),
+      trustList: FAKE_TRUST_LIST,
+    });
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe('bundle-missing');
+    // Detail should mention both bundle AND detached probe paths.
+    expect(result.detail).toContain(`${binary}.bundle`);
+    expect(result.detail).toContain(`${binary}.sig`);
+    expect(result.detail).toContain(`${binary}.cert`);
+    expect(result.detail).toContain('--bundle');
+    expect(result.detail).toContain('--output-signature');
+  });
+
+  test('explicit options.bundlePath skips detached detection (operator override)', () => {
+    const binary = makeBinary('detached-override.tgz', 'LEGIT_BINARY_v1\nBODY');
+    fs.writeFileSync(`${binary}.sig`, 'sig');
+    fs.writeFileSync(`${binary}.cert`, 'cert');
+    const explicitBundle = `${binary}.explicit-bundle`;
+    fs.writeFileSync(explicitBundle, '{"shape":"bundle"}');
+    const result = verifyBinary(binary, {
+      cosignBin: path.join(stubBinDir, 'cosign'),
+      trustList: FAKE_TRUST_LIST,
+      bundlePath: explicitBundle,
+    });
+    expect(result.ok).toBe(true);
+    expect(result.material.kind).toBe('bundle');
+    expect(result.material.bundlePath).toBe(explicitBundle);
+    const calls = readCallLog();
+    const lastCall = calls[calls.length - 1];
+    expect(lastCall).toContain('--bundle');
+    expect(lastCall).toContain(explicitBundle);
+    expect(lastCall).not.toContain('--signature');
   });
 });


### PR DESCRIPTION
## Summary

Closes WAVE-B-BUNDLE-FORMAT (NEW HIGH, qa CV-VERIFY-BUNDLE-NAMING-LIVE finding 2026-05-09). After PR #107's 3-tier bundle fall-through, `pgserve verify <genie-tarball>` still failed `no-trust-match` because:

- The bundle-resolved `provenance.intoto.jsonl` carries the **SLSA generator workflow's** cert subject — not genie's `release.yml` subject.
- pgserve's `TRUSTED_IDENTITIES` regex requires genie's `release.yml@refs/tags/v*`.
- Mismatch → no-trust-match.

But genie DOES emit a release.yml-bound signature — just in **detached `<tarball>.sig` + `<tarball>.cert` siblings**, not a bundled JSON envelope. pgserve's pre-fix `verifyBinary` only knew `--bundle <path>`; this PR teaches it `--signature <sig> --certificate <cert>` too.

Same asymmetric-cohort-principle pattern as PR #107 (CV-VERIFY-BUNDLE-NAMING). Producer side stays unchanged; pgserve becomes the format-omnivorous consumer.

## Fix

Three new module-level exports + dispatched cosign invocation:

```js
resolveDetachedCosign(binaryPath)
  // Returns { signature, certificate } when both siblings exist; null otherwise.

resolveVerificationMaterial(binaryPath, { bundlePath } = {})
  // Single-call resolver; returns { kind:'bundle'|'detached', exists, probed, ... }
  // applying priority rules:
  //   1. explicit options.bundlePath → bundle (operator override)
  //   2. detached pair exists        → detached (genie's emit shape)
  //   3. bundle fall-through         → bundle (PR #107's 3-tier candidate list)

invokeCosign({ ..., material, ... })
  // Dispatches on material.kind:
  //   bundled  → ['--bundle', material.bundlePath]
  //   detached → ['--signature', material.signature, '--certificate', material.certificate]
```

`verifyBinary` consumes the material; result shape adds `result.material` (full diagnostic object) and preserves `result.bundle` for back-compat (null on detached path).

## Priority decision: detached wins over bundle when both present

Reasoning (documented in `resolveDetachedCosign` header):

- Producer-explicit publishing of `<binary>.sig` + `<binary>.cert` is the established cosign convention.
- Preferring bundles silently could mask producer-side regressions in dual-emit setups.
- Operators who specifically want bundle resolution can pass `--bundle <path>` to override (test verified: explicit override wins).

Per qa's recipe S3 + the asymmetric-cohort-principle memory rule.

## Bundle-missing diagnostic enriched

When NEITHER detached siblings nor the 3 bundle candidates exist, the error detail now lists ALL probed paths AND mentions both regen commands (`cosign sign-blob --bundle …` AND `--output-signature … --output-certificate …`). Reason code unchanged for log-grep compatibility.

## Tests

13 new in `tests/cosign/verify-binary.test.js` — covers qa's 4 scaffolds plus 9 more:

| Group | Count | Coverage |
|-------|-------|----------|
| `resolveDetachedCosign` | 4 | null/single-sibling/both-siblings detection |
| `resolveVerificationMaterial` priority | 4 | explicit-override / detached-wins / bundle-fallback / nothing-exists |
| `verifyBinary` detached-format end-to-end | 5 | cosign argv assertion: detached uses --signature/--certificate, bundle uses --bundle, override forces bundle, all-absent returns enriched bundle-missing |

```
$ bun test tests/cosign/verify-binary.test.js
 33 pass / 0 fail / 105 expect() calls
 (was 20 / 53; +13 tests, +52 expects)

$ bun test --timeout 30000
 671 pass / 3 skip / 0 fail / 1962 expect() calls / 48 files / 32.18s

$ bun run lint && bun run deadcode
 clean
```

## Composition-test readiness

QA's `QA-RECIPE-WAVE-B-BUNDLE-FORMAT.md` ships the verification recipe (S1-S5). Key load-bearing test:

- **S3a** — against v4.260509.2: pre-fix error mentions SLSA generator subject; post-fix error mentions genie's `release.yml@refs/heads/main` subject. Different cert subjects = different code paths fired = proof Option A engages.
- **S3b** / **S5** — when a post-Wave-B genie release ships (cert subject `refs/tags/v*`), end-to-end verification succeeds without an override.

## Test plan

- [ ] CI matrix passes
- [ ] qa runs S1-S4 against this PR's CI artifacts; expects the cert-subject-shift signal in S3a
- [ ] qa S5 deferred until next genie release tag with Wave-B-ancestor cuts
- [ ] Felipe merge → consumer-side detached-format support live for ALL signed-app cohort members

## Cross-references

- `QA-FINDINGS-CV-VERIFY-BUNDLE-NAMING-LIVE.md` — qa's live discovery
- `QA-RECIPE-WAVE-B-BUNDLE-FORMAT.md` — pre-shipped recipe + implementation guidance
- `feedback_asymmetric_cohort_principle.md` — memory-pinned principle this fix exemplifies
- PR #107 (CV-VERIFY-BUNDLE-NAMING) — the bundled-format companion fix; this PR extends the same dispatch surface

🤖 Generated with [Claude Code](https://claude.com/claude-code)