### PR TITLE
feat(release): channel-aware .well-known writer (Phase B mirror)

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -17,9 +17,9 @@
 #   2. Sanity-check: every tarball must have its sig + cert + intoto.jsonl
 #      + sha256 siblings before any release upload happens
 #   3. Create GitHub Release (draft until manual promotion) with all assets
-#   4. Update `latest.json` channel pointer in the repo (committed, served via
-#      raw.githubusercontent.com — install.sh reads this for stable/beta/canary
-#      resolution)
+#   4. Update `<channel>.json` channel pointer in the repo (committed, served via
+#      raw.githubusercontent.com — install.sh reads this for stable/homolog/dev
+#      resolution; stable maps to latest.json for v1-manifest back-compat)
 #
 # Verification by consumers:
 #   gh release download v<version> --repo namastexlabs/pgserve --pattern '*.tar.gz'
@@ -61,10 +61,15 @@ on:
         required: true
         type: choice
         default: stable
+        # Canonical channel taxonomy (Felipe directive 2026-05-12, unified
+        # across pgserve/omni/genie): stable / homolog / dev. beta + canary
+        # have been retired. pgserve in practice only uses `stable` (main
+        # branch); homolog + dev are listed for cross-repo taxonomy parity
+        # and operator-dispatch capability if a future workflow needs them.
         options:
           - stable
-          - beta
-          - canary
+          - homolog
+          - dev
       draft:
         description: 'Create as draft (require manual promotion)?'
         required: true
@@ -212,23 +217,24 @@ jobs:
       # `autopg update` can resolve the current version for each channel via:
       #   curl -fsSL https://raw.githubusercontent.com/<repo>/main/.well-known/<channel>.json
       #
-      # Filename map (mirrors genie wish release-channel-dev, PR #2419, and
-      # omni PR #633 — Phase A of the cross-repo unification):
-      #   stable → latest.json     (kept for back-compat with v1 manifest layout)
-      #   beta   → beta.json       (reserved for future operator dispatch)
-      #   canary → canary.json     (reserved for future operator dispatch)
+      # Filename map (canonical taxonomy per Felipe directive 2026-05-12,
+      # unified across pgserve/omni/genie — beta + canary retired):
+      #   stable  → latest.json    (kept for back-compat with v1 manifest layout)
+      #   homolog → homolog.json   (homologation/staging — operator-dispatch only on pgserve)
+      #   dev     → dev.json       (development — operator-dispatch only on pgserve)
       #
-      # NO `dev` channel for pgserve. autopg ships from main only — there
-      # is no dev branch posture, no auto-version-from-dev workflow, and no
-      # development-channel consumers. Felipe directive 2026-05-12: "no dev
-      # branch, autopg wont have dev channel". The genie-style stable-also-
-      # writes-dev.json behavior is intentionally omitted here.
+      # Pgserve in practice ships only from main → `stable`. The autopg cohort
+      # has no dev branch, no auto-version workflow, and no development-channel
+      # consumers — homolog + dev are present for cross-repo taxonomy parity
+      # and ad-hoc operator dispatches (e.g., for ad-hoc autopg test releases).
+      # The genie-style "stable also advances dev.json" behavior is omitted
+      # because pgserve has no continuous dev-branch release stream that
+      # consumers track.
       #
       # The stable-only gate that lived here previously was lifted — every
-      # non-draft publish writes the manifest for its channel. In practice
-      # today only `stable` channel runs through this workflow (beta/canary
-      # are reserved for future operator dispatch); the case-statement
-      # keeps the same code shape as omni/genie for cross-repo readability.
+      # non-draft publish writes the manifest for its channel. The
+      # case-statement keeps the same code shape as omni/genie for
+      # cross-repo readability.
       # ---------------------------------------------------------------------
       - name: Update channel manifests (.well-known/*.json — non-draft only)
         if: ${{ !inputs.draft }}
@@ -240,13 +246,19 @@ jobs:
           set -euo pipefail
           # stable keeps the historical filename `latest.json`; every other
           # channel uses its own name. install.sh + autopg update consume
-          # the same convention. Unlike genie/omni, no dev branch path
-          # exists for pgserve so the stable-also-advances-dev case is
-          # intentionally absent.
+          # the same convention. Unlike omni/genie which auto-advance
+          # dev.json on stable releases (single-pipeline reality), pgserve
+          # has no continuous dev-branch release stream — homolog + dev are
+          # operator-dispatch-only paths here.
           declare -A MANIFEST_FILES=()
           case "$CHANNEL" in
-            stable) MANIFEST_FILES[stable]="latest.json" ;;
-            *)      MANIFEST_FILES[$CHANNEL]="${CHANNEL}.json" ;;
+            stable)  MANIFEST_FILES[stable]="latest.json" ;;
+            homolog) MANIFEST_FILES[homolog]="homolog.json" ;;
+            dev)     MANIFEST_FILES[dev]="dev.json" ;;
+            *)
+              echo "::error::unknown channel: $CHANNEL (valid: stable, homolog, dev)"
+              exit 1
+              ;;
           esac
 
           mkdir -p .well-known

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -207,27 +207,80 @@ jobs:
             echo "::warning::dist/ is empty — no assets to upload"
           fi
 
-      - name: Update latest.json channel pointer
-        if: ${{ steps.ch.outputs.channel == 'stable' && !inputs.draft }}
+      # ---------------------------------------------------------------------
+      # Per-channel manifest pointers — committed to main so install.sh +
+      # `autopg update` can resolve the current version for each channel via:
+      #   curl -fsSL https://raw.githubusercontent.com/<repo>/main/.well-known/<channel>.json
+      #
+      # Filename map (mirrors genie wish release-channel-dev, PR #2419, and
+      # omni PR #633 — Phase A of the cross-repo unification):
+      #   stable → latest.json     (kept for back-compat with v1 manifest layout)
+      #   beta   → beta.json       (reserved for future operator dispatch)
+      #   canary → canary.json     (reserved for future operator dispatch)
+      #
+      # NO `dev` channel for pgserve. autopg ships from main only — there
+      # is no dev branch posture, no auto-version-from-dev workflow, and no
+      # development-channel consumers. Felipe directive 2026-05-12: "no dev
+      # branch, autopg wont have dev channel". The genie-style stable-also-
+      # writes-dev.json behavior is intentionally omitted here.
+      #
+      # The stable-only gate that lived here previously was lifted — every
+      # non-draft publish writes the manifest for its channel. In practice
+      # today only `stable` channel runs through this workflow (beta/canary
+      # are reserved for future operator dispatch); the case-statement
+      # keeps the same code shape as omni/genie for cross-repo readability.
+      # ---------------------------------------------------------------------
+      - name: Update channel manifests (.well-known/*.json — non-draft only)
+        if: ${{ !inputs.draft }}
         env:
           GH_TOKEN: ${{ github.token }}
           VERSION: ${{ steps.ver.outputs.version }}
+          CHANNEL: ${{ steps.ch.outputs.channel }}
         run: |
+          set -euo pipefail
+          # stable keeps the historical filename `latest.json`; every other
+          # channel uses its own name. install.sh + autopg update consume
+          # the same convention. Unlike genie/omni, no dev branch path
+          # exists for pgserve so the stable-also-advances-dev case is
+          # intentionally absent.
+          declare -A MANIFEST_FILES=()
+          case "$CHANNEL" in
+            stable) MANIFEST_FILES[stable]="latest.json" ;;
+            *)      MANIFEST_FILES[$CHANNEL]="${CHANNEL}.json" ;;
+          esac
+
           mkdir -p .well-known
-          cat > .well-known/latest.json <<EOF
+          for manifest_channel in "${!MANIFEST_FILES[@]}"; do
+            FILE="${MANIFEST_FILES[$manifest_channel]}"
+            cat > ".well-known/${FILE}" <<EOF
           {
-            "channel": "stable",
+            "schema_version": 1,
+            "channel": "${manifest_channel}",
             "version": "${VERSION}",
             "released_at": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
             "tarball_base": "https://github.com/${{ github.repository }}/releases/download/v${VERSION}",
             "platforms": ["linux-x64-glibc","linux-x64-musl","linux-arm64","darwin-x64","darwin-arm64"]
           }
           EOF
-          # Commit only if changed; CI bot configured globally
-          if ! git diff --quiet .well-known/latest.json; then
-            git config user.name "release-bot"
-            git config user.email "release-bot@namastex.com"
-            git add .well-known/latest.json
-            git commit -m "chore(release): update latest.json → v${VERSION}"
-            git push origin HEAD:main || echo "::warning::push failed (likely permission); update latest.json manually"
+          done
+
+          git config user.name "release-bot"
+          git config user.email "release-bot@namastex.com"
+          # Stage first, then compare against HEAD. `git diff --quiet <path>`
+          # returns 0 (no diff) for *untracked* files because they aren't in
+          # the index — staging registers the path; then
+          # `git diff --cached --quiet HEAD --` correctly reports "differs
+          # from HEAD" for both new and modified files. Mirrors the
+          # bootstrap fix from genie PR #2412/#2419.
+          MANIFEST_PATHS=()
+          for f in "${MANIFEST_FILES[@]}"; do
+            MANIFEST_PATHS+=(".well-known/${f}")
+          done
+          git add "${MANIFEST_PATHS[@]}"
+          if git diff --cached --quiet HEAD -- "${MANIFEST_PATHS[@]}"; then
+            echo "manifests unchanged — nothing to commit"
+            exit 0
           fi
+          MANIFEST_LIST=$(IFS=','; echo "${!MANIFEST_FILES[*]}")
+          git commit -m "chore(release): update manifests (${MANIFEST_LIST}) → v${VERSION}"
+          git push origin HEAD:main || echo "::warning::push failed (likely permission); update ${MANIFEST_PATHS[*]} manually"


### PR DESCRIPTION
## Summary

Phase B of the cross-repo release-pipeline unification. Ports the producer-side `.well-known/<channel>.json` writer pattern from [genie PR #2419 (release-channel-dev)](https://github.com/automagik-dev/genie/pull/2419) and [omni PR #633](https://github.com/automagik-dev/omni/pull/633) to pgserve, **main-only + stable-only** per Felipe directive 2026-05-12: *"no dev branch, autopg wont have dev channel"*.

## Filename map (pgserve)

| Channel | File | Status |
|---|---|---|
| `stable` | `.well-known/latest.json` | active (kept for v1 back-compat) |
| `beta` | `.well-known/beta.json` | reserved for future operator dispatch |
| `canary` | `.well-known/canary.json` | reserved for future operator dispatch |
| `dev` | — | **intentionally absent** — pgserve has no dev branch, no auto-version-from-dev workflow, no development-channel consumers |

The genie-style "stable also advances dev.json" behavior is intentionally omitted here. Pgserve ships from main only.

## Behavior changes

1. **Drop the stable-only gate** on the `.well-known` writer. Today only stable releases run through this workflow; beta/canary are reserved for future operator dispatch. The case-map keeps the same code shape as omni/genie for cross-repo readability.
2. **Apply the staged-then-cached diff bootstrap fix** (mirrors genie PR #2412 + #2419). Before this fix, new manifest files weren't getting committed because `git diff --quiet <path>` returns 0 for untracked paths. Staging first, then comparing against HEAD via `--cached`, fixes the bootstrap silent no-op.

## What this PR is NOT

- **Not an orchestrator refactor**. Pgserve still uses `build-tarballs.yml` → `workflow_run` → `sign-attest.yml` → `workflow_run` → `release-publish.yml` chaining. Genie/omni use a single `release.yml` orchestrator with `workflow_call`. Collapsing the chain is a separate (and bigger) refactor; tracked as Phase B follow-up.
- **Not adding a Version workflow**. Pgserve has no auto-version-from-dev. Tags are cut by operator (Felipe) directly.
- **Not touching install.sh / autopg update**. Consumer-side channel awareness is a separate landing.

## Test plan

- [x] `bun run lint` clean
- [x] YAML syntax valid (parsed via js-yaml)
- [x] Workflow logic diff-reviewed against omni PR #633 and genie PR #2419
- [ ] Post-merge: next stable release (tag push on main) confirms `.well-known/latest.json` still updates correctly via the new case-map path

## Cross-repo references

- Genie source PR: https://github.com/automagik-dev/genie/pull/2419
- Omni mirror PR: https://github.com/automagik-dev/omni/pull/633
- Parent wish: `.genie/wishes/v3-prerelease-trust-loop/WISH.md` (this repo)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Enhanced release publication workflow to automatically generate and maintain channel manifests for stable, beta, and canary release channels
  * Workflow now updates `.well-known/` directory with channel-specific manifest files containing version and release metadata
  * Improved commit logic to publish changes only when manifest content differs from previous state

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/namastexlabs/pgserve/pull/128)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->