### PR TITLE
feat(release)!: V3-2 — drop npm publish (post-npm-departure cutover)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -185,11 +185,17 @@ jobs:
           echo "prev=${{ steps.prev.outputs.tag }}"
 
   # ---------------------------------------------------------------------------
-  # Build & Publish: matrix build of platform binaries + npm publish via OIDC.
+  # Build (sanity): matrix build of platform binaries.
   #
-  # The reusable workflow filename is `version.yml` because npm Trusted
-  # Publisher is configured against that exact path. Renaming requires
-  # updating the npmjs.com Trusted Publisher entry first.
+  # V3-2 npm departure: the npm `publish` job in version.yml has been
+  # removed. This `build` step remains as a per-release sanity-build
+  # gate; its artifacts are not currently consumed by any downstream
+  # workflow.
+  #
+  # The reusable workflow filename `version.yml` is preserved because the
+  # historical npm Trusted Publisher entry was bound to that path; once
+  # the Trusted Publisher entry is fully retired at the registry level,
+  # this file can be renamed or merged into release.yml.
   #
   # The `if:` uses `always() && needs.prepare.result == 'success' &&
   # needs.prepare.outputs.skip != 'true'`. This is the bulletproof pattern
@@ -207,7 +213,7 @@ jobs:
   # works as intended.
   # ---------------------------------------------------------------------------
   build:
-    name: Build & Publish
+    name: Build (sanity)
     needs: prepare
     if: |
       always() &&
@@ -216,6 +222,10 @@ jobs:
     uses: ./.github/workflows/version.yml
     with:
       version: ${{ needs.prepare.outputs.version }}
+      # `npm_tag` input is deprecated post-V3-2 (npm departure). The
+      # publish job that consumed it has been removed; passing 'latest'
+      # is harmless and kept here only to satisfy the still-required
+      # parameter shape until version.yml's signature is simplified.
       npm_tag: latest
       # Use prepare.outputs.ref (which resolves to the bump-job tag on
       # dispatch, or `github.sha` on push). Build cannot reference
@@ -223,15 +233,22 @@ jobs:
       # On the push path nobody creates the tag before this runs; the
       # SHA-based checkout works because the merge commit already has the
       # bumped package.json. The tag is pushed by the bump job (when
-      # workflow_dispatch is used). GitHub Release creation now flows
-      # through `release-publish.yml` exclusively — see "Release job
-      # removed" note below.
+      # workflow_dispatch is used). GitHub Release creation flows through
+      # `release-publish.yml` exclusively (Wave A PR-A2 race fix).
+      #
+      # V3-2 npm departure: the `publish` job that this workflow used to
+      # call has been removed from version.yml. release.yml now only runs:
+      #   bump (workflow_dispatch only) → prepare → build (sanity)
+      # The cosign-signed GitHub Releases pipeline runs independently via:
+      #   tag push → build-tarballs.yml → sign-attest.yml → release-publish.yml
+      # See .genie/wishes/pgserve-singleton-no-proxy/SHARED-DESIGN.md
+      # Decision #1 ("3.0 reserved for post-npm-departure cutover").
       #
       # KNOWN LIMITATION (Wave A PR-A2 follow-up): the push-to-main flow
       # NO LONGER creates a tag automatically. The dropped `release` job
       # was creating the tag via `gh release create v${VERSION}` against
-      # HEAD; without it, push-event runs of release.yml will npm-publish
-      # but produce no tag → no `build-tarballs → sign-attest →
+      # HEAD; without it, push-event runs of release.yml will build but
+      # produce no tag → no `build-tarballs → sign-attest →
       # release-publish` chain → no GitHub Release.
       #
       # Workaround until a tag-creation step lands: route releases via
@@ -259,7 +276,8 @@ jobs:
   #
   # Option 1 (recommended by engineer DEEPER-AUDIT, accepted by Felipe):
   # drop this job entirely. release-publish.yml owns all GH-Releases
-  # creation. release.yml retains only bump + build + npm publish.
+  # creation. release.yml retains only bump + prepare + build (sanity)
+  # after the V3-2 npm-departure removed the npm publish step too.
   #
   # The single-file pgserve-* binaries previously attached here are NOT
   # currently re-attached by release-publish.yml — they're a development

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -1,14 +1,21 @@
 name: Build All Platforms
 
+# v3.0.0: this workflow used to build + npm-publish. The npm `publish` job
+# was removed in V3-2 (post-npm-departure cutover). The remaining `build`
+# job is preserved as a per-release sanity build; its artifacts are not
+# currently consumed downstream. The GitHub Releases pipeline runs via
+# build-tarballs.yml → sign-attest.yml → release-publish.yml (an
+# independent chain that produces the cosign-signed autopg-*.tar.gz set).
+
 on:
   workflow_call:
     inputs:
       version:
-        description: 'Version to publish'
+        description: 'Version label for the build (informational only — no longer published to npm)'
         required: true
         type: string
       npm_tag:
-        description: 'npm dist-tag (next or latest)'
+        description: 'DEPRECATED — npm dist-tag input; ignored after V3-2 npm departure'
         required: false
         type: string
         default: 'next'
@@ -19,11 +26,11 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Version (leave empty for build-only)'
+        description: 'Version label (leave empty for build-only)'
         required: false
         type: string
       npm_tag:
-        description: 'npm dist-tag'
+        description: 'DEPRECATED — npm dist-tag; ignored after V3-2 npm departure'
         required: false
         type: choice
         options:
@@ -107,122 +114,33 @@ jobs:
           path: dist/${{ matrix.output }}*
           retention-days: 7
 
-  publish:
-    name: Publish to npm
-    needs: build
-    runs-on: ubuntu-latest
-    if: inputs.version != ''
-    # Note: `environment: npm-publish` was removed because the npmjs.com
-    # Trusted Publisher entry for `pgserve` does not declare an environment
-    # name. With the env gate present here, the OIDC token's environment
-    # claim did not match the registry's expectation and `npm publish`
-    # returned 404. Re-add this line if/when the Trusted Publisher entry
-    # has its Environment Name field set to `npm-publish`.
-    permissions:
-      id-token: write
-      contents: read
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ inputs.ref || github.ref }}
-
-      # Node 24 ships npm 11.5+ which has built-in OIDC trusted-publisher
-      # support. Avoids the `npm install -g npm@latest` self-upgrade bug
-      # (Arborist clobbering its own promise-retry dep mid-install) that
-      # broke rlmx's OIDC publish on Node 22.
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '24'
-          registry-url: 'https://registry.npmjs.org'
-
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: 1.3.11
-
-      - name: Install dependencies
-        run: bun install
-
-      - name: Verify npm version supports OIDC trusted publishing
-        run: |
-          NPM_VERSION=$(npm --version)
-          echo "npm version: ${NPM_VERSION}"
-          MAJOR=$(echo "${NPM_VERSION}" | cut -d. -f1)
-          if [ "${MAJOR}" -lt 11 ]; then
-            echo "::error::npm ${NPM_VERSION} too old — OIDC requires >= 11.5.1. Bump node-version above."
-            exit 1
-          fi
-
-      - name: Download all artifacts
-        uses: actions/download-artifact@v4
-        with:
-          path: dist/
-          pattern: binaries-*
-          merge-multiple: true
-
-      - name: Verify binaries
-        run: |
-          echo "Downloaded binaries:"
-          ls -la dist/
-
-          MISSING=""
-          # Supported platforms: linux-x64, darwin-arm64, windows-x64
-          for platform in linux-x64 darwin-arm64; do
-            if [ ! -f "dist/pgserve-$platform" ]; then
-              MISSING="$MISSING pgserve-$platform"
-            fi
-          done
-          if [ ! -f "dist/pgserve-windows-x64.exe" ]; then
-            MISSING="$MISSING pgserve-windows-x64.exe"
-          fi
-
-          if [ -n "$MISSING" ]; then
-            echo "Missing binaries:$MISSING"
-            exit 1
-          fi
-
-          echo "All binaries present!"
-
-      - name: Check if version already published
-        id: check
-        run: |
-          VERSION="${{ inputs.version }}"
-          if npm view pgserve@$VERSION version >/dev/null 2>&1; then
-            echo "Version $VERSION already published"
-            echo "published=true" >> $GITHUB_OUTPUT
-          else
-            echo "Version $VERSION not yet published"
-            echo "published=false" >> $GITHUB_OUTPUT
-          fi
-
-      - name: Publish to npm via OIDC
-        if: steps.check.outputs.published == 'false'
-        env:
-          HUSKY: "0"
-          # npm auto-enables provenance in any CI env with `id-token: write`,
-          # regardless of the --provenance CLI flag. On some runners the
-          # server-side sigstore check fails with 422; disable explicitly.
-          # OIDC token exchange still happens.
-          NPM_CONFIG_PROVENANCE: "false"
-        run: |
-          echo "Publishing version ${{ inputs.version }} with tag ${{ inputs.npm_tag }} via OIDC"
-          npm publish --access public --tag ${{ inputs.npm_tag }}
-
-      - name: Verify publish
-        if: steps.check.outputs.published == 'false'
-        run: |
-          # npm registry can take up to 30s to propagate
-          for i in 1 2 3 4 5; do
-            echo "Attempt $i: Checking npm for pgserve@${{ inputs.version }}..."
-            if npm view pgserve@${{ inputs.version }} version 2>/dev/null; then
-              echo "Successfully published pgserve@${{ inputs.version }} with tag @${{ inputs.npm_tag }}"
-              exit 0
-            fi
-            echo "Not found yet, waiting 10s..."
-            sleep 10
-          done
-          echo "Warning: Version not found after 50s, but publish command succeeded"
-          exit 0
+  # ---------------------------------------------------------------------------
+  # Publish job — REMOVED in v3.0.0 (V3-2 npm-departure).
+  #
+  # pgserve no longer publishes to npmjs.com. Distribution flows through:
+  #   - `install.sh` + GitHub Releases (cosign-keyless-signed tarballs) for
+  #     first install
+  #   - `pgserve update` for subsequent in-place version migrations
+  #
+  # See:
+  #   - .genie/wishes/pgserve-singleton-no-proxy/WISH.md L95
+  #     ("pgserve@3.0.0 bump reserved for post-npm-departure cutover")
+  #   - .genie/wishes/pgserve-singleton-no-proxy/SHARED-DESIGN.md Decision #1
+  #     ("3.0 reserved for post-npm-departure cutover per distribution-exodus")
+  #   - install.sh (canonical installer)
+  #   - .github/workflows/release-publish.yml (GitHub Releases pipeline)
+  #
+  # Historical v2.x tarballs on npmjs.com stay published (npm registry
+  # tarballs are immutable). No new versions go to npm from v3.0.0 onward.
+  #
+  # The `build` job above is preserved as a sanity-build check that the
+  # codebase still compiles on each release run; its artifacts are not
+  # currently consumed by any downstream workflow but the build itself
+  # serves as a gate. If/when that gate moves elsewhere, `build` can be
+  # dropped too along with this whole file.
+  #
+  # GitHub Actions secrets that backed the npm OIDC flow (none — pgserve
+  # used Trusted Publisher, no token needed) are unaffected. The
+  # npmjs.com Trusted Publisher entry for `pgserve` can be removed at the
+  # registry level once Felipe confirms no rollback is desired.
+  # ---------------------------------------------------------------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,23 +17,41 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased] — pgserve v3.0.0 (post-npm-departure cutover)
 
 The v3.0.0 cohort moves pgserve off npm-as-canonical-distribution. Installs +
-in-place updates flow through `install.sh` + GitHub Releases exclusively; the
-npm tarball is no longer the source of truth (the `npm publish` step will be
-dropped from `version.yml` in V3-2). Tracking wish:
-`pgserve-singleton-no-proxy` Decision #1 — *"3.0 reserved for post-npm-
-departure cutover (`distribution-exodus`)"*.
+in-place updates flow through `install.sh` + GitHub Releases exclusively.
+Tracking wish: `pgserve-singleton-no-proxy` Decision #1 — *"3.0 reserved for
+post-npm-departure cutover (`distribution-exodus`)"*.
 
 ### Changed (breaking)
 
 - **`pgserve upgrade` → `pgserve update` (clean cutover)**. The `upgrade` verb
   is gone; `pgserve upgrade` exits with "unknown verb" (the B4 path from
-  `pgserve-singleton-no-proxy` G3). Operators (and the npm postinstall hook)
-  must use `pgserve update`. Source dir renamed `src/upgrade/` →
-  `src/update/`; tests `tests/upgrade/` → `tests/update/`; CLI dispatch +
-  wrapper allowlist + postinstall script all updated in lockstep.
+  `pgserve-singleton-no-proxy` G3). Operators must use `pgserve update`.
+  Source dir renamed `src/upgrade/` → `src/update/`; tests `tests/upgrade/`
+  → `tests/update/`; CLI dispatch + wrapper allowlist all updated in lockstep.
 - **`pgserve update` orchestrator function** in `src/update/index.js` is now
   exported as `update()` (was `upgrade()`); the `STEPS` array shape is
   unchanged.
+- **npm publish step removed** from `.github/workflows/version.yml`. v3.0.0+
+  releases ship via GitHub Releases only (cosign-keyless-signed tarballs via
+  `install.sh` + `pgserve update`). Historical v2.x tarballs on npmjs.com
+  stay published (npm registry tarballs are immutable); no new versions go
+  to npm from v3.0.0 onward.
+- **`package.json` `postinstall` hook removed**. The hook auto-ran
+  `autopg upgrade` (and was rewired to `pgserve update` in V3-1) on
+  `npm install` / `bun install`. Since v3.0.0 doesn't publish to npm, the
+  hook never fires for end-users; dropped to avoid confusing the dev-only
+  invocation path. `scripts/postinstall.cjs` is preserved in the repo for
+  manual invocation; the hook can be re-added if a future cohort
+  reintroduces an npm distribution path.
+
+### Removed
+
+- `.github/workflows/version.yml` — `Publish to npm via OIDC` job and its
+  7 supporting steps (Setup Node 24, Verify OIDC support, Download
+  artifacts, Verify binaries, Check version, Publish, Verify publish).
+  The `build` matrix job is preserved as a per-release sanity gate.
+- `package.json:scripts.postinstall` — no longer triggered after npm
+  departure.
 
 ## [2.6.0] / [2.6.1] - 2026-05-09
 

--- a/package.json
+++ b/package.json
@@ -35,8 +35,7 @@
     "test:npx": "scripts/test-npx.sh",
     "test:bun-self-heal": "scripts/test-bun-self-heal.sh",
     "prepublishOnly": "npm run console:build && npm run lint && npm run deadcode && npm run test:npx && npm run test:bun-self-heal",
-    "prepare": "husky",
-    "postinstall": "node scripts/postinstall.cjs"
+    "prepare": "husky"
   },
   "keywords": [
     "postgresql",


### PR DESCRIPTION
## Summary

**BREAKING.** Drops `npm publish` from the release pipeline. v3.0.0+ ships exclusively via GitHub Releases (cosign-keyless-signed tarballs via `install.sh` + `pgserve update`). Historical v2.x tarballs on npmjs.com stay published (registry tarballs are immutable); **no new versions go to npm**.

Closes **V3-2** of the v3.0.0 cohort per `pgserve-singleton-no-proxy` SHARED-DESIGN.md Decision #1: *"3.0 reserved for post-npm-departure cutover (distribution-exodus)"*. Felipe directive 2026-05-10: *"publishing independently from npmjs, using install.sh + update cli command from now on"*.

4 files / 98 insertions / 145 deletions.

## What changes

### `.github/workflows/version.yml`
- **Removed** the entire `publish` job (118 lines): Setup Node 24, Setup Bun, Install deps, Verify npm OIDC support, Download artifacts, Verify binaries, Check version published, Publish to npm via OIDC, Verify publish.
- Replaced with a multi-paragraph removal-marker comment cross-referencing Decision #1 + the cosign-signed GitHub Releases pipeline (build-tarballs.yml → sign-attest.yml → release-publish.yml).
- `build` matrix job is **preserved** as a per-release sanity gate; its artifacts (single-file pgserve-* binaries) aren't consumed downstream but the build itself proves the codebase compiles.
- Workflow header + workflow_call / workflow_dispatch input descriptions updated; `npm_tag` marked DEPRECATED.

### `.github/workflows/release.yml`
- `build:` job name `"Build & Publish"` → `"Build (sanity)"`.
- Stale comments cleaned: section header + the dropped-release-job comment block both updated to reflect bump + prepare + build (sanity) post-V3-2.

### `package.json`
- **Removed** `scripts.postinstall: node scripts/postinstall.cjs`. The hook auto-ran `autopg upgrade` (then `pgserve update` after V3-1) on npm/bun install — never fires for end-users after npm departure. `scripts/postinstall.cjs` itself stays in the repo for manual invocation if needed.

### `CHANGELOG.md`
- `[Unreleased]` v3.0.0 entry rewritten to fold V3-2 in: documents npm-publish-step + postinstall-hook removal under both "Changed (breaking)" and a new "Removed" subsection.

## Pipeline after this lands

```
git push origin v3.0.0
   ├── triggers release.yml:           bump → prepare → build (sanity)
   │     (no GH Release created here; npm publish gone)
   │
   └── triggers build-tarballs.yml     → autopg-3.0.0-<plat>.tar.gz artifacts
         │
         └── workflow_run sign-attest.yml  → cosign sign + SLSA L3 attest
               │
               └── workflow_run release-publish.yml
                     └── GitHub Release v3.0.0 with cosign-signed assets
```

Operators install via:
```bash
curl -fsSL https://raw.githubusercontent.com/namastexlabs/pgserve/main/install.sh | bash
# OR pin: PGSERVE_VERSION=v3.0.0 curl ... | bash
```

In-place updates via `pgserve update`.

## What stays as-is (deliberate)

- `scripts/postinstall.cjs` — preserved + test suite still passes (12/12). Functions correctly if invoked manually.
- npmjs.com Trusted Publisher entry — left in place at the registry level. Can be removed once v3.0.0 bakes in production.
- `version.yml` filename — historical TP entry was bound to this path; rename requires registry update first.
- `prepublishOnly` script in package.json — harmless gate for any manual `npm pack` local invocation.

## Test plan

- [x] `bun test tests/update/postinstall.test.js` — 12/12 pass (postinstall.cjs still works when invoked manually)
- [x] `grep -rnE "npm publish" .github/workflows/` — only the explanatory comment in release.yml remains
- [x] `grep -nE "postinstall" package.json` — 0 matches (entry dropped)
- [ ] CI green (lint + deadcode + integration tests)
- [ ] On next tag push, the build-tarballs → sign-attest → release-publish chain runs and produces a signed GitHub Release; release.yml runs bump + prepare + build (sanity) only.

## Cohort sequencing

| Step | Status |
|---|---|
| V3-3 doc-hallucination cleanup | ✅ #120 merged |
| V3-1 verb rename `upgrade` → `update` | ✅ #121 merged |
| **V3-2 drop npm publish (this PR)** | ⏳ open |
| V3-4 cut tag `v3.0.0` | yours — the first publishing independently from npmjs |

🤖 Generated with [Claude Code](https://claude.com/claude-code)