### PR TITLE
fix(release): scratch unbound var aborts every build-tarballs job (v3.0.0 GA blocker)

### DIFF
--- a/scripts/fetch-postgres-bins.sh
+++ b/scripts/fetch-postgres-bins.sh
@@ -117,7 +117,7 @@ stage_from_pkg() {
   # `scratch: unbound variable` and mask the real fetch error
   # (chatgpt-codex P2 review on PR #84).
   local scratch=""
-  trap 'rm -rf "$scratch"' RETURN
+  trap 'rm -rf "${scratch:-}"' RETURN
   scratch=$(mktemp -d) || return 1
 
   pushd "$scratch" >/dev/null
@@ -155,7 +155,7 @@ stage_from_url() {
 
   local scratch
   scratch=$(mktemp -d)
-  trap 'rm -rf "$scratch"' RETURN
+  trap 'rm -rf "${scratch:-}"' RETURN
 
   curl -fsSL "$url" -o "${scratch}/pg.tar.gz"
   tar -xzf "${scratch}/pg.tar.gz" -C "$scratch"


### PR DESCRIPTION
## v3.0.0 GA blocker — root cause

Every `Build <platform>` job in `Build Tarballs (autopg)` fails:
\`\`\`
scripts/fetch-postgres-bins.sh: line 179: scratch: unbound variable
##[error]Process completed with exit code 1
\`\`\`
`trap 'rm -rf "$scratch"' RETURN` (in `stage_from_pkg`/`stage_from_url`) leaks globally — bash RETURN traps aren't function-local without `set -o functrace` — and re-fires in `fetch_one`'s scope (line 179) where `$scratch` is undefined → `set -u` abort → exit 1 on **all 5 platforms**. v3.0.0's build run `26054382726` failed exactly this way; it's also why the prior **v2.7.0** sign-attest failed (`artifact not found` — build-tarballs never produced artifacts). **Not caused by the org transfer.**

## Fix

`${scratch:-}` in both traps — `set -u`-safe when the trap fires in a foreign scope; real cleanup still runs when `scratch` is set. Verified: `set -u` + a leaked RETURN trap no longer aborts; `bash -n` clean.

## After merge

v3.0.0's tag currently points at the broken commit and **published nothing** (build failed) — so v3.0.0 is safe to re-cut onto the fixed commit. Re-cut strategy is an operator call (see follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error reporting in PostgreSQL binary fetch operations by ensuring error messages are not masked during cleanup procedures.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/automagik-dev/autopg/pull/132?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->