### PR TITLE
release: v3.0.0 — autopg org transfer + install.sh bootstrap repair

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## v3.0.0 — autopg (org transfer + bootstrap repair)
+
+**Changed:** Repository transferred `namastexlabs/pgserve` → `automagik-dev/autopg` (transfer + rename). Old URLs 301-redirect. `src/cosign/trust-list.js` self-trust regex flipped to `automagik-dev/autopg` — v3+ binaries verify v3+ releases signed under the new org identity.
+
+**Fixed:** `install.sh` fresh-host bootstrap, broken independent of the transfer: correct `autopg-*` asset names with glibc/musl detection, `gh api` latest-resolution (the unauthenticated `curl|sed` path returned empty), correct extracted layout (`autopg/autopg`) plus a `~/.local/bin/autopg` symlink, and a `cosign verify-blob` fallback with a dual-org identity regexp so hosts on `gh < 2.49` can still cryptographically verify the current `latest` (signed pre-transfer under the old org).
+
+**Note:** the npm `pgserve` package remains on v2.6.10 as legacy LTS for `@withone/cli` — not deprecated.
+
 ## v2.2.x — Transparent Upgrade
 
 **Added:** `autopg upgrade` CLI verb — idempotent migration runner that reconciles port back to canonical 8432, flushes the binary cache against the pinned PG version, re-resolves the plpgsql `.so` path per database, refreshes `~/.autopg/<app>.env` files, signals consumers, and validates final health.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "autopg",
-  "version": "2.7.0",
+  "version": "3.0.0",
   "description": "Embedded PostgreSQL server with true concurrent connections - zero config, auto-provision databases",
   "main": "src/index.js",
   "type": "module",


### PR DESCRIPTION
## v3.0.0 GA — via PR (no hand tag)

Bumps `package.json` 2.7.0 → 3.0.0 + CHANGELOG. **Merging this to `main` is the GA trigger:** `release.yml` fires on push-to-main → `prepare` resolves 3.0.0 (no v3.0.0 tag yet) → tags `v3.0.0` → `build-tarballs` → `sign-attest` (Fulcio subject `automagik-dev/autopg`, matches the rewritten single-org trust regex) → `release-publish` ships signed assets.

Merge is humans-only per §19 — same as the #130 dev→main promotion you did.

### Already in main (via #129/#130)
Org rewrite + install.sh repair. This PR only carries the version bump that releases it.

### After merge — I run automatically
- Watch the release chain (build → sign-attest → release-publish) green
- **Phase 5 fresh-host smoke**: `curl …/automagik-dev/autopg/main/install.sh | bash` → `autopg --version` = 3.0.0 → `autopg verify`
- Then start **track 2**: omni → autopg socket-singleton + signed parity (inline)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## v3.0.0 Release

* **Installation & Configuration Updates**
  * Installation script enhanced with improved system detection and correct asset naming conventions
  * Corrected binary extraction paths and directory layout structure for better file organization
  * Verification mechanisms now include enhanced fallback support for various GitHub CLI versions
  * Increased overall reliability for fresh system bootstrapping and complete setup processes

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/automagik-dev/autopg/pull/131?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->