### PR TITLE
feat(release): Wave A PR-A2 — release-publish wiring + race-fix + sanity check

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -47,6 +47,15 @@ on:
       version:
         description: 'Version to publish (e.g. 2.6.2)'
         required: true
+      sign_run_id:
+        description: |
+          Workflow run ID of the upstream "Sign + Attest Tarballs (autopg)"
+          run that produced the autopg-signed-bundle-<version> artifact.
+          Find it via:
+            gh run list --workflow "Sign + Attest Tarballs (autopg)" --limit 5
+          REQUIRED for manual dispatch — there's no automatic upstream
+          run-id resolution outside the workflow_run trigger path.
+        required: true
       channel:
         description: 'Release channel'
         required: true
@@ -70,6 +79,10 @@ permissions:
   contents: write              # gh release create
   id-token: write              # cosign keyless OIDC (if re-signing)
   attestations: write          # actions/attest-build-provenance@v1
+  actions: read                # cross-run download via `run-id` requires
+                               # this — when an explicit permissions block
+                               # is present, unlisted scopes are denied,
+                               # so we must enumerate every scope we use.
 
 jobs:
   publish:
@@ -126,11 +139,10 @@ jobs:
           name: autopg-signed-bundle-${{ steps.ver.outputs.version }}
           path: dist/
           # Cross-workflow downloads need the upstream run-id +
-          # github-token. workflow_run gives us the run-id for free;
-          # workflow_dispatch falls back to the current run (where the
-          # bundle would have been uploaded if release-publish were ever
-          # invoked inline — currently always cross-workflow).
-          run-id: ${{ github.event.workflow_run.id || github.run_id }}
+          # github-token. workflow_run gives us the run-id for free
+          # (github.event.workflow_run.id); manual dispatch operators
+          # must supply it via the `sign_run_id` input.
+          run-id: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.id || inputs.sign_run_id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: List release assets

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -5,33 +5,47 @@
 # is free, maintained by GitHub, and `gh attestation verify` reads cosign
 # signatures from Sigstore Rekor without any custom verification server.
 #
-# Trigger: tag push `v*` OR manual dispatch.
+# Trigger: runs after `sign-attest.yml` completes successfully (workflow_run)
+# OR on manual dispatch. The workflow_run trigger ensures the signing
+# artifacts exist BEFORE release-publish attempts to attach them — closes
+# the race window that previously shipped releases with no signing siblings.
 #
-# Pipeline (chained from build-tarballs.yml + sign-attest.yml on the same tag):
-#   1. Download per-platform tarballs from build-tarballs.yml artifacts
-#   2. Download cosign signatures + SLSA attestations from sign-attest.yml artifacts
-#   3. Create GitHub Release (draft until manual promotion) with all assets attached
+# Pipeline:
+#   1. Download `autopg-signed-bundle-<version>` aggregate artifact from
+#      sign-attest.yml's upstream workflow_run (contains tarballs + sha256 +
+#      sig + cert + intoto.jsonl + manifest.json — everything in one fetch)
+#   2. Sanity-check: every tarball must have its sig + cert + intoto.jsonl
+#      + sha256 siblings before any release upload happens
+#   3. Create GitHub Release (draft until manual promotion) with all assets
 #   4. Update `latest.json` channel pointer in the repo (committed, served via
 #      raw.githubusercontent.com — install.sh reads this for stable/beta/canary
 #      resolution)
 #
 # Verification by consumers:
 #   gh release download v<version> --repo namastexlabs/pgserve --pattern '*.tar.gz'
-#   gh attestation verify autopg-<platform>.tar.gz --owner namastexlabs
-#   # OR via cosign:
-#   cosign verify-blob --bundle autopg-<platform>.tar.gz.bundle autopg-<platform>.tar.gz
+#   pgserve verify autopg-<v>-<platform>.tar.gz
+#   # OR raw cosign keyless:
+#   cosign verify-blob \
+#     --certificate-identity-regexp '^https://github.com/namastexlabs/pgserve/.github/workflows/sign-attest.yml@refs/tags/v.*$' \
+#     --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \
+#     --signature autopg-<v>-<platform>.tar.gz.sig \
+#     --certificate autopg-<v>-<platform>.tar.gz.cert \
+#     autopg-<v>-<platform>.tar.gz
 # ============================================================================
 
 name: release-publish
 
 on:
-  push:
-    tags:
-      - 'v*'
+  workflow_run:
+    workflows: ["Sign + Attest Tarballs (autopg)"]
+    types: [completed]
+    # No `branches:` filter — let workflow_run fire on every successful
+    # sign-attest run, including tag refs (Wave A PR-A1 Mismatch 5 fix
+    # mirror — same logic as sign-attest.yml's own trigger).
   workflow_dispatch:
     inputs:
       version:
-        description: 'Version to publish (e.g. 2.5.0)'
+        description: 'Version to publish (e.g. 2.6.2)'
         required: true
       channel:
         description: 'Release channel'
@@ -62,17 +76,32 @@ jobs:
     name: Publish to GitHub Releases
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    # On workflow_run trigger only fire if the upstream sign-attest run
+    # succeeded. workflow_dispatch path has no upstream and falls through.
+    if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          # On workflow_run, the head_sha is the commit sign-attest ran
+          # against; use it so latest.json updates happen on the right ref.
+          ref: ${{ github.event.workflow_run.head_sha || github.ref }}
 
       - name: Resolve version
         id: ver
+        env:
+          # workflow_run carries the upstream's head_branch which is the
+          # tag name (e.g. `v2.6.4`) for tag-triggered runs.
+          UPSTREAM_BRANCH: ${{ github.event.workflow_run.head_branch }}
         run: |
           if [ -n "${{ inputs.version }}" ]; then
             echo "version=${{ inputs.version }}" >> "$GITHUB_OUTPUT"
+          elif [ -n "${UPSTREAM_BRANCH}" ]; then
+            # workflow_run: strip leading `v` if present
+            echo "version=${UPSTREAM_BRANCH#v}" >> "$GITHUB_OUTPUT"
           else
-            # Strip leading `v` from tag ref
-            echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+            # Manual dispatch fallback: read package.json
+            VER=$(node -p "require('./package.json').version")
+            echo "version=${VER}" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Resolve channel
@@ -85,25 +114,55 @@ jobs:
             echo "channel=stable" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Download tarball artifacts (build-tarballs.yml)
+      - name: Download signed bundle aggregate (sign-attest.yml)
         uses: actions/download-artifact@v4
         with:
-          pattern: autopg-*-tarball
-          merge-multiple: true
+          # sign-attest.yml's aggregate job uploads ONE artifact named
+          # `autopg-signed-bundle-<version>` containing every per-platform
+          # tarball + sha256 + sig + cert + intoto.jsonl + manifest.json.
+          # Single download replaces the prior pair of broken patterns
+          # (`autopg-*-tarball`, `autopg-*-signed`) that didn't match
+          # any real artifact name.
+          name: autopg-signed-bundle-${{ steps.ver.outputs.version }}
           path: dist/
-
-      - name: Download signature artifacts (sign-attest.yml)
-        uses: actions/download-artifact@v4
-        with:
-          pattern: autopg-*-signed
-          merge-multiple: true
-          path: dist/
-        continue-on-error: true   # sign-attest.yml may not have run on dispatch
+          # Cross-workflow downloads need the upstream run-id +
+          # github-token. workflow_run gives us the run-id for free;
+          # workflow_dispatch falls back to the current run (where the
+          # bundle would have been uploaded if release-publish were ever
+          # invoked inline — currently always cross-workflow).
+          run-id: ${{ github.event.workflow_run.id || github.run_id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: List release assets
         run: |
           echo "=== dist/ ==="
           ls -la dist/ || true
+
+      - name: Sanity-check signed bundle siblings (Wave A PR-A2 D8)
+        env:
+          VERSION: ${{ steps.ver.outputs.version }}
+        run: |
+          set -euo pipefail
+          MISSING=0
+          shopt -s nullglob
+          TARBALLS=(dist/autopg-${VERSION}-*.tar.gz)
+          if [ ${#TARBALLS[@]} -eq 0 ]; then
+            echo "::error::no autopg-${VERSION}-*.tar.gz tarballs in dist/ — sign-attest bundle is empty"
+            exit 1
+          fi
+          for tb in "${TARBALLS[@]}"; do
+            for ext in sig cert intoto.jsonl sha256; do
+              if [ ! -f "${tb}.${ext}" ]; then
+                echo "::error::missing ${tb}.${ext}"
+                MISSING=$((MISSING + 1))
+              fi
+            done
+          done
+          if [ "${MISSING}" -gt 0 ]; then
+            echo "::error::${MISSING} required sibling files missing — refusing to publish a release without signing material"
+            exit 1
+          fi
+          echo "::notice::all ${#TARBALLS[@]} tarballs have complete sig + cert + intoto.jsonl + sha256 siblings"
 
       - name: Create GitHub Release with all assets
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -223,10 +223,22 @@ jobs:
       # On the push path nobody creates the tag before this runs; the
       # SHA-based checkout works because the merge commit already has the
       # bumped package.json. The tag is pushed by the bump job (when
-      # workflow_dispatch is used) OR by the human merge (when push event
-      # carries an annotated tag). GitHub Release creation now flows
+      # workflow_dispatch is used). GitHub Release creation now flows
       # through `release-publish.yml` exclusively — see "Release job
       # removed" note below.
+      #
+      # KNOWN LIMITATION (Wave A PR-A2 follow-up): the push-to-main flow
+      # NO LONGER creates a tag automatically. The dropped `release` job
+      # was creating the tag via `gh release create v${VERSION}` against
+      # HEAD; without it, push-event runs of release.yml will npm-publish
+      # but produce no tag → no `build-tarballs → sign-attest →
+      # release-publish` chain → no GitHub Release.
+      #
+      # Workaround until a tag-creation step lands: route releases via
+      # workflow_dispatch (the bump job creates and pushes the tag,
+      # which then fires build-tarballs → sign-attest → release-publish).
+      # This matches Felipe's current operational practice (all recent
+      # v2.x releases were cut via workflow_dispatch, not push-to-main).
       ref: ${{ needs.prepare.outputs.ref }}
     secrets: inherit
 
@@ -255,8 +267,13 @@ jobs:
   # operators need them, future PR-A3+ (D7 naming reconciliation) can
   # route them through release-publish.
   #
-  # Tag creation itself is unaffected: the `bump` job (workflow_dispatch
-  # path) and the human merge commit (push path) both still create the
-  # tag. release-publish.yml's `on: push: tags: ['v*']` trigger picks
-  # up the tag and creates the Release with signed artifacts.
+  # Tag creation on the WORKFLOW_DISPATCH path is unaffected — the
+  # `bump` job creates and pushes the tag. release-publish.yml fires
+  # on `workflow_run` after sign-attest completes, picks up the tag
+  # via the upstream `workflow_run.head_branch`, and creates the
+  # GitHub Release with signed artifacts.
+  #
+  # Tag creation on the PUSH path is NOT covered here anymore — see
+  # known limitation in `build` job above. If push-to-main releases
+  # are required, route them through `workflow_dispatch` instead.
   # ---------------------------------------------------------------------------

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -222,68 +222,41 @@ jobs:
       # `needs.bump.*` directly — only `prepare` is in its `needs:` chain.
       # On the push path nobody creates the tag before this runs; the
       # SHA-based checkout works because the merge commit already has the
-      # bumped package.json. The release job creates the tag at the end
-      # via `gh release create`.
+      # bumped package.json. The tag is pushed by the bump job (when
+      # workflow_dispatch is used) OR by the human merge (when push event
+      # carries an annotated tag). GitHub Release creation now flows
+      # through `release-publish.yml` exclusively — see "Release job
+      # removed" note below.
       ref: ${{ needs.prepare.outputs.ref }}
     secrets: inherit
 
   # ---------------------------------------------------------------------------
-  # Release: download artifacts, create GitHub Release with cliff-free notes.
+  # Release job — REMOVED in Wave A PR-A2 (Mismatch 7 Option 1).
+  #
+  # Previously this job created the GitHub Release with the pgserve-*
+  # single-file binaries. release-publish.yml ALSO creates a GitHub
+  # Release on the same tag with the autopg-*.tar.gz tarballs +
+  # cosign signing artifacts. Both ran `gh release create` without
+  # cross-workflow idempotency → race:
+  #   - if this job won: release-publish fell through to upload --clobber
+  #     and the release ended up with BOTH naming conventions on the
+  #     same tag (operator confusion)
+  #   - if release-publish won: this job's gh release create failed with
+  #     "already exists", turning the release.yml run red even though
+  #     everything succeeded
+  #
+  # Option 1 (recommended by engineer DEEPER-AUDIT, accepted by Felipe):
+  # drop this job entirely. release-publish.yml owns all GH-Releases
+  # creation. release.yml retains only bump + build + npm publish.
+  #
+  # The single-file pgserve-* binaries previously attached here are NOT
+  # currently re-attached by release-publish.yml — they're a development
+  # artifact, not the canonical production distribution surface. If
+  # operators need them, future PR-A3+ (D7 naming reconciliation) can
+  # route them through release-publish.
+  #
+  # Tag creation itself is unaffected: the `bump` job (workflow_dispatch
+  # path) and the human merge commit (push path) both still create the
+  # tag. release-publish.yml's `on: push: tags: ['v*']` trigger picks
+  # up the tag and creates the Release with signed artifacts.
   # ---------------------------------------------------------------------------
-  release:
-    name: Create GitHub Release
-    needs: [prepare, build]
-    if: |
-      always() &&
-      needs.prepare.result == 'success' &&
-      needs.build.result == 'success' &&
-      needs.prepare.outputs.skip != 'true'
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          # Same as the build job: prefer the bump job's tag (dispatch
-          # path) but fall back to the SHA (push path, no tag exists yet).
-          ref: ${{ needs.prepare.outputs.ref }}
-
-      - name: Download binaries
-        uses: actions/download-artifact@v4
-        with:
-          path: dist/
-          pattern: binaries-*
-          merge-multiple: true
-
-      - name: List artifacts
-        run: ls -la dist/
-
-      - name: Create release
-        env:
-          GH_TOKEN: ${{ github.token }}
-          RELEASE_NOTES: ${{ needs.prepare.outputs.changelog }}
-        run: |
-          TAG="${{ needs.prepare.outputs.tag }}"
-          VERSION="${{ needs.prepare.outputs.version }}"
-
-          if [ -z "$RELEASE_NOTES" ]; then
-            RELEASE_NOTES="Release ${TAG}"
-          fi
-
-          {
-            echo "$RELEASE_NOTES"
-            echo ""
-            echo "## Install"
-            echo ""
-            echo '```bash'
-            echo "npm install pgserve@${VERSION}"
-            echo "bunx pgserve@${VERSION}"
-            echo '```'
-          } > /tmp/release-notes.md
-
-          # The tag already exists (created by bump job on dispatch, or by the
-          # human commit on push). gh release create resolves --target via the
-          # tag automatically when omitted.
-          gh release create "${TAG}" \
-            --title "${TAG}" \
-            --notes-file /tmp/release-notes.md \
-            dist/*


### PR DESCRIPTION
## Summary

**Wave A PR-A2** — plumbs the new signing artifacts from sign-attest.yml through release-publish.yml to the GitHub Release page, and removes the `gh release create` race between release.yml and release-publish.yml. Builds on **PR #114** (Wave A PR-A1 trust-loop core).

After this lands + the next pgserve release tag cuts, `pgserve verify <published-binary>` should return **OK** end-to-end (Wave A S3 acceptance flips from RED → GREEN).

Addresses **Mismatches 3, 4, 7** from `ENGINEER-PIVOT-1-WAVE-A-AUDIT-DEEPER.md`. 2 files / 117 insertions / 85 deletions.

## What this PR fixes

| # | Gap | Fix |
|---|-----|-----|
| 3 | `release-publish.yml` download patterns (`autopg-*-tarball`, `autopg-*-signed`) don't match any real artifact name | **D3** — single download of `autopg-signed-bundle-<version>` (aggregate from sign-attest.yml; contains everything) |
| 4 | release-publish.yml triggers on tag push but sign-attest.yml runs async via workflow_run on build-tarballs completion — release-publish was racing the signing pipeline and shipping releases with no signing artifacts | **D5** — change trigger to `workflow_run` on "Sign + Attest Tarballs (autopg)" completion; guard `if:` ensures upstream succeeded |
| 7 | `release.yml` and `release-publish.yml` BOTH ran `gh release create` on the same tag — race produced either red runs or releases with mixed `pgserve-*` + `autopg-*` naming | **D6** — drop the entire `release` job from release.yml (Option 1, engineer-recommended); release-publish.yml owns all GH-Releases creation |
| — | No release-time guard that signing material is complete | **D8** — sanity-check step in release-publish.yml verifies every tarball has its `.sig` + `.cert` + `.intoto.jsonl` + `.sha256` siblings BEFORE `gh release create` |

## File-by-file

### `.github/workflows/release-publish.yml` (+74 / -27)

- Header rewritten: workflow_run trigger rationale, single-aggregate download, new pipeline diagram, post-Wave-A `cosign verify-blob` example (keyless flags)
- Trigger changed from `push: tags: ['v*']` to `workflow_run` on "Sign + Attest Tarballs (autopg)" completion
- `publish` job gains `if:` guard skipping when upstream sign-attest failed
- Checkout uses `github.event.workflow_run.head_sha || github.ref`
- Version resolved from `github.event.workflow_run.head_branch` (the tag name) with `package.json` fallback for manual dispatch
- Two old broken download steps replaced with one: `name: autopg-signed-bundle-<version>` (no glob pattern; explicit), with `run-id: github.event.workflow_run.id` + `github-token: secrets.GITHUB_TOKEN` for cross-workflow fetch
- New "Sanity-check signed bundle siblings" step (D8) — verifies every `autopg-<v>-<plat>.tar.gz` has its `.sig` + `.cert` + `.intoto.jsonl` + `.sha256` companions before any upload happens

### `.github/workflows/release.yml` (+43 / -58)

- Entire `release` job removed (lines 230-289 in pre-edit file). Replaced with a multi-paragraph comment explaining why (Mismatch 7 Option 1, engineer-recommended, Felipe-greenlit) and what happens to the single-file `pgserve-*` Bun binaries (currently dropped from the release page; route through release-publish in a future D7 if operators need them).
- `build` job comment updated to reflect that tag-on-release-job is gone (tag still flows from `bump` job on dispatch path / human merge on push path).

## How the new release flow works

```
git push origin v2.6.4
     ├── triggers `release.yml`           → bump + build + npm publish
     │     (no GH Release creation here anymore)
     │
     └── triggers `build-tarballs.yml`    → builds + uploads autopg-2.6.4-<plat> artifacts
           │
           └── workflow_run triggers `sign-attest.yml`   → keyless cosign sign + SLSA L3 attest
                 │                                          uploads autopg-signed-bundle-2.6.4
                 │
                 └── workflow_run triggers `release-publish.yml`
                       ├── downloads autopg-signed-bundle-2.6.4 (cross-run fetch)
                       ├── sanity-checks every tarball has sig + cert + intoto.jsonl + sha256
                       ├── gh release create v2.6.4 + uploads all assets
                       └── updates .well-known/latest.json on main (stable channel only)
```

## Test plan

- [x] `bun test tests/cosign/` — 100 pass, zero regressions (this PR is workflow-only)
- [x] `grep -nE 'autopg-\*-tarball|autopg-\*-signed' .github/workflows/release-publish.yml` — clean (no broken patterns)
- [x] `grep -c '^  release:' .github/workflows/release.yml` — 0 (release job dropped)
- [x] release.yml jobs intact: `bump`, `prepare`, `build` still present
- [ ] CI green
- [ ] Next pgserve release tag cuts → operator runs `pgserve verify <published-binary>` → returns OK (Wave A S3 acceptance)

## Out of scope (PR-A3 + PR-B follow-ups)

| Deliverable | Surface | Notes |
|---|---|---|
| D7 — naming reconciliation finalization | release-publish.yml | implicitly satisfied by D6 (only autopg-* now); if pgserve-* binaries need to come back, route via release-publish in PR-A3 |
| D9 — E2E CI test job + tests/integration/wave-a-e2e.test.sh | new file + ci.yml | local build → sign → verify round-trip; catches regressions before they reach the published release |
| D10 — npm provenance flip | version.yml | `NPM_CONFIG_PROVENANCE: "true"` (or move to gh-hosted runner) |
| D11 — docs/security/cosign-trust.md | docs/ | operator-facing trust-anchor reference + binary-vs-tarball doc clarification |
| D12 — Drop COSIGN_PRIVATE_KEY/COSIGN_PASSWORD repo secrets | gh CLI | `gh secret delete COSIGN_PRIVATE_KEY/COSIGN_PASSWORD` after a release confirms keyless works |
| D13 — Delete keys/cosign.pub from repo | git rm | no longer referenced by any workflow after PR-A1 |

## Cross-references

- PR #114 — Wave A PR-A1 trust-loop core (prerequisite)
- `agents/genie-pgserve/ENGINEER-PIVOT-1-WAVE-A-AUDIT-DEEPER.md` — full mismatch table
- `agents/genie-pgserve/SIGNED-APPS-MISSION-STATE.md` — Wave A scope
- engineer T25 — quantitative verify of zero-signing-artifacts state against v2.6.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced release publishing process and artifact validation reliability.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/namastexlabs/pgserve/pull/115)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->