### PR TITLE
fix(trust-list): omni regex anchors on sign-attest.yml@ (pre-emptive G2 mirror)

### DIFF
--- a/src/cosign/trust-list.js
+++ b/src/cosign/trust-list.js
@@ -52,15 +52,16 @@ export const TRUSTED_IDENTITIES = Object.freeze([
     id: 'automagik-omni-release',
     publisher: '@automagik/omni',
     issuer: SIGSTORE_GITHUB_ACTIONS_ISSUER,
-    // Omni signing pipeline TBD — `v3-prerelease-trust-loop` G2 wires
-    // it. Keeping the `release.yml@` anchor as the contract-of-intent
-    // until omni's signing workflow filename is locked in G2. If omni
-    // mirrors genie's orchestrator+workflow_call pattern, this regex
-    // must flip to `sign-attest.yml@` before omni's first signed tag
-    // can verify. Re-validate against the first signed omni release
-    // bundle during G4 smoke.
-    identityRegexp: '^https://github.com/automagik-dev/omni/.github/workflows/release.yml@refs/tags/v.*$',
-    description: 'Namastex automagik omni release workflow (GitHub Actions OIDC)',
+    // Omni signing pipeline mirrors genie's orchestrator+workflow_call
+    // pattern (Felipe directive 2026-05-11, decision 2.α for
+    // `v3-prerelease-trust-loop` G2): release.yml orchestrates, the
+    // cosign keyless sign-blob runs inside a reusable sign-attest.yml,
+    // and the Fulcio SAN URI binds to sign-attest.yml@<ref>. Anchoring
+    // here pre-emptively so omni's first signed tag (post-G2 merge)
+    // verifies without a follow-up trust-list flip. Re-validate against
+    // the first signed omni bundle during G4 smoke.
+    identityRegexp: '^https://github.com/automagik-dev/omni/.github/workflows/sign-attest.yml@refs/tags/v.*$',
+    description: 'Namastex automagik omni sign-attest workflow (GitHub Actions OIDC)',
   }),
   Object.freeze({
     id: 'automagik-pgserve-release',

--- a/tests/cosign/trust-list.test.js
+++ b/tests/cosign/trust-list.test.js
@@ -103,11 +103,17 @@ describe('genie + omni entries (cohort siblings — regression sanity)', () => {
     );
   });
 
-  test('omni entry anchors on automagik-dev/omni release.yml@refs/tags/v.*', () => {
+  test('omni entry anchors on automagik-dev/omni sign-attest.yml@refs/tags/v.*', () => {
+    // Pre-emptive: omni's signing pipeline mirrors genie's
+    // orchestrator+workflow_call pattern per Felipe directive 2026-05-11
+    // (v3-prerelease-trust-loop G2 decision 2.α). The omni sign-attest.yml
+    // is being authored under automagik-dev/omni; this regex shape is
+    // locked here so the first signed omni release tag verifies without
+    // a follow-up trust-list flip. Re-validate empirically during G4.
     const entry = getTrustedById('automagik-omni-release');
     expect(entry).toBeTruthy();
     expect(entry.identityRegexp).toMatch(
-      /^\^https:\/\/github\.com\/automagik-dev\/omni\/\.github\/workflows\/release\.yml@refs\/tags\/v\.\*\$$/,
+      /^\^https:\/\/github\.com\/automagik-dev\/omni\/\.github\/workflows\/sign-attest\.yml@refs\/tags\/v\.\*\$$/,
     );
   });
 });


### PR DESCRIPTION
## Summary

- **Pre-emptive companion to PR #126**: flips omni `automagik-omni-release` regex to `sign-attest.yml@` to match the genie pattern locked yesterday.
- Felipe directive 2026-05-11 for `v3-prerelease-trust-loop` G2 (decision **2.α**): omni's signing pipeline mirrors genie's orchestrator+workflow_call pattern. `release.yml` orchestrates, the cosign keyless sign-blob runs inside a reusable `sign-attest.yml`, and the Fulcio SAN URI therefore binds to `sign-attest.yml@<ref>`.
- Landing the trust-list change BEFORE omni's first signed tag cuts means no follow-up regex-flip PR after G2 merges. If G2 deviates from the mirror pattern for any reason, this PR can be reverted (or amended) — cheaper than catching it during G4 smoke.

## Why now, not after G2?

Two reasons:
1. **Engineer brief for G2 is being authored in parallel and explicitly mandates `sign-attest.yml` as the workflow filename**. The trust regex + the omni implementation must match; better to commit pgserve to the contract first so the engineer agent can't accidentally drift.
2. **Aligns the cohort visually** — genie + omni now have identical regex shapes (modulo the org/repo segment). pgserve's own entry is the third cohort sibling with the same shape.

## Test plan

- [x] `bun test tests/cosign/trust-list.test.js` — 11 pass / 0 fail
- [x] `bun run lint` — clean
- [ ] G4 smoke against omni's first signed bundle (post-G2 merge) — final empirical validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration Updates**
  - Updated signature verification configuration for `automagik-omni-release` to reference the correct signing workflow.

* **Tests**
  - Updated corresponding verification tests to reflect configuration changes.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/namastexlabs/pgserve/pull/127)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->