### PR TITLE
feat(release): Wave A PR-B D10 — enable npm-side provenance

### DIFF
--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -198,18 +198,27 @@ jobs:
             echo "published=false" >> $GITHUB_OUTPUT
           fi
 
-      - name: Publish to npm via OIDC
+      - name: Publish to npm via OIDC + provenance
         if: steps.check.outputs.published == 'false'
         env:
           HUSKY: "0"
-          # npm auto-enables provenance in any CI env with `id-token: write`,
-          # regardless of the --provenance CLI flag. On some runners the
-          # server-side sigstore check fails with 422; disable explicitly.
-          # OIDC token exchange still happens.
-          NPM_CONFIG_PROVENANCE: "false"
+          # Wave A PR-B D10 — enable npm-side provenance.
+          # We run on github-hosted ubuntu-latest with `id-token: write` +
+          # Trusted Publisher OIDC configured at npmjs.com. The prior
+          # NPM_CONFIG_PROVENANCE: "false" workaround was carried over
+          # from self-hosted-runner experiments where the sigstore
+          # server-side check 422'd; that path no longer applies. With
+          # provenance: true, npm publishes a Sigstore-backed provenance
+          # statement alongside the tarball, queryable via:
+          #   npm view pgserve@<v> dist.attestations
+          #   gh attestation verify <tarball> --owner namastexlabs
+          # If the registry-side sigstore check ever 422s in production,
+          # flip back to "false" and file a follow-up ticket; the keyless
+          # cosign tarball signing pipeline is independent and unaffected.
+          NPM_CONFIG_PROVENANCE: "true"
         run: |
-          echo "Publishing version ${{ inputs.version }} with tag ${{ inputs.npm_tag }} via OIDC"
-          npm publish --access public --tag ${{ inputs.npm_tag }}
+          echo "Publishing version ${{ inputs.version }} with tag ${{ inputs.npm_tag }} via OIDC + provenance"
+          npm publish --access public --tag ${{ inputs.npm_tag }} --provenance
 
       - name: Verify publish
         if: steps.check.outputs.published == 'false'

--- a/docs/security/cosign-trust.md
+++ b/docs/security/cosign-trust.md
@@ -156,7 +156,7 @@ cosign verify-blob \
 
 Expected: `Verified OK`.
 
-### SLSA L3 provenance verification
+### SLSA L3 provenance verification (GitHub Releases tarballs)
 
 ```bash
 gh attestation verify autopg-2.6.4-linux-x64-glibc.tar.gz --owner namastexlabs
@@ -164,6 +164,31 @@ gh attestation verify autopg-2.6.4-linux-x64-glibc.tar.gz --owner namastexlabs
 
 Checks the inline `.intoto.jsonl` provenance bundle against Sigstore Rekor.
 Asserts: this exact tarball was produced by this exact build job run.
+
+### npm-side provenance (registry tarballs)
+
+The npm registry separately signs the `pgserve` tarball via npm's Trusted
+Publisher OIDC integration. Operators verifying an `npm install` tarball:
+
+```bash
+# Inspect provenance attached to a registry version
+npm view pgserve@2.6.4 dist.attestations
+
+# Or download + verify via gh attestation
+npm pack pgserve@2.6.4
+gh attestation verify pgserve-2.6.4.tgz --owner namastexlabs
+```
+
+This is **separate from** the cosign signing pipeline that produces
+GitHub Releases tarballs (`autopg-<v>-<plat>.tar.gz` siblings). npm
+provenance covers the `npm install` path; cosign covers the
+`gh release download` path. Both flow through Sigstore Rekor; together
+they cover both distribution surfaces.
+
+Releases through v2.6.x (pre-D10) shipped without npm provenance — the
+publish workflow set `NPM_CONFIG_PROVENANCE: "false"` as a workaround
+for a sigstore-server 422 issue on self-hosted runners that no longer
+applies. v2.6.x+1 onward emit provenance.
 
 ## Adding a custom trust root (operator)
 


### PR DESCRIPTION
## Summary

Closes **Wave A PR-B D10** — flips `NPM_CONFIG_PROVENANCE` from `"false"` to `"true"` in `version.yml`'s npm publish step + adds `--provenance` CLI flag explicitly. Documents npm-side provenance verification in `docs/security/cosign-trust.md`.

2 files / 43 insertions / 9 deletions. Behavior change on the npm publish path.

## Why now

- The original `false` setting was carried over from a self-hosted-runner experiment where the sigstore server-side check returned 422. **pgserve's actual publish job runs on github-hosted `ubuntu-latest`** (line 113 of `version.yml`) with `id-token: write` + Trusted Publisher OIDC configured at npmjs.com — the 422 path no longer applies.
- Engineer `ENGINEER-PIVOT-1-WAVE-A-AUDIT-DEEPER.md` Mismatch 6 flagged this as a sibling cohort issue, deferred to PR-B.

## After this lands

- `npm publish` emits a Sigstore-backed provenance statement alongside the registry tarball.
- Operators verify via:
  ```bash
  npm view pgserve@<v> dist.attestations
  # OR
  npm pack pgserve@<v>
  gh attestation verify pgserve-<v>.tgz --owner namastexlabs
  ```
- Covers the `npm install pgserve` distribution surface (the cosign pipeline covers the `gh release download` surface). Both flow through Sigstore Rekor.

## File changes

### `.github/workflows/version.yml` (+13 / -8)

- `NPM_CONFIG_PROVENANCE: "false"` → `"true"`
- `npm publish --access public --tag <tag>` → `npm publish --access public --tag <tag> --provenance`
- Step renamed `Publish to npm via OIDC` → `Publish to npm via OIDC + provenance`
- Inline comment rewritten — explains why the 422 workaround was historical, what `provenance: true` produces, what to do if the registry 422s again (flip back + file ticket; cosign pipeline unaffected)

### `docs/security/cosign-trust.md` (+26 / -1)

- SLSA L3 verification section split into two:
  - **GitHub Releases tarballs**: cosign + `.intoto.jsonl` via `gh attestation verify`
  - **npm registry tarballs**: Trusted Publisher OIDC via `npm view <pkg>@<v> dist.attestations` OR `gh attestation verify`
- Notes that releases through v2.6.x (pre-D10) shipped without npm provenance; v2.6.x+1 onward emit provenance.

## Risk + rollback

If the registry 422s in production:
- **Symptom**: `npm publish --provenance` fails before the package appears on npmjs.com (the OIDC token exchange succeeds; the sigstore-server-side step fails)
- **Quick fix**: revert this PR or flip `NPM_CONFIG_PROVENANCE` back to `"false"` + drop the `--provenance` flag
- **Independence**: the cosign-keyless GitHub Releases pipeline (PRs #114/#115/#117/#118) is independent and unaffected by an npm registry 422

## Wave A status after this PR

| Layer | PR | State |
|---|---|---|
| Trust-loop core (D1+D2+D4) | #114 | ✅ merged |
| Plumbing (D3+D5+D6+D8) | #115 | ✅ merged |
| Docs (D11) | #116 | ✅ merged |
| E2E CI gate (D9) | #117 | ✅ merged |
| Script keyless + D13 closure | #118 | ✅ merged |
| **npm provenance (D10)** | **this PR** | ⏳ open |
| Naming finalize (D7) | — | implicit after #115 |
| Secret cleanup (D12) | — | manual `gh secret delete` (admin perms) |

After this lands, **Wave A is done end-to-end on the code/infrastructure side**. Only D12 remains, and it's a single-command admin operation by Felipe.

## Test plan

- [x] `grep -nE 'NPM_CONFIG_PROVENANCE|--provenance' .github/workflows/version.yml` — confirms `"true"` + `--provenance` flag present
- [ ] CI green
- [ ] Next pgserve release tag cut — operator runs `npm view pgserve@<v> dist.attestations` → returns a non-empty attestation array

🤖 Generated with [Claude Code](https://claude.com/claude-code)