### PR TITLE
fix(release): verify provenance with gh attestation verify (slsa-verifier cannot)

### DIFF
--- a/.github/workflows/sign-attest.yml
+++ b/.github/workflows/sign-attest.yml
@@ -254,8 +254,11 @@ jobs:
         with:
           cosign-release: 'v2.4.1'
 
-      - name: Install slsa-verifier
-        uses: slsa-framework/slsa-verifier/actions/installer@v2.6.0
+      # slsa-verifier removed: it only verifies slsa-github-generator
+      # (intoto:0.0.2) provenance and rejects every actions/attest-build-
+      # provenance bundle ("unexpected tlog entry type: got dsse:0.0.1").
+      # verify-published-artifacts.sh now uses `gh attestation verify`
+      # (gh is preinstalled on GitHub runners).
 
       - name: Aggregate manifest.json
         shell: bash
@@ -269,6 +272,7 @@ jobs:
         shell: bash
         env:
           AUTOPG_SOURCE_URI: github.com/${{ github.repository }}
+          GH_TOKEN: ${{ github.token }}   # gh attestation verify (provenance gate)
         run: |
           bash scripts/verify-published-artifacts.sh dist/
 

--- a/scripts/verify-published-artifacts.sh
+++ b/scripts/verify-published-artifacts.sh
@@ -112,8 +112,14 @@ require_tools() {
     exit 2
   }
   if [[ "$SKIP_SLSA" -eq 0 ]]; then
-    if ! command -v slsa-verifier >/dev/null 2>&1; then
-      note "slsa-verifier not on PATH — provenance check will be skipped (pass --skip-slsa to silence)"
+    # Provenance is produced by actions/attest-build-provenance, whose Rekor
+    # entry is `dsse:0.0.1`. `slsa-verifier verify-artifact` only understands
+    # slsa-github-generator's `intoto:0.0.2` entries and fails every bundle
+    # with "unexpected tlog entry type" — that gate is why no v3 ever got
+    # past signing. `gh attestation verify` is the first-class verifier for
+    # attest-build-provenance bundles.
+    if ! command -v gh >/dev/null 2>&1; then
+      note "gh not on PATH — provenance check will be skipped (pass --skip-slsa to silence)"
       SKIP_SLSA=1
     fi
   fi
@@ -191,13 +197,19 @@ verify_slsa() {
     bad "$(basename "$tarball"): missing .intoto.jsonl provenance"
     return 1
   fi
-  if slsa-verifier verify-artifact \
-        "$tarball" \
-        --provenance-path "$prov" \
-        --source-uri "$SOURCE_URI" >/dev/null 2>&1; then
+  # SOURCE_URI is `github.com/<owner>/<repo>`; gh wants `<owner>/<repo>`.
+  local repo="${SOURCE_URI#github.com/}"
+  # Offline bundle verification, anchored to the same Fulcio identity +
+  # OIDC issuer the cosign keyless check enforces, so a stray attestation
+  # from another workflow can't satisfy this gate.
+  if gh attestation verify "$tarball" \
+        --bundle "$prov" \
+        --repo "$repo" \
+        --cert-identity-regex "$TRUST_REGEX" \
+        --cert-oidc-issuer "$OIDC_ISSUER" >/dev/null 2>&1; then
     ok "$(basename "$tarball"): SLSA provenance verifies"
   else
-    bad "$(basename "$tarball"): slsa-verifier FAILED"
+    bad "$(basename "$tarball"): gh attestation verify FAILED"
     return 1
   fi
 }


### PR DESCRIPTION
Follow-up to #134/#135. The reason no v3 ever published even after signing.

Cutting v3.0.4 (after #135) proved #1a/#1b/#6/#8 in real CI: all 3 Build jobs
green (linux-x64-glibc, linux-arm64, darwin-arm64), all 3 cosign keyless
signatures + SLSA provenances produced. sign-attest aggregate then failed in
verify-published-artifacts.sh: slsa-verifier FAILED -> pass=9 fail=3.

Real error (captured from v3.0.4 bundles + slsa-verifier v2.6.0, not theorized):
  FAILED: matching bundle entry with content: unexpected tlog entry type:
  expected intoto:0.0.2, got dsse:0.0.1

slsa-verifier verify-artifact only verifies slsa-github-generator provenance
(Rekor intoto:0.0.2). Our provenance is actions/attest-build-provenance
(slsa.dev/provenance/v1, buildType actions.github.io/buildtypes/workflow/v1,
Rekor dsse:0.0.1). slsa-verifier rejects every such bundle; --builder-id does
not help. This gate could never have gone green on a real release.

Fix: verify with `gh attestation verify` (first-class for attest-build-
provenance), offline via --bundle, anchored to the same Fulcio identity regex
+ OIDC issuer the cosign keyless check enforces. Drop the dead slsa-verifier
installer (gh preinstalled on runners); give the verify step GH_TOKEN.

Proof vs the real v3.0.4 signed bundles (sign-attest run 26113708890):
linux-x64-glibc / linux-arm64 / darwin-arm64 all verify exit 0; a byte-flipped
tarball fails exit 1. shellcheck clean. Fixture path untouched (keyed +
--skip-slsa).

Separate, documented: release.yml bump dispatches build-tarballs via
GITHUB_TOKEN; GitHub does not cascade workflow_run from a GITHUB_TOKEN-
initiated run, so build->sign->publish must be hand-driven with a PAT for now
(how v3.0.4 got signed). Auto-cascade is a tracked follow-up, deliberately not
blind-implemented (untestable under human-merge-only).

After merge (per S19, human-merge only): v3.0.0/v3.0.2/v3.0.3/v3.0.4 are
phantom - do NOT move them. Cut v3.0.5 via
`gh workflow run release.yml -f bump=patch`; build->sign->publish then
hand-driven with a PAT, then verify the signed Release + install.sh smoke.
