### PR TITLE
fix(console): bootstrap React globals before screen imports

### DIFF
--- a/console/src/globals.js
+++ b/console/src/globals.js
@@ -1,0 +1,24 @@
+// Bootstrap React onto globalThis BEFORE any screen module evaluates.
+//
+// Why a separate file: ESM hoists `import` statements above sibling
+// top-level code in the importer. If we did `globalThis.React = React`
+// inline inside main.jsx (alongside `import './screens/databases.jsx'`
+// etc.), the screen modules would execute first and reference bare
+// identifiers like `useState` against an unprepared globalThis,
+// crashing with "ReferenceError: React is not defined".
+//
+// Importing this module first guarantees its body runs to completion
+// before any subsequent import — the fixed-up globalThis is then
+// visible to every screen module that references React/useState/etc.
+// as a free identifier.
+import React from 'react';
+import * as ReactDOM from 'react-dom/client';
+
+Object.assign(globalThis, {
+  React,
+  ReactDOM,
+  // Spread named React exports so screens can reference `useState`,
+  // `useEffect`, `useMemo`, `useRef`, `useCallback`, `Fragment`, etc.
+  // as bare identifiers without explicit `React.` qualification.
+  ...React,
+});

--- a/console/src/main.jsx
+++ b/console/src/main.jsx
@@ -1,8 +1,7 @@
-import React from 'react';
-import * as ReactDOM from 'react-dom/client';
-
-globalThis.React = React;
-globalThis.ReactDOM = ReactDOM;
+// MUST be the first import: bootstraps React/ReactDOM/hooks onto
+// globalThis before any screen module evaluates. See globals.js for
+// the ESM import-hoisting hazard this fixes.
+import './globals.js';
 
 import './api.js';
 import './data.jsx';


### PR DESCRIPTION
## Summary

- Console fails to mount on every browser load with `Uncaught ReferenceError: React is not defined`. Reproduces independently of any extension (initially mistaken for SES/MetaMask interaction).
- Root cause: ESM hoists `import` statements above sibling top-level code, so `globalThis.React = React` in `main.jsx` ran AFTER all screen modules' bodies — the screens reference `useState`/`useEffect` as bare identifiers and crash on first hook call.
- Bonus bug: `useState`/`useEffect`/etc. were never copied to `globalThis` regardless of order.

## Fix

Extract bootstrap into `console/src/globals.js` and import it as the first side-effect import in `main.jsx`. ESM guarantees the imported module's body runs to completion before the importer continues, so globals attach before any screen evaluates. `Object.assign(globalThis, { React, ReactDOM, ...React })` exposes all named React exports as bare globals.

## Bundle verification

After `npm run console:build`:

```
$ grep -boE '(Object\.assign\(globalThis|ReactDOM\.createRoot)' console/dist/app.js
142348:Object.assign(globalThis    ← bootstrap (new)
209181:ReactDOM.createRoot         ← render call
```

Bootstrap runs ~67 KB before the render call. Before this PR, the only `globalThis.React=` write happened ~70 bytes AFTER `ReactDOM.createRoot`, well past the first hook invocation.

## Test plan

- [ ] `npm run console:build` succeeds (24 modules bundled, 209.25 KB)
- [ ] `pgserve ui` → load `http://127.0.0.1:8433/` in any browser → console mounts cleanly with no errors
- [ ] Screens (databases, tables, sql, settings, etc.) render with hooks working
- [ ] No regression in production minify (Bun --minify keeps the bootstrap module-side-effect intact since the assignments touch the global)

## Notes

\`console/dist/\` is gitignored — diff is source-only. Rebuild lives under existing \`prepublishOnly\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal application bootstrap infrastructure to reorganize module initialization sequence.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/namastexlabs/pgserve/pull/111)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->