### PR TITLE
docs: V3-3 — fix hallucinated docs (npm direction + fictional trust subsystems)

### DIFF
--- a/docs/migrations/v2.6-from-v2.5.md
+++ b/docs/migrations/v2.6-from-v2.5.md
@@ -76,21 +76,26 @@ continue to work unchanged.
 
 If you want to opt into the new surface:
 
-1. **Upgrade the package**:
+1. **Install or update via the canonical installer** (cosign-verified GitHub
+   Releases tarball):
    ```bash
-   npm install -g pgserve@2.6.x
-   # OR for project pins:
-   npm install pgserve@^2.6.0
+   curl -fsSL https://raw.githubusercontent.com/namastexlabs/pgserve/main/install.sh | bash
+   # Pin a specific version:
+   PGSERVE_VERSION=v2.6.1 curl -fsSL https://raw.githubusercontent.com/namastexlabs/pgserve/main/install.sh | bash
+   # Dry-run (print actions without executing):
+   bash install.sh --dry-run
    ```
+   The installer fetches the per-platform tarball from
+   `github.com/namastexlabs/pgserve/releases/download/v<version>/`, verifies
+   the cosign attestation via `gh attestation verify`, then runs
+   `pgserve install` to wire pm2 supervision.
 
 2. **Verify the install**:
    ```bash
    pgserve doctor --json
    ```
    Every check should report `PASS` or `WARN` — zero `FAIL`. If a check fails,
-   the JSON output describes the remediation. See
-   [`docs/trust-store.md`](../trust-store.md) for trust-store doctor checks
-   specifically.
+   the JSON output describes the remediation.
 
 3. **(Optional) Register your app for manifest LOCK 1**:
    ```bash
@@ -103,10 +108,14 @@ If you want to opt into the new surface:
 
 4. **(Optional) Add a custom trust root**:
    ```bash
-   pgserve trust add <identity-regex>
+   pgserve trust add my-org-release \
+       --issuer https://token.actions.githubusercontent.com \
+       --identity-regexp '^https://github.com/my-org/my-app/.github/workflows/release.yml@refs/tags/v.*$' \
+       --publisher '@my-org/my-app' \
+       --description 'My organization release pipeline'
    pgserve trust list
    ```
-   See [`docs/trust-store.md`](../trust-store.md) for the trust-store schema
+   See [`docs/trust-store.md`](../trust-store.md) for the full CLI reference
    and the precedence rules between built-in and user-extensible roots.
 
 ## What NOT to change
@@ -119,17 +128,18 @@ If you want to opt into the new surface:
   `pgserve gc` — they handle the advisory-lock + audit-log invariants.
 - **Do not replace `~/.pgserve/trust/identities.json` wholesale.** Use
   `pgserve trust add/remove`. The format is documented in
-  [`docs/trust-store.md`](../trust-store.md) but the verbs ensure schema
-  validity + audit logging.
+  [`docs/trust-store.md`](../trust-store.md); the verbs ensure schema
+  validity + hardcoded-id shadow refusal.
 
 ## Rollback
 
 `pgserve` 2.6.x does not perform any destructive schema changes against
 `pgserve_meta` (existing column shape is preserved; `autopg_meta` is purely
-additive). To roll back:
+additive). To roll back, re-run the installer with a pinned older version:
 
 ```bash
-npm install -g pgserve@2.5.0    # or your prior pin
+PGSERVE_VERSION=v2.5.0 curl -fsSL https://raw.githubusercontent.com/namastexlabs/pgserve/main/install.sh | bash
+# Or any prior pin you had verified.
 ```
 
 The new `~/.autopg/<slug>/` directories and `~/.pgserve/trust/identities.json`

--- a/docs/trust-store.md
+++ b/docs/trust-store.md
@@ -136,29 +136,40 @@ Exit codes:
 
 ## Doctor checks
 
-`pgserve doctor` reports:
+`pgserve doctor` currently does **not** probe the trust store. The supervisor,
+postmaster, pm2 wiring, and `~/.autopg/admin.json` shape are what doctor
+inspects today (see `src/commands/doctor.js`). Trust-store integrity checks
+(file modes, schema validity, publisher-match) are reserved for a future
+release — tracked under `pgserve-singleton-no-proxy` Group 6 (self-healing
+`pgserve update` pipeline) and its companion `doctor --fix` tiered modes.
 
-| Check | PASS / WARN / FAIL |
-|-------|--------------------|
-| `~/.pgserve/trust/` exists and mode 0700 | PASS / FAIL |
-| `~/.pgserve/trust/identities.json` mode 0600 (if present) | PASS / FAIL |
-| `identities.json` matches schema (if present) | PASS / FAIL |
-| At least one entry trusts a release workflow that matches `pgserve.publisher` from package.json | PASS / WARN |
+Until those land, operators verify the trust store manually:
 
-Use `pgserve doctor --json` to feed downstream tooling.
+```bash
+# Inspect the user-extensible store (JSON list)
+pgserve trust list --json | jq
+
+# Confirm hardcoded entries are present (regression sanity)
+pgserve trust list --json | jq '[.[] | select(.source == "hardcoded")] | length'
+# Expected: >= 3 (genie, omni, pgserve self-trust)
+
+# Confirm file mode is 0600 (manual check)
+stat -c '%a' ~/.pgserve/trust/identities.json 2>/dev/null || stat -f '%Lp' ~/.pgserve/trust/identities.json
+# Expected: 600
+```
 
 ## Audit
 
-Every `add` and `remove` invocation appends a line to
-`~/.pgserve/audit/trust-<YYYY-MM-DD>.log`:
+`pgserve trust add` and `pgserve trust remove` currently do **not** write
+a dedicated audit log. The user-extensible store at
+`~/.pgserve/trust/identities.json` is the audit trail itself: each entry
+carries an `addedAt` ISO-8601 timestamp populated by `validateEntry()` in
+`src/cosign/trust-store.js`. Removed entries are dropped without a tombstone.
 
-```
-2026-05-10T18:23:11.123Z trust.add  id=my-org-release publisher=@my-org/cli
-2026-05-10T18:24:02.456Z trust.remove id=my-org-release
-```
-
-The audit file rotates alongside `gc-<DATE>.log` (kept >0 days, deleted
-when older than 90 days at start of each gc/trust run).
+A dedicated `~/.pgserve/audit/trust-<DATE>.log` analogue to the `gc` audit
+log is tracked as a future enhancement under `pgserve-singleton-no-proxy`
+(no shipped wish today). Operators who need a separate trust-mutation
+audit log can wrap the verb in their own shell history capture until then.
 
 ## Cross-references
 


### PR DESCRIPTION
## Summary

Doc-only PR closing the hallucination ledger surfaced during the v3 audit. **Zero code changes.** 2 files / 51 insertions / 30 deletions.

Part of the **V3 (npm-departure) preparation**. Felipe's directive: *"publishing independently from npmjs, using install.sh + update cli command from now on"*. This PR clears stale npm-recommendation language from docs so v3 release notes don't reference contradictory upgrade paths.

## Three classes of fix

### 1. npm install → install.sh (direction correction)

`docs/migrations/v2.6-from-v2.5.md` had `npm install -g pgserve@2.6.x` + `npm install pgserve@^2.6.0` as the canonical upgrade path AND `npm install -g pgserve@2.5.0` as the rollback path. This contradicts `autopg-distribution-cutover-finalize` G1 Decision #1: install.sh is canonical.

Replaced with:
```bash
curl -fsSL https://raw.githubusercontent.com/namastexlabs/pgserve/main/install.sh | bash
# Pin: PGSERVE_VERSION=v2.6.1 curl ... | bash
# Dry-run: bash install.sh --dry-run
```

### 2. `pgserve trust add` example — wrong-syntax fix

Inline example showed `pgserve trust add <identity-regex>`. The verb (per `src/commands/trust.js:32`) requires `add <id> --issuer <url> --identity-regexp <re>`. Operators following the example would have exited 1 with `--issuer <url> is required`. Replaced with the full-syntax form.

### 3. `docs/trust-store.md` fictional subsystems — purged

The doc previously claimed two subsystems that **do not exist in code**:

| Hallucination | Reality | Fix |
|---|---|---|
| `pgserve doctor` checks trust-store dir mode, file mode, schema, publisher match (4-row table) | `grep -nE "trust/\|identities\.json" src/commands/doctor.js` → **zero matches** | Replaced table with accurate "doctor doesn't probe the trust store today" + 3-line manual operator workaround |
| `pgserve trust add/remove` writes `~/.pgserve/audit/trust-<YYYY-MM-DD>.log` rotating alongside `gc-<DATE>.log` | `src/cosign/trust-store.js` + `src/commands/trust.js` have **zero audit-log writes** | Replaced with accurate note: the per-entry `addedAt` ISO-8601 timestamp in `identities.json` IS the audit trail today; dedicated audit log is future work |

### 4. Trimmed an inaccurate "audit logging" claim

`docs/migrations/v2.6-from-v2.5.md` "What NOT to change" bullet about trust verbs claimed they ensure "schema validity + audit logging". Trimmed to the actual guarantees: "schema validity + hardcoded-id shadow refusal" (matches `isHardcodedId()` in `src/cosign/trust-store.js:184`).

## Root cause

These hallucinations originated from **PR #110** (v2.6 cohort docs) where I authored from the wish spec + cohort intuition instead of grep-verifying every claim against shipped code. Felipe caught the npm-direction reversal during a separate review; this PR closes the broader ledger.

## Test plan

- [x] `grep -nE "npm install|npm install -g" docs/migrations/v2.6-from-v2.5.md docs/trust-store.md docs/security/cosign-trust.md` — zero matches
- [x] `grep -nE "audit/trust-|trust-<DATE>" docs/trust-store.md` — zero matches
- [x] `grep -nE "pgserve trust add <" docs/migrations/v2.6-from-v2.5.md` — zero matches (no more wrong-syntax examples)
- [ ] Visual review: every CLI example matches the actual verb's `USAGE` block

## V3 path after this PR | Step | Status |
|---|---|
| **V3-3** doc fix (this PR) | ⏳ open |
| **V3-1** verb rename: `pgserve upgrade` → `pgserve update` (clean cutover per Felipe directive) | next |
| **V3-2** drop `npm publish` from release pipeline | after V3-1 |
| **V3-4** cut tag v3.0.0 | Felipe's call |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated v2.6 migration guide with canonical installation and rollback procedures using the installer tarball.
  * Clarified trust store behavior: `pgserve doctor` no longer probes the trust store, with manual verification steps documented.
  * Documented concrete trust management examples and audit trail behavior via the identities JSON file.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/namastexlabs/pgserve/pull/120)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->