### PR TITLE
fix(release): repair v3 signed-release pipeline (Bugs #1a/#1b/#2/#3)

### DIFF
--- a/.github/workflows/build-tarballs.yml
+++ b/.github/workflows/build-tarballs.yml
@@ -137,8 +137,18 @@ jobs:
             # GitHub-hosted ARM64 runners; falls back to QEMU emulation
             # if the org has not yet enabled ubuntu-24.04-arm runners.
             runner:   ubuntu-24.04-arm
-          - platform: darwin-x64
-            runner:   macos-13
+          # BRIEF-v3-build-fix Bug #2: darwin-x64 is intentionally NOT in
+          # this matrix. Its only viable hosted runner is `macos-13` (the
+          # last Intel macOS image — macos-14/15 are Apple Silicon), and
+          # the org's macOS runners are chronically unavailable, so the job
+          # sat `queued` forever holding the run-level conclusion `null`.
+          # That masked real failures AND, because a missing
+          # `autopg-*-darwin-x64` artifact fails sign-attest's `aggregate`
+          # (needs:[sign], no `if: always()`), it silently sank the entire
+          # signed-release chain. Dropping it lets the 4 buildable
+          # platforms publish a real signed release. Intel-macOS support is
+          # a tracked follow-up (re-add with a self-hosted/available Intel
+          # runner, or cross-build darwin-x64 + sign on darwin-arm64).
           - platform: darwin-arm64
             runner:   macos-latest
 

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -271,7 +271,7 @@ jobs:
             "version": "${VERSION}",
             "released_at": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
             "tarball_base": "https://github.com/${{ github.repository }}/releases/download/v${VERSION}",
-            "platforms": ["linux-x64-glibc","linux-x64-musl","linux-arm64","darwin-x64","darwin-arm64"]
+            "platforms": ["linux-x64-glibc","linux-x64-musl","linux-arm64","darwin-arm64"]
           }
           EOF
           done

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,6 +89,39 @@ jobs:
           git tag -a "${TAG}" -m "release ${TAG}"
           git push origin HEAD --follow-tags
 
+      # BRIEF-v3-build-fix Bug #3: the bump commit carries `[skip ci]` (a
+      # required bot-loop guard — the prepare gate filters that same marker
+      # so the push of this commit does NOT retrigger release.yml). But
+      # GitHub's skip-ci suppression ALSO applies to the *tag* push event,
+      # so `build-tarballs.yml` (on: push tags v*) never fires → the
+      # signed-release chain (build-tarballs → sign-attest →
+      # release-publish) silently never starts. This hit v2.7.0, v3.0.0,
+      # v3.0.2 (all tagged, none published anything).
+      #
+      # Fix: dispatch build-tarballs explicitly against the freshly-pushed
+      # tag. workflow_dispatch is NOT subject to skip-ci, GITHUB_TOKEN is
+      # permitted to start it, and `--ref ${TAG}` makes every job in the
+      # chain check out the tagged tree. `[skip ci]` stays intact.
+      - name: Kick build-tarballs for the tag (skip-ci-immune)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION="${{ steps.bump.outputs.version }}"
+          TAG="${{ steps.bump.outputs.tag }}"
+          # Tag refs need a beat to register before the API accepts --ref.
+          for i in 1 2 3 4 5; do
+            if gh workflow run build-tarballs.yml \
+                 --ref "${TAG}" \
+                 -f version="${VERSION}"; then
+              echo "Dispatched build-tarballs.yml @ ${TAG} (version=${VERSION})"
+              exit 0
+            fi
+            echo "build-tarballs dispatch attempt ${i} failed; retrying in 10s"
+            sleep 10
+          done
+          echo "::error::could not dispatch build-tarballs.yml for ${TAG}"
+          exit 1
+
   # ---------------------------------------------------------------------------
   # Prepare: resolve version, skip if tag already exists, build changelog.
   #

--- a/.github/workflows/sign-attest.yml
+++ b/.github/workflows/sign-attest.yml
@@ -83,7 +83,11 @@ jobs:
           - linux-x64-glibc
           - linux-x64-musl
           - linux-arm64
-          - darwin-x64
+          # darwin-x64 dropped in lockstep with build-tarballs.yml — see
+          # the Bug #2 comment there. A `download-artifact` for a tarball
+          # build-tarballs never produced would fail this matrix leg, and
+          # the `aggregate` job (needs:[sign]) would be skipped, taking the
+          # whole release-publish chain down with it.
           - darwin-arm64
 
     steps:

--- a/bin/postgres-server.js
+++ b/bin/postgres-server.js
@@ -19,6 +19,9 @@ import { PostgresManager } from '../src/postgres.js';
 import { resolveSocketDir, ensureSocketDir } from '../src/lib/socket-dir.js';
 import { writeRuntimeJson, clearRuntimeJson } from '../src/lib/runtime-json.js';
 import { createLogger } from '../src/logger.js';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
 
 // Global error handlers — surface unhandled rejections + uncaught errors
 // loud so a process supervisor (pm2 / systemd-user / launchd) restarts the
@@ -32,6 +35,26 @@ process.on('uncaughtException', (error) => {
 });
 
 const args = process.argv.slice(2);
+
+// `autopg --version` / `-v` — MUST exit 0 with `autopg <version>`.
+//
+// This entry point is what `scripts/build-binary.sh` compiles via
+// `bun build --compile` (the tarball's `autopg` binary IS this file),
+// AND what `bin/autopg-wrapper.cjs` spawns through bun for the npm path.
+// Both surfaces previously fell through to `printHelp()` + `exit(1)` —
+// `tests/integration/tarball-smoke.sh` swallowed the stderr and reported
+// the generic "autopg binary not executable", masking the real cause
+// (no `--version` handler ever existed). See BRIEF-v3-build-fix Bug #1a.
+//
+// Version source: build-binary.sh injects `--define BUILD_VERSION="'<v>'"`,
+// so in the compiled binary the bare `BUILD_VERSION` token is replaced with
+// a string literal. `typeof` on an undeclared identifier is the one safe
+// form in JS (returns 'undefined' without throwing), so the non-compiled
+// wrapper path falls back to package.json cleanly.
+if (args[0] === '--version' || args[0] === '-v') {
+  process.stdout.write(`autopg ${resolveVersion()}\n`);
+  process.exit(0);
+}
 
 if (args[0] === 'postmaster') {
   await runPostmasterSubcommand(args.slice(1));
@@ -216,6 +239,20 @@ no router, no bun proxy, no daemon control socket.
   }
   if (opts.socketDir === undefined) opts.socketDir = resolveSocketDir();
   return opts;
+}
+
+function resolveVersion() {
+  // Compiled binary: bun's `--define` already replaced BUILD_VERSION with a
+  // string literal. `typeof <undeclared>` is the only reference form that
+  // can't throw, so the non-compiled (wrapper/dev) path falls through here.
+  if (typeof BUILD_VERSION !== 'undefined' && BUILD_VERSION) return BUILD_VERSION;
+  try {
+    const here = dirname(fileURLToPath(import.meta.url));
+    const pkg = JSON.parse(readFileSync(join(here, '..', 'package.json'), 'utf8'));
+    return pkg.version || '0.0.0';
+  } catch {
+    return '0.0.0';
+  }
 }
 
 function printHelp() {

--- a/scripts/fetch-postgres-bins.sh
+++ b/scripts/fetch-postgres-bins.sh
@@ -31,6 +31,46 @@ DIST_DIR="${AUTOPG_DIST_DIR:-${REPO_ROOT}/dist}"
 
 PLATFORMS=(linux-x64-glibc linux-x64-musl linux-arm64 darwin-x64 darwin-arm64)
 
+# Stage the bundled shared-library tree (libssl.so.1.1, libcrypto.so.1.1,
+# libicu*.so.60, libxml2, …) that @embedded-postgres ships under native/lib/.
+#
+# WITHOUT this the postgres binary cannot start on ANY modern host: its
+# DT_NEEDED list references libssl.so.1.1 + libicui18n.so.60 which no
+# current distro provides, and its RUNPATH is `$ORIGIN/../lib` — so the
+# libs MUST sit at <out>/lib/. The previous fetch logic copied only bin/
+# + share/, so every tarball shipped a postgres that died with
+# "error while loading shared libraries" (BRIEF-v3-build-fix Bug #1b).
+#
+# The package also ships pg-symlinks.json: the version symlinks
+# (libicui18n.so.60 → libicui18n.so.60.2) that postgres' DT_NEEDED
+# resolves through are created by the package's postinstall, which we
+# deliberately skip (`npm install --ignore-scripts`). Replay them here so
+# the staged tree is self-contained and `postgres --version` works via
+# RUNPATH alone (what tests/integration/tarball-smoke.sh --real asserts).
+stage_lib_tree() {
+  local src_lib="$1" out_dir="$2" symlinks_json="${3:-}"
+  if [[ ! -d "$src_lib" ]]; then
+    echo "    (no lib/ at ${src_lib}; skipping bundled-lib stage)"
+    return 0
+  fi
+  cp -R "$src_lib" "${out_dir}/lib"
+  if [[ -n "$symlinks_json" && -f "$symlinks_json" ]]; then
+    node -e '
+      const fs = require("fs"), path = require("path");
+      const [json, libDir] = process.argv.slice(1);
+      const entries = JSON.parse(fs.readFileSync(json, "utf8"));
+      let n = 0;
+      for (const { source, target } of entries) {
+        const linkPath = path.join(libDir, path.basename(target));
+        try { fs.unlinkSync(linkPath); } catch {}
+        fs.symlinkSync(path.basename(source), linkPath);
+        n++;
+      }
+      console.log(`    ✓ replayed ${n} pg-symlinks into ${libDir}`);
+    ' "$symlinks_json" "${out_dir}/lib"
+  fi
+}
+
 # Map autopg platform tag → npm package suffix used by @embedded-postgres.
 # linux-x64-musl + linux-arm64 currently lack a published @embedded-postgres
 # package; for those, set AUTOPG_POSTGRES_LOCAL_DIR or AUTOPG_POSTGRES_URL_TEMPLATE.
@@ -106,6 +146,7 @@ stage_from_local() {
   fi
   cp -R "$local_dir/bin"   "$out_dir/bin"
   cp -R "$local_dir/share" "$out_dir/share" 2>/dev/null || mkdir -p "$out_dir/share"
+  stage_lib_tree "$local_dir/lib" "$out_dir"
 }
 
 stage_from_pkg() {
@@ -142,6 +183,7 @@ EOF
 
   cp -R "${native}/bin"   "${out_dir}/bin"
   cp -R "${native}/share" "${out_dir}/share" 2>/dev/null || mkdir -p "${out_dir}/share"
+  stage_lib_tree "${native}/lib" "${out_dir}" "${native}/pg-symlinks.json"
   popd >/dev/null
 }
 
@@ -174,6 +216,7 @@ stage_from_url() {
   fi
   cp -R "${root}/bin"   "${out_dir}/bin"
   cp -R "${root}/share" "${out_dir}/share" 2>/dev/null || mkdir -p "${out_dir}/share"
+  stage_lib_tree "${root}/lib" "${out_dir}"
 }
 
 fetch_one() {


### PR DESCRIPTION
## Why no v3 ever published

`BRIEF-v3-build-fix.md`. Every v3 tag (v2.7.0 / v3.0.0 / v3.0.2) was immutable-tagged but **published nothing** — three independent blockers, all reproduced locally with evidence (not theorized).

## Bugs fixed

### #1a — `autopg --version` exited 1 (all platforms)
`bin/postgres-server.js` — the file `bun build --compile` turns into the tarball's `autopg`, **and** what `autopg-wrapper.cjs` spawns via bun — never had a `--version` handler. It fell through to `printHelp()` + `process.exit(1)`. `tests/integration/tarball-smoke.sh:154` swallowed stderr with `2>/dev/null` and reported the generic *"autopg binary not executable"*, masking the real cause for three releases.
**Fix:** add `--version`/`-v` → `autopg <v>` exit 0, using bun's `--define BUILD_VERSION` literal with a package.json fallback for the non-compiled wrapper/dev path.

### #1b — `postgres --version` exited 127 (`libssl.so.1.1` / `libicu*.so.60` not found, all platforms)
`@embedded-postgres` ships `native/lib/` (libssl.so.1.1, libcrypto.so.1.1, libicu*.so.60, libxml2, …) **plus** `pg-symlinks.json` (the version symlinks postgres' `DT_NEEDED` resolves through; created by the package postinstall we skip via `--ignore-scripts`). `scripts/fetch-postgres-bins.sh` copied only `bin/` + `share/` — it **dropped `lib/` entirely** and never replayed the symlinks. postgres' `RUNPATH` is `$ORIGIN/../lib`, so every shipped tarball's postgres was **DOA on any modern host**, not just in CI.
**Fix:** new `stage_lib_tree` helper copies `native/lib/` and replays `pg-symlinks.json`; wired into all three source paths (pkg / local / url).

### #2 — `darwin-x64` chronically `queued` (masked failures, sank the chain)
Only viable hosted runner is `macos-13` (last Intel image; macos-14/15 are Apple Silicon) and the org's macOS runners are unavailable, so the job sat `queued` forever holding run-conclusion `null`. A missing `autopg-*-darwin-x64` artifact also fails `sign-attest`'s `aggregate` (`needs:[sign]`, no `if: always()`) → kills `release-publish`. Dropped from the build + sign matrices and the channel manifest. **Intel-macOS is a tracked follow-up** (self-hosted/available Intel runner, or cross-build + sign on darwin-arm64).

### #3 — `[skip ci]` suppressed the tag-triggered release
`release.yml`'s `bump` job commits `[skip ci] release vX` (a required bot-loop guard the `prepare` gate filters) then tags **that** commit. GitHub's skip-ci suppression also applies to the **tag-push** event → `build-tarballs.yml` never fired → the entire signed-release chain silently never started.
**Fix:** the `bump` job now explicitly `gh workflow run build-tarballs.yml --ref <tag> -f version=<v>` (with retry). `workflow_dispatch` is skip-ci-immune and GITHUB_TOKEN-permitted; `[skip ci]` stays intact (no bot loop).

## Evidence (local, reproduced — not theorized)

Full `linux-x64-glibc` pipeline `build-binary → fetch-postgres-bins → assemble-tarball → tarball-smoke.sh --real`:

```
✓ autopg --version → autopg 3.0.3
✓ postgres --version → postgres (PostgreSQL) 18.3
==> 11 passed, 0 failed        (was: 9 passed, 2 failed, exit 1)
```

- Tarball **48M** (inside the 30–120MB band check)
- Fixture smoke **11/0 on all 5 platforms** (the every-PR gate)
- `shellcheck -S warning` **clean** on all touched scripts
- All four workflows parse; matrices confirmed (`darwin-x64` removed from build + sign)
- npm wrapper path `autopg --version` → exit 0 via package.json fallback

## Merge / release

Per repo constraint §19, PRs targeting `main` are **human-merge only** — leaving this for a maintainer. On merge, cut **v3.0.3** via `gh workflow run release.yml -f bump=patch` (do **not** move the phantom v3.0.0/v3.0.2 tags). The #3 fix makes the `bump` job kick `build-tarballs` for the new tag → `sign-attest` → `release-publish` should produce the first real signed v3 GitHub Release (`.tar.gz` + `.sig` + `.cert` + `.intoto.jsonl` + `.sha256`), after which `install.sh` fresh-host smoke can run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--version` / `-v` flag support to check application version.

* **Changes**
  * Removed Intel macOS (darwin-x64) platform support.
  * Improved PostgreSQL library staging and runtime resolution across build configurations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/automagik-dev/autopg/pull/134?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->