### PR TITLE
fix(release): v3.0.3 run follow-ups — actions:write, linux-arm64, drop musl, tar_flags

### DIFF
--- a/.github/workflows/build-tarballs.yml
+++ b/.github/workflows/build-tarballs.yml
@@ -131,8 +131,14 @@ jobs:
         include:
           - platform: linux-x64-glibc
             runner:   ubuntu-latest
-          - platform: linux-x64-musl
-            runner:   ubuntu-latest
+          # linux-x64-musl dropped: @embedded-postgres publishes NO musl
+          # build (only glibc linux-x64 + linux-arm64), and no
+          # AUTOPG_POSTGRES_URL_TEMPLATE repo var is configured, so every
+          # musl fetch died "no @embedded-postgres pkg ... set
+          # AUTOPG_POSTGRES_URL_TEMPLATE". A missing artifact also sinks
+          # sign-attest's aggregate (same failure mode as darwin-x64).
+          # Re-add when a musl postgres source (URL template / self-hosted
+          # cache) exists — tracked follow-up.
           - platform: linux-arm64
             # GitHub-hosted ARM64 runners; falls back to QEMU emulation
             # if the org has not yet enabled ubuntu-24.04-arm runners.

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -271,7 +271,7 @@ jobs:
             "version": "${VERSION}",
             "released_at": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
             "tarball_base": "https://github.com/${{ github.repository }}/releases/download/v${VERSION}",
-            "platforms": ["linux-x64-glibc","linux-x64-musl","linux-arm64","darwin-arm64"]
+            "platforms": ["linux-x64-glibc","linux-arm64","darwin-arm64"]
           }
           EOF
           done

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,6 +37,12 @@ concurrency:
 
 permissions:
   contents: write
+  actions: write    # the bump job's "Kick build-tarballs" step calls
+                    # `gh workflow run build-tarballs.yml` — creating a
+                    # workflow_dispatch event needs actions:write or the
+                    # default GITHUB_TOKEN gets HTTP 403 "Resource not
+                    # accessible by integration" (Bug #3 follow-up: the
+                    # dispatch step failed for v3.0.3 with exactly this).
   id-token: write   # required so the reusable `version.yml` workflow can mint
                     # the OIDC token for npm Trusted Publishing — without this,
                     # GH rejects the workflow at parse time (startup_failure)

--- a/.github/workflows/sign-attest.yml
+++ b/.github/workflows/sign-attest.yml
@@ -81,7 +81,9 @@ jobs:
       matrix:
         platform:
           - linux-x64-glibc
-          - linux-x64-musl
+          # linux-x64-musl dropped in lockstep with build-tarballs.yml
+          # (no @embedded-postgres musl package). A download-artifact for a
+          # tarball that was never built fails this leg and skips aggregate.
           - linux-arm64
           # darwin-x64 dropped in lockstep with build-tarballs.yml — see
           # the Bug #2 comment there. A `download-artifact` for a tarball

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
   "optionalDependencies": {
     "@embedded-postgres/darwin-arm64": "18.3.0-beta.17",
     "@embedded-postgres/darwin-x64": "18.3.0-beta.17",
+    "@embedded-postgres/linux-arm64": "18.3.0-beta.17",
     "@embedded-postgres/linux-x64": "18.3.0-beta.17",
     "@embedded-postgres/windows-x64": "18.3.0-beta.17"
   },

--- a/scripts/assemble-tarball.sh
+++ b/scripts/assemble-tarball.sh
@@ -165,7 +165,12 @@ assemble_one() {
     tar_flags+=(--owner=0 --group=0 --numeric-owner)
   fi
 
-  tar -C "$stage" -czf "$tarball" "${tar_flags[@]}" autopg/ || return 1
+  # macOS ships bash 3.2, where `"${arr[@]}"` on an EMPTY array trips
+  # `set -u` ("unbound variable"). On macOS BSD-tar none of the GNU-only
+  # flags above match, so tar_flags is empty and every darwin-* assemble
+  # died here (pre-existing; only surfaced once builds reached this step).
+  # `${arr[@]+"${arr[@]}"}` expands to nothing when unset, the flags when set.
+  tar -C "$stage" -czf "$tarball" ${tar_flags[@]+"${tar_flags[@]}"} autopg/ || return 1
   echo "    ✓ tarball: $tarball ($(du -h "$tarball" | cut -f1))"
 
   # 4) outer SHA256 — Group 8 cosign-signs this; Group 9 publishes both.

--- a/scripts/fetch-postgres-bins.sh
+++ b/scripts/fetch-postgres-bins.sh
@@ -78,7 +78,10 @@ embedded_pkg_for() {
   case "$1" in
     linux-x64-glibc) echo "linux-x64" ;;
     linux-x64-musl)  echo "" ;;
-    linux-arm64)     echo "" ;;
+    # @embedded-postgres/linux-arm64 IS published (same 18.3.0-beta.* line
+    # as linux-x64); the mapping was just never wired, so every arm64
+    # release build failed "no @embedded-postgres pkg for linux-arm64".
+    linux-arm64)     echo "linux-arm64" ;;
     darwin-x64)      echo "darwin-x64" ;;
     darwin-arm64)    echo "darwin-arm64" ;;
     *) return 1 ;;


### PR DESCRIPTION
Follow-up to #134. Dispatching `build-tarballs` for **v3.0.3** (after #134 merged) **proved the #1a/#1b fixes work** — `Build linux-x64-glibc: completed/success` (previously `9 passed, 2 failed`). It also surfaced 4 further blockers — all pre-existing infra/portability defects, **not regressions from #134**:

| # | Blocker (evidence from run `26112612549`) | Fix |
|---|---|---|
| **5** | Bug #3's "Kick build-tarballs" step → `HTTP 403: Resource not accessible by integration` on the workflow_dispatch API. Tag **v3.0.3 was created+pushed fine**, but the signed chain was never kicked (default `GITHUB_TOKEN` can't dispatch without `actions:write`). | add `actions: write` to `release.yml` permissions |
| **6** | `Build linux-arm64: failure` — *"no @embedded-postgres pkg for linux-arm64"*, yet `@embedded-postgres/linux-arm64@18.3.0-beta.17` **is published**. `embedded_pkg_for` simply never mapped it. | map `linux-arm64` + add to `optionalDependencies` |
| **7** | `Build linux-x64-musl: failure` — `@embedded-postgres` publishes **no musl build** and no `AUTOPG_POSTGRES_URL_TEMPLATE` var is set; missing artifact also sinks `sign-attest`'s `aggregate` (same mode as darwin-x64). | drop `linux-x64-musl` from build+sign matrices + channel manifest (tracked follow-up) |
| **8** | `Build darwin-arm64: failure` — `assemble-tarball.sh:168 tar_flags[@]: unbound variable`. macOS **bash 3.2** + `set -u` + empty array (BSD tar matches none of the GNU-only flags). Killed every darwin-* assemble. | `${tar_flags[@]+"${tar_flags[@]}"}` empty-safe expansion |

**Net published surface:** `linux-x64-glibc`, `linux-arm64`, `darwin-arm64` — each backed by a real `@embedded-postgres` package.

### Validation (local)
- glibc full `build → fetch → assemble → smoke --real`: **11 passed, 0 failed** (no regression)
- `tar_flags` idiom verified empty **and** populated under `set -u`
- `shellcheck -S warning` clean; fixture smoke **11/0** on all 3 kept platforms; 4 workflows parse
- linux-arm64 `npm EBADPLATFORM` locally is a host-x64 artifact — CI's `linux-arm64` job runs on `ubuntu-24.04-arm` (cpu matches there; darwin-arm64 already fetched OK on its arm64 runner in the v3.0.3 run)

### Release note
Per §19 this is **human-merge only**. v3.0.3 is now a phantom tag (chain never kicked due to blocker 5 + arm64/musl/darwin build failures) — do **not** move it. After merge, cut **v3.0.4** via `gh workflow run release.yml -f bump=patch`; with `actions:write` the bump job will self-dispatch `build-tarballs` → sign-attest → release-publish for the 3-platform signed release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed `linux-x64-musl` from supported release platforms.
  * Added proper `linux-arm64` platform support to builds.
  * Updated CI/CD workflows with necessary permissions and platform configurations.

* **Bug Fixes**
  * Fixed tarball assembly compatibility on macOS.
  * Resolved linux-arm64 package resolution in the build pipeline.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/automagik-dev/autopg/pull/135?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->