### PR TITLE
fix(trust-list): genie regex anchors on sign-attest.yml@ (v3 G1 blocker)

### DIFF
--- a/src/cosign/trust-list.js
+++ b/src/cosign/trust-list.js
@@ -37,13 +37,28 @@ export const TRUSTED_IDENTITIES = Object.freeze([
     id: 'automagik-genie-release',
     publisher: '@automagik/genie',
     issuer: SIGSTORE_GITHUB_ACTIONS_ISSUER,
-    identityRegexp: '^https://github.com/automagik-dev/genie/.github/workflows/release.yml@refs/tags/v.*$',
-    description: 'Namastex automagik genie release workflow (GitHub Actions OIDC)',
+    // genie's release.yml is an orchestrator that workflow_call's into
+    // sign-attest.yml — the Fulcio SAN URI therefore binds to
+    // sign-attest.yml@<ref>, not release.yml@<ref>. Verified against
+    // both v4.260511.1 (released from main) and v4.260511.2 (released
+    // from wish/genie-distribution-cutover-g1) bundle certificates on
+    // 2026-05-11: both cert subjects are
+    // `automagik-dev/genie/.github/workflows/sign-attest.yml@refs/tags/v4.260511.x`.
+    // Same shape as pgserve's own entry below.
+    identityRegexp: '^https://github.com/automagik-dev/genie/.github/workflows/sign-attest.yml@refs/tags/v.*$',
+    description: 'Namastex automagik genie sign-attest workflow (GitHub Actions OIDC)',
   }),
   Object.freeze({
     id: 'automagik-omni-release',
     publisher: '@automagik/omni',
     issuer: SIGSTORE_GITHUB_ACTIONS_ISSUER,
+    // Omni signing pipeline TBD — `v3-prerelease-trust-loop` G2 wires
+    // it. Keeping the `release.yml@` anchor as the contract-of-intent
+    // until omni's signing workflow filename is locked in G2. If omni
+    // mirrors genie's orchestrator+workflow_call pattern, this regex
+    // must flip to `sign-attest.yml@` before omni's first signed tag
+    // can verify. Re-validate against the first signed omni release
+    // bundle during G4 smoke.
     identityRegexp: '^https://github.com/automagik-dev/omni/.github/workflows/release.yml@refs/tags/v.*$',
     description: 'Namastex automagik omni release workflow (GitHub Actions OIDC)',
   }),

--- a/tests/admin/admin-bootstrap.test.js
+++ b/tests/admin/admin-bootstrap.test.js
@@ -32,7 +32,7 @@ const SAMPLE_LOCKED_ROOTS = Object.freeze([
     id: 'automagik-genie-release',
     publisher: '@automagik/genie',
     issuer: 'https://token.actions.githubusercontent.com',
-    identityRegexp: '^https://github.com/automagik-dev/genie/.github/workflows/release.yml@refs/tags/v.*$',
+    identityRegexp: '^https://github.com/automagik-dev/genie/.github/workflows/sign-attest.yml@refs/tags/v.*$',
     description: 'genie release',
   }),
 ]);

--- a/tests/cosign/trust-list.test.js
+++ b/tests/cosign/trust-list.test.js
@@ -89,11 +89,17 @@ describe('automagik-pgserve-release entry (Wave A regression)', () => {
 });
 
 describe('genie + omni entries (cohort siblings — regression sanity)', () => {
-  test('genie entry anchors on automagik-dev/genie release.yml@refs/tags/v.*', () => {
+  test('genie entry anchors on automagik-dev/genie sign-attest.yml@refs/tags/v.*', () => {
+    // genie's release.yml is an orchestrator that workflow_call's into
+    // sign-attest.yml — the Fulcio SAN URI binds to sign-attest.yml@<ref>.
+    // Verified empirically against v4.260511.1 + v4.260511.2 bundle certs
+    // on 2026-05-11. Locking the regex shape here so a regression that
+    // reverts to `release.yml@` is caught at unit-test time, not at
+    // `pgserve verify --slug genie` runtime.
     const entry = getTrustedById('automagik-genie-release');
     expect(entry).toBeTruthy();
     expect(entry.identityRegexp).toMatch(
-      /^\^https:\/\/github\.com\/automagik-dev\/genie\/\.github\/workflows\/release\.yml@refs\/tags\/v\.\*\$$/,
+      /^\^https:\/\/github\.com\/automagik-dev\/genie\/\.github\/workflows\/sign-attest\.yml@refs\/tags\/v\.\*\$$/,
     );
   });
 


### PR DESCRIPTION
## Summary

- **v3-prerelease-trust-loop G1 finding**: pgserve trust-list `automagik-genie-release` entry anchors on `release.yml@refs/tags/v.*`, but genie's actual cosign cert subject for both v4.260511.1 (main) and v4.260511.2 (wish branch) is `sign-attest.yml@refs/tags/v.*`. `pgserve verify --slug genie` would have failed against any current genie release.
- Genie's `release.yml` is an orchestrator that `workflow_call`s into `sign-attest.yml` — Fulcio SAN URI binds to the inner reusable workflow. Same pattern pgserve already uses; the pgserve entry's own comment documents this for itself but the genie entry was never updated to match.
- Omni entry kept on `release.yml@` as contract-of-intent — `v3-prerelease-trust-loop` G2 (omni signing pipeline) will lock the actual filename; re-validate during G4 smoke and flip if omni mirrors genie's orchestrator pattern.

## Reproduce (proves the bug + the fix)

```bash
# Pre-fix: FAIL
gh release download v4.260511.1 --repo automagik-dev/genie \
    --pattern 'genie-4.260511.1-linux-x64-glibc.tar.gz*'
cosign verify-blob \
  --bundle genie-4.260511.1-linux-x64-glibc.tar.gz.bundle \
  --certificate-identity-regexp '^https://github.com/automagik-dev/genie/.github/workflows/release.yml@refs/tags/v.*$' \
  --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \
  genie-4.260511.1-linux-x64-glibc.tar.gz
# → Error: none of the expected identities matched
#   got subjects [...sign-attest.yml@refs/tags/v4.260511.1]

# Post-fix: PASS
cosign verify-blob \
  --bundle genie-4.260511.1-linux-x64-glibc.tar.gz.bundle \
  --certificate-identity-regexp '^https://github.com/automagik-dev/genie/.github/workflows/sign-attest.yml@refs/tags/v.*$' \
  --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \
  genie-4.260511.1-linux-x64-glibc.tar.gz
# → Verified OK
```

## Files changed (3)

- `src/cosign/trust-list.js` — genie `identityRegexp` flipped + explanatory comment block
- `tests/cosign/trust-list.test.js` — regex-shape regression lock (test name updated)
- `tests/admin/admin-bootstrap.test.js` — sample fixture aligned for grep-ability

## Test plan

- [x] `bun test tests/cosign/trust-list.test.js tests/admin/admin-bootstrap.test.js` — 30 pass / 0 fail
- [x] `bun run lint` — clean
- [x] `bun run deadcode` — clean (only pre-existing react/react-dom hints)
- [x] Empirically verified cosign verify-blob PASSES with new regex on v4.260511.1 + v4.260511.2 bundles

🤖 Generated with [Claude Code](https://claude.com/claude-code)
