### PR TITLE
release: v3.0.1 — first published v3 (post build-tarballs fix)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v3.0.1 — build-tarballs fix
+
+**Fixed:** `scripts/fetch-postgres-bins.sh` RETURN trap leaked globally (no `set -o functrace`) and aborted every per-platform build under `set -u` (`scratch: unbound variable`). This blocked the v3.0.0 build chain entirely; v3.0.1 is the first published v3 release (v3.0.0 tag never produced assets).
+
 ## v3.0.0 — autopg (org transfer + bootstrap repair)
 
 **Changed:** Repository transferred `namastexlabs/pgserve` → `automagik-dev/autopg` (transfer + rename). Old URLs 301-redirect. `src/cosign/trust-list.js` self-trust regex flipped to `automagik-dev/autopg` — v3+ binaries verify v3+ releases signed under the new org identity.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pgserve",
-  "version": "2.0.0",
+  "version": "3.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pgserve",
-      "version": "2.0.0",
+      "version": "3.0.1",
       "license": "MIT",
       "dependencies": {
         "bun": "^1.3.4"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "autopg",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Embedded PostgreSQL server with true concurrent connections - zero config, auto-provision databases",
   "main": "src/index.js",
   "type": "module",


### PR DESCRIPTION
## v3.0.1 — the real v3 release

`v3.0.0` tag exists but **published zero assets** (build-tarballs `scratch` unbound-var bug, fixed in #132). Per immutable-tag discipline v3.0.0 stays a phantom; **v3.0.1 is the first published v3**.

Bumps `package.json` 3.0.0 → 3.0.1 + CHANGELOG. Carries the org rewrite + install.sh repair (#129) and the build fix (#132), both already in main.

### After you merge
Push the tag (operator — §19/hook-gated for me):
\`\`\`
git -C /home/genie/workspace/repos/pgserve fetch origin && git -C /home/genie/workspace/repos/pgserve switch main && git -C /home/genie/workspace/repos/pgserve reset --hard origin/main && git -C /home/genie/workspace/repos/pgserve tag -a v3.0.1 -m "release v3.0.1" && git -C /home/genie/workspace/repos/pgserve push origin v3.0.1
\`\`\`
→ build-tarballs (now fixed) → sign-attest (Fulcio `automagik-dev/autopg`) → release-publish. I watch (SHA-scoped), then Phase 5 smoke + track 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)