### PR TITLE
feat(release): Wave A PR-A1 — trust-loop core (keyless cosign + drop branches filter + regex re-anchor)

### DIFF
--- a/.github/workflows/sign-attest.yml
+++ b/.github/workflows/sign-attest.yml
@@ -1,22 +1,26 @@
 name: Sign + Attest Tarballs (autopg)
 
 # Group 8 of autopg-distribution-cutover — signs every tarball produced
-# by build-tarballs.yml with cosign + emits a SLSA L3 build-provenance
-# attestation per platform, then aggregates a top-level manifest.json
-# for Group 9 (CDN publish) to consume.
+# by build-tarballs.yml with cosign keyless OIDC + emits a SLSA L3 build-
+# provenance attestation per platform, then aggregates a top-level
+# manifest.json for release-publish.yml to consume.
 #
-# Trigger: runs after build-tarballs.yml completes successfully on a tag
-# push (workflow_run), or on manual dispatch (workflow_dispatch) — also
-# usable as a callable workflow.
+# Trigger: runs after build-tarballs.yml completes successfully (any
+# ref, including tag pushes), or on manual dispatch (workflow_dispatch)
+# — also usable as a callable workflow.
 #
-# Required GitHub Actions secrets:
-#   COSIGN_PRIVATE_KEY    full contents of cosign.key (paired with keys/cosign.pub)
-#   COSIGN_PASSWORD       password used during `cosign generate-key-pair`
+# Signing is cosign keyless (OIDC via GitHub Actions). No secrets
+# required; the id-token: write permission below mints OIDC tokens on
+# demand. The Fulcio cert subject encodes
+# `<repo>/.github/workflows/sign-attest.yml@<ref>`, which is what
+# `src/cosign/trust-list.js` anchors `automagik-pgserve-release`
+# against (refs/tags/v.* under post-Wave-A binding).
 #
 # Outputs (uploaded as a single artifact `autopg-signed-bundle`):
 #   dist/autopg-<version>-<platform>.tar.gz
 #   dist/autopg-<version>-<platform>.tar.gz.sha256
 #   dist/autopg-<version>-<platform>.tar.gz.sig
+#   dist/autopg-<version>-<platform>.tar.gz.cert
 #   dist/autopg-<version>-<platform>.tar.gz.intoto.jsonl
 #   dist/manifest.json
 
@@ -24,9 +28,12 @@ on:
   workflow_run:
     workflows: ["Build Tarballs (autopg)"]
     types: [completed]
-    branches:
-      - main
-      - 'wish/**'
+    # Wave A (v2.6.x) — Mismatch 5 fix: the `branches:` filter excluded
+    # tag refs, so on a `git push origin v*` build-tarballs.yml ran but
+    # this workflow never fired (release-publish then shipped zero
+    # signing artifacts). Dropping the filter makes workflow_run fire on
+    # every successful build-tarballs run, including tag pushes that
+    # produce the actual release artifacts.
   workflow_dispatch:
     inputs:
       version:
@@ -47,11 +54,9 @@ on:
         description: 'upstream run id'
         required: false
         type: string
-    secrets:
-      COSIGN_PRIVATE_KEY:
-        required: true
-      COSIGN_PASSWORD:
-        required: true
+    # Wave A (v2.6.x) — keyless OIDC: no secrets required.
+    # The id-token: write permission below mints OIDC tokens on demand;
+    # cosign sign-blob exchanges them for a Fulcio cert at signing time.
 
 concurrency:
   group: sign-attest-${{ github.ref }}-${{ inputs.version || github.sha }}
@@ -130,25 +135,28 @@ jobs:
           fi
           echo "sha256 match: ${ACTUAL}  ${TARBALL}"
 
-      - name: cosign sign-blob
+      - name: cosign sign-blob (keyless OIDC)
         shell: bash
         env:
-          COSIGN_PRIVATE_KEY: ${{ secrets.COSIGN_PRIVATE_KEY }}
-          COSIGN_PASSWORD:    ${{ secrets.COSIGN_PASSWORD }}
+          COSIGN_YES: "true"
           VERSION:  ${{ steps.ver.outputs.version }}
           PLATFORM: ${{ matrix.platform }}
         run: |
           set -euo pipefail
           TARBALL="dist/autopg-${VERSION}-${PLATFORM}.tar.gz"
           SIG="${TARBALL}.sig"
+          CERT="${TARBALL}.cert"
 
+          # Keyless OIDC: cosign exchanges the workflow's id-token for a
+          # short-lived Fulcio certificate. The cert subject encodes the
+          # workflow path + ref, which trust-list.js anchors against.
           cosign sign-blob \
             --yes \
-            --key env://COSIGN_PRIVATE_KEY \
             --output-signature "${SIG}" \
+            --output-certificate "${CERT}" \
             "${TARBALL}"
 
-          echo "::notice::signed ${TARBALL} -> ${SIG}"
+          echo "::notice::signed ${TARBALL} (keyless) -> ${SIG} + ${CERT}"
 
       - name: cosign verify-blob (self-check)
         shell: bash
@@ -158,9 +166,16 @@ jobs:
         run: |
           set -euo pipefail
           TARBALL="dist/autopg-${VERSION}-${PLATFORM}.tar.gz"
+          # Keyless verify: anchor on this workflow's own path + a
+          # permissive ref-tail (covers tag refs in production runs and
+          # branch refs during workflow_run-internal CI). The strict
+          # consumer-facing trust regex in src/cosign/trust-list.js
+          # tightens this to refs/tags/v.*.
           cosign verify-blob \
-            --key keys/cosign.pub \
+            --certificate-identity-regexp "^https://github.com/${{ github.repository }}/.github/workflows/sign-attest.yml@" \
+            --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
             --signature "${TARBALL}.sig" \
+            --certificate "${TARBALL}.cert" \
             "${TARBALL}"
 
       - name: Generate SLSA build provenance
@@ -194,6 +209,7 @@ jobs:
             dist/autopg-${{ steps.ver.outputs.version }}-${{ matrix.platform }}.tar.gz
             dist/autopg-${{ steps.ver.outputs.version }}-${{ matrix.platform }}.tar.gz.sha256
             dist/autopg-${{ steps.ver.outputs.version }}-${{ matrix.platform }}.tar.gz.sig
+            dist/autopg-${{ steps.ver.outputs.version }}-${{ matrix.platform }}.tar.gz.cert
             dist/autopg-${{ steps.ver.outputs.version }}-${{ matrix.platform }}.tar.gz.intoto.jsonl
           retention-days: 14
           if-no-files-found: error
@@ -250,7 +266,7 @@ jobs:
         run: |
           bash scripts/verify-published-artifacts.sh dist/
 
-      - name: Fail if any tarball lacks sig + provenance
+      - name: Fail if any tarball lacks sig + cert + provenance
         shell: bash
         env:
           VERSION: ${{ steps.ver.outputs.version }}
@@ -258,7 +274,7 @@ jobs:
           set -euo pipefail
           MISSING=0
           for f in dist/autopg-${VERSION}-*.tar.gz; do
-            for ext in sig intoto.jsonl sha256; do
+            for ext in sig cert intoto.jsonl sha256; do
               if [[ ! -f "${f}.${ext}" ]]; then
                 echo "::error::missing ${f}.${ext}"
                 MISSING=$((MISSING + 1))
@@ -270,7 +286,7 @@ jobs:
             exit 1
           fi
 
-      - name: Upload aggregated bundle (handoff to Group 9)
+      - name: Upload aggregated bundle (handoff to release-publish)
         uses: actions/upload-artifact@v4
         with:
           name: autopg-signed-bundle-${{ steps.ver.outputs.version }}
@@ -278,8 +294,8 @@ jobs:
             dist/autopg-${{ steps.ver.outputs.version }}-*.tar.gz
             dist/autopg-${{ steps.ver.outputs.version }}-*.tar.gz.sha256
             dist/autopg-${{ steps.ver.outputs.version }}-*.tar.gz.sig
+            dist/autopg-${{ steps.ver.outputs.version }}-*.tar.gz.cert
             dist/autopg-${{ steps.ver.outputs.version }}-*.tar.gz.intoto.jsonl
             dist/manifest.json
-            keys/cosign.pub
           retention-days: 30
           if-no-files-found: error

--- a/src/cosign/trust-list.js
+++ b/src/cosign/trust-list.js
@@ -51,8 +51,15 @@ export const TRUSTED_IDENTITIES = Object.freeze([
     id: 'automagik-pgserve-release',
     publisher: 'pgserve',
     issuer: SIGSTORE_GITHUB_ACTIONS_ISSUER,
-    identityRegexp: '^https://github.com/namastexlabs/pgserve/.github/workflows/release.yml@refs/tags/v.*$',
-    description: 'Namastex automagik pgserve release workflow (GitHub Actions OIDC)',
+    // Wave A (v2.6.x): pgserve's signing happens in `sign-attest.yml`,
+    // not `release.yml` (which is the unrelated npm-publish workflow
+    // with zero cosign content). Renaming sign-attest.yml → release.yml
+    // would clobber that workflow, so we anchor the trust regex on
+    // sign-attest.yml instead. Mirror image of genie PR #1725 (binding
+    // release.yml@refs/tags/v* — same Sigstore identity discipline,
+    // different workflow filename).
+    identityRegexp: '^https://github.com/namastexlabs/pgserve/.github/workflows/sign-attest.yml@refs/tags/v.*$',
+    description: 'Namastex automagik pgserve sign-attest workflow (GitHub Actions OIDC)',
   }),
 ]);
 

--- a/tests/cosign/trust-list.test.js
+++ b/tests/cosign/trust-list.test.js
@@ -1,0 +1,126 @@
+/**
+ * Tests for the hardcoded TRUSTED_IDENTITIES list.
+ *
+ * Wave A (v2.6.x): regression coverage for the trust-regex anchor
+ * targets — must match the actual signing workflow file path on each
+ * producer (genie/omni use release.yml; pgserve uses sign-attest.yml
+ * because release.yml is the unrelated npm-publish pipeline).
+ */
+
+import { test, expect, describe } from 'bun:test';
+import {
+  TRUSTED_IDENTITIES,
+  SIGSTORE_GITHUB_ACTIONS_ISSUER,
+  getTrustedById,
+  getTrustedByPublisher,
+  listHardcodedTrust,
+} from '../../src/cosign/trust-list.js';
+
+describe('TRUSTED_IDENTITIES shape', () => {
+  test('is frozen — Object.freeze on the array and each entry', () => {
+    expect(Object.isFrozen(TRUSTED_IDENTITIES)).toBe(true);
+    for (const entry of TRUSTED_IDENTITIES) {
+      expect(Object.isFrozen(entry)).toBe(true);
+    }
+  });
+
+  test('every entry binds to the GitHub Actions OIDC issuer', () => {
+    for (const entry of TRUSTED_IDENTITIES) {
+      expect(entry.issuer).toBe(SIGSTORE_GITHUB_ACTIONS_ISSUER);
+    }
+  });
+
+  test('every entry has a non-empty id, identityRegexp, description', () => {
+    for (const entry of TRUSTED_IDENTITIES) {
+      expect(typeof entry.id).toBe('string');
+      expect(entry.id.length).toBeGreaterThan(0);
+      expect(typeof entry.identityRegexp).toBe('string');
+      expect(entry.identityRegexp.length).toBeGreaterThan(0);
+      expect(typeof entry.description).toBe('string');
+    }
+  });
+});
+
+describe('automagik-pgserve-release entry (Wave A regression)', () => {
+  test('anchors on sign-attest.yml (NOT release.yml)', () => {
+    const entry = getTrustedById('automagik-pgserve-release');
+    expect(entry).toBeTruthy();
+    // Wave A regression: anchor must match the actual signing workflow
+    // file. release.yml is pgserve's npm-publish workflow; the cosign
+    // signing pipeline lives in sign-attest.yml.
+    expect(entry.identityRegexp).toMatch(/sign-attest\.yml@/);
+    expect(entry.identityRegexp).not.toMatch(/release\.yml@/);
+    // refs/tags/v* binding is preserved (mirror of genie PR #1725).
+    expect(entry.identityRegexp).toMatch(/refs\/tags\/v\.\*\$/);
+  });
+
+  test('matches a synthetic post-Wave-A cert subject', () => {
+    const entry = getTrustedById('automagik-pgserve-release');
+    const re = new RegExp(entry.identityRegexp);
+    expect(
+      re.test(
+        'https://github.com/namastexlabs/pgserve/.github/workflows/sign-attest.yml@refs/tags/v2.6.4',
+      ),
+    ).toBe(true);
+    // Must NOT match release.yml subjects (the unrelated npm workflow).
+    expect(
+      re.test(
+        'https://github.com/namastexlabs/pgserve/.github/workflows/release.yml@refs/tags/v2.6.4',
+      ),
+    ).toBe(false);
+    // Must NOT match a different repo with the same workflow filename.
+    expect(
+      re.test(
+        'https://github.com/someone-else/pgserve/.github/workflows/sign-attest.yml@refs/tags/v2.6.4',
+      ),
+    ).toBe(false);
+    // Must NOT match branch refs — only refs/tags/v.*.
+    expect(
+      re.test(
+        'https://github.com/namastexlabs/pgserve/.github/workflows/sign-attest.yml@refs/heads/main',
+      ),
+    ).toBe(false);
+  });
+
+  test('publisher is the bare "pgserve" name (matches package.json)', () => {
+    const entry = getTrustedById('automagik-pgserve-release');
+    expect(entry.publisher).toBe('pgserve');
+  });
+});
+
+describe('genie + omni entries (cohort siblings — regression sanity)', () => {
+  test('genie entry anchors on automagik-dev/genie release.yml@refs/tags/v.*', () => {
+    const entry = getTrustedById('automagik-genie-release');
+    expect(entry).toBeTruthy();
+    expect(entry.identityRegexp).toMatch(
+      /^\^https:\/\/github\.com\/automagik-dev\/genie\/\.github\/workflows\/release\.yml@refs\/tags\/v\.\*\$$/,
+    );
+  });
+
+  test('omni entry anchors on automagik-dev/omni release.yml@refs/tags/v.*', () => {
+    const entry = getTrustedById('automagik-omni-release');
+    expect(entry).toBeTruthy();
+    expect(entry.identityRegexp).toMatch(
+      /^\^https:\/\/github\.com\/automagik-dev\/omni\/\.github\/workflows\/release\.yml@refs\/tags\/v\.\*\$$/,
+    );
+  });
+});
+
+describe('lookup helpers', () => {
+  test('getTrustedById returns null for an unknown id', () => {
+    expect(getTrustedById('does-not-exist')).toBe(null);
+  });
+
+  test('getTrustedByPublisher returns null for an unknown publisher', () => {
+    expect(getTrustedByPublisher('@nope/none')).toBe(null);
+  });
+
+  test('listHardcodedTrust marks every entry as source=hardcoded removable=false', () => {
+    const list = listHardcodedTrust();
+    expect(list.length).toBe(TRUSTED_IDENTITIES.length);
+    for (const entry of list) {
+      expect(entry.source).toBe('hardcoded');
+      expect(entry.removable).toBe(false);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

**Wave A PR-A1** — closes the cert-binding correctness layer of the pgserve self-trust loop. Path Alpha + 2-PR split per engineer's recommended defaults. Plumbing layer (release-publish wiring + naming + race fix + E2E test) follows in **PR-A2**.

Addresses **Mismatches 1, 2, 5** from `ENGINEER-PIVOT-1-WAVE-A` audits (engineer paste-ready proposed-edits applied).

3 files / 178 insertions / 29 deletions.

## What this PR fixes

The trust-loop is currently RED end-to-end (verified by engineer T25 against v2.6.0 + v2.6.1). Three independent gaps:

| # | Gap | This PR's fix |
|---|-----|---------------|
| 1 | `sign-attest.yml` uses **keyed** cosign (COSIGN_PRIVATE_KEY/COSIGN_PASSWORD secrets) but `trust-list.js` expects **keyless** OIDC binding | **D1** — flip `cosign sign-blob` to keyless, ship `.cert` sidecar, switch verify-blob self-check to keyless flags |
| 2 | `trust-list.js` `automagik-pgserve-release` regex anchors on `release.yml@refs/tags/v.*` — but `release.yml` is pgserve's npm-publish workflow with zero cosign content | **D2** — re-anchor regex on `sign-attest.yml@refs/tags/v.*` (rename blocked by collision with the npm workflow) |
| 5 | `sign-attest.yml` `workflow_run` trigger has `branches: [main, 'wish/**']` filter that **excludes tag refs** — so `git push origin v*` fires build-tarballs but never sign-attest | **D4** — drop the `branches:` filter; workflow_run now fires on every successful build-tarballs run including tag pushes |

## What this PR does NOT fix (queued for PR-A2)

Without the **release-publish.yml** download-pattern wiring (D3) + the workflow_call shape between sign-attest and release-publish (D5), the new keyless `.sig`+`.cert` artifacts produced by sign-attest still don't reach the GitHub Release page. `pgserve verify <published-binary>` will still return FAIL until PR-A2 lands.

This PR is **intentionally scoped** to the cert-binding correctness layer so the YAML changes are reviewable in isolation.

## File-by-file

### `.github/workflows/sign-attest.yml` (+41 / -29)

- Header rewritten — keyless rationale, no-secrets-required, new artifact list (`.cert` sibling added)
- `on.workflow_run.branches:` filter dropped (D4)
- `workflow_call.secrets:` block dropped — keyless needs none (D1)
- `cosign sign-blob` step: drop `--key env://COSIGN_PRIVATE_KEY`, add `--output-certificate` for the Fulcio cert sidecar
- `cosign verify-blob (self-check)` step: switch from `--key keys/cosign.pub` to keyless flags (`--certificate-identity-regexp` anchored on `${{ github.repository }}/.github/workflows/sign-attest.yml@` + `--certificate-oidc-issuer` + `--certificate`)
- Per-platform `Upload signed bundle` step: include `.cert` sibling
- Aggregate `Fail if any tarball lacks sig + cert + provenance` step: extend required-extension list with `cert`
- Aggregate `Upload aggregated bundle` step: include `.cert`; **drop `keys/cosign.pub`** (no longer needed under keyless)

### `src/cosign/trust-list.js` (+9 / -2)

- `automagik-pgserve-release` `identityRegexp` flips from `release.yml@refs/tags/v.*` to `sign-attest.yml@refs/tags/v.*`
- Inline comment block explains why rename was rejected (release.yml collision with npm-publish workflow), with cross-ref to genie PR #1725
- Description updated to "sign-attest workflow"; entry `id` stays `automagik-pgserve-release` for log/diagnostic backwards compat

### `tests/cosign/trust-list.test.js` (NEW, +126)

11 tests, **100% function / 100% line coverage** on `src/cosign/trust-list.js`:
- Wave A regression: pgserve regex anchors on `sign-attest.yml` NOT `release.yml`
- Synthetic post-Wave-A cert subject matches; `release.yml` subjects, other-repo subjects, branch refs do NOT match
- Cohort sibling sanity: genie + omni regexes still anchor on their respective `release.yml@refs/tags/v.*`
- Lookup helpers (`getTrustedById` / `getTrustedByPublisher`) + `listHardcodedTrust` shape

## Test plan

- [x] `bun test tests/cosign/trust-list.test.js` — 11 pass, 100% coverage
- [x] `bun test tests/cosign/` — 100 pass, 267 expect() calls, zero regressions
- [x] `grep -nE 'COSIGN_PRIVATE_KEY|COSIGN_PASSWORD|--key |keys/cosign\.pub' .github/workflows/sign-attest.yml` — clean
- [x] `grep -cE -- '--certificate-identity-regexp|--certificate-oidc-issuer|--output-certificate' .github/workflows/sign-attest.yml` — 3 keyless refs present
- [ ] CI green
- [ ] Visual review of YAML diff (the workflow file is high-blast-radius)

## Out of scope (PR-A2 + PR-B follow-ups)

| | Surface | Mismatch |
|---|---------|----------|
| PR-A2 D3 | release-publish.yml download patterns | 3 |
| PR-A2 D5 | sign-attest.yml workflow_call into release-publish | 4 |
| PR-A2 D6 | release.yml drop `gh release create` (Option 1) | 7 |
| PR-A2 D7 | naming reconciliation (autopg-* shape on uploads) | brief D2 |
| PR-A2 D8 | release-time tarball-content sanity check | brief D3 |
| PR-A2 D9 | E2E CI test job + tests/integration/wave-a-e2e.test.sh | brief D4 |
| PR-B D10 | npm provenance flip | 6 |
| PR-B D11 | docs/security/cosign-trust.md | brief D5 + 8 |
| PR-B D12 | Drop COSIGN_PRIVATE_KEY/COSIGN_PASSWORD repo secrets | post-D1 cleanup |
| PR-B D13 | Delete keys/cosign.pub from repo | post-D1 cleanup |

## Cross-references

- `agents/genie-pgserve/PROPOSED-EDIT-SIGN-ATTEST-KEYLESS.md` — engineer paste-ready
- `agents/genie-pgserve/PROPOSED-EDIT-TRUST-LIST-PGSERVE-REGEX.md` — engineer paste-ready
- `agents/genie-pgserve/ENGINEER-PIVOT-1-WAVE-A-AUDIT-DEEPER.md` — full mismatch table
- `agents/genie-pgserve/SIGNED-APPS-MISSION-STATE.md` — Wave A scope
- genie PR #1725 — mirror (release.yml @refs/tags/v* binding fix on the producer side)

🤖 Generated with [Claude Code](https://claude.com/claude-code)