### PR TITLE
fix(release): unified compiled CLI entry — tarball autopg gets all verbs (#10)

### DIFF
--- a/bin/autopg-cli.js
+++ b/bin/autopg-cli.js
@@ -1,0 +1,123 @@
+#!/usr/bin/env bun
+
+/**
+ * autopg-cli — the unified entry point for the COMPILED single-binary
+ * distribution (BRIEF-v3-build-fix blocker #10).
+ *
+ * `scripts/build-binary.sh` compiles THIS file with `bun build --compile`.
+ * The tarball's `autopg` IS this module.
+ *
+ * Why this exists: the npm package's bin (`bin/autopg-wrapper.cjs`) is a
+ * node launcher that resolves an external `bun` from node_modules and
+ * spawns it on `bin/postgres-server.js` for the long-running paths, while
+ * routing the pure-node operator verbs (install / verify / doctor / …)
+ * in-process through `src/cli-install.cjs`. That spawn-external-bun model
+ * cannot exist inside a single compiled binary — there is no node_modules
+ * and the binary already IS the runtime. Before this entry, the build
+ * compiled bare `postgres-server.js`, so the tarball `autopg` only knew
+ * `--version` / `postmaster` / `serve` and every operator verb (and
+ * install.sh's own final `autopg install`) exited 1 with a help dump.
+ *
+ * This entry mirrors the wrapper's dispatch, MINUS the bun-spawn:
+ *   - `--version` / `-v`         → print `autopg <version>` (exit 0)
+ *   - install/operator verbs     → src/cli-install.cjs `dispatch()` in
+ *                                  process. The supervised postmaster
+ *                                  command is THIS executable
+ *                                  (`process.execPath`) invoked with
+ *                                  `postmaster` — pm2 runs it under
+ *                                  `--interpreter none`, and the binary
+ *                                  handles `postmaster` natively.
+ *   - postmaster/serve/help/…    → delegate to bin/postgres-server.js
+ *                                  (re-used as a module; it reads argv).
+ *
+ * Keep the verb set in sync with bin/autopg-wrapper.cjs's
+ * __installSubcommands — that file remains the npm-path dispatcher.
+ */
+
+import cliInstall from '../src/cli-install.cjs';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const args = process.argv.slice(2);
+const sub = args[0];
+
+// `autopg --version` / `-v` — MUST exit 0 with `autopg <version>`.
+// Same contract + version source as bin/postgres-server.js (the bun
+// `--define BUILD_VERSION` literal in the compiled binary, package.json
+// fallback otherwise). `typeof` on an undeclared id is the one safe form.
+if (sub === '--version' || sub === '-v') {
+  process.stdout.write(`autopg ${resolveVersion()}\n`);
+  process.exit(0);
+}
+
+// Mirror of bin/autopg-wrapper.cjs __installSubcommands (the authoritative
+// npm-path routing). These are pure node + child_process — no bun, no
+// running PG backend — so they run in-process here.
+const INSTALL_SUBCOMMANDS = new Set([
+  'install',
+  'uninstall',
+  'status',
+  'url',
+  'port',
+  'config',
+  'update',
+  'restart',
+  'ui',
+  'verify',
+  'doctor',
+  'trust',
+  'gc',
+  'provision',
+  'create-app',
+]);
+
+if (sub && INSTALL_SUBCOMMANDS.has(sub)) {
+  // In the compiled binary, the postmaster the supervisor (pm2) must run
+  // is THIS executable with `postmaster`. process.execPath is the compiled
+  // binary path; buildPm2StartArgs() does
+  //   pm2 start <scriptPath> --interpreter none -- postmaster …
+  // so pm2 execs `<self> postmaster …`, which the binary handles.
+  const self = process.execPath;
+  const result = cliInstall.dispatch(sub, process.argv.slice(3), {
+    scriptPath: self,
+    wrapperPath: self,
+  });
+
+  // dispatch() returns either a number (sync verbs) or a Promise (async
+  // verbs: uninstall/doctor/verify/trust/gc/provision/create-app/update).
+  // Mirror the wrapper's dual handling + the EADDRINUSE double-print guard.
+  if (result && typeof result.then === 'function') {
+    result.then(
+      (code) => process.exit(typeof code === 'number' ? code : 0),
+      (err) => {
+        if (err && err.code !== 'EADDRINUSE') {
+          process.stderr.write(`autopg: ${err?.message ?? err}\n`);
+        }
+        if (process.exitCode === undefined || process.exitCode === 0) {
+          process.exitCode = 1;
+        }
+      },
+    );
+  } else {
+    process.exit(typeof result === 'number' ? result : 0);
+  }
+} else {
+  // postmaster / serve / --help / help / empty / unknown flags →
+  // bin/postgres-server.js owns this surface (it reads process.argv and
+  // dispatches, including its own `serve`→`postmaster` alias + the
+  // EX_USAGE-style unknown-verb exit). Re-used as a module so there is a
+  // single postmaster implementation.
+  await import('./postgres-server.js');
+}
+
+function resolveVersion() {
+  if (typeof BUILD_VERSION !== 'undefined' && BUILD_VERSION) return BUILD_VERSION;
+  try {
+    const here = dirname(fileURLToPath(import.meta.url));
+    const pkg = JSON.parse(readFileSync(join(here, '..', 'package.json'), 'utf8'));
+    return pkg.version || '0.0.0';
+  } catch {
+    return '0.0.0';
+  }
+}

--- a/knip.json
+++ b/knip.json
@@ -3,6 +3,7 @@
   "entry": [
     "src/index.js",
     "bin/postgres-server.js",
+    "bin/autopg-cli.js",
     "bin/autopg-wrapper.cjs",
     "src/update/index.js",
     "src/commands/**",

--- a/scripts/build-binary.sh
+++ b/scripts/build-binary.sh
@@ -28,7 +28,13 @@
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
-ENTRY_POINT="${AUTOPG_ENTRY_POINT:-bin/postgres-server.js}"
+# BRIEF-v3-build-fix #10: compile the UNIFIED CLI entry, not bare
+# postgres-server.js. bin/autopg-cli.js routes the operator verbs
+# (install/verify/doctor/…) through src/cli-install.cjs in-process and
+# delegates postmaster/serve to postgres-server.js, so the tarball
+# `autopg` has the full verb surface (and install.sh's own `autopg
+# install` works). Was `bin/postgres-server.js` → only --version/postmaster.
+ENTRY_POINT="${AUTOPG_ENTRY_POINT:-bin/autopg-cli.js}"
 DIST_DIR="${AUTOPG_DIST_DIR:-${REPO_ROOT}/dist}"
 FALLBACK_ENABLED="${AUTOPG_BUILD_FALLBACK:-0}"
 


### PR DESCRIPTION
**Blocker #10** — found running the Phase-5 smoke on the published **v3.0.5**.

The tarball `autopg` only knew `--version`/`postmaster`/`serve`. `verify`, `doctor`, `install`, … live in `bin/autopg-wrapper.cjs` + `src/cli-install.cjs` (the npm `bin`) and were never compiled in. Consequences:
- `autopg verify <tarball>` (Phase-5 smoke 2) exited 1 with a help dump
- `install.sh`'s own final `"$INSTALL_DIR/autopg" install` is broken for the tarball distribution (never exercised — no v3 ever installed end-to-end)

The wrapper can't be the compile entry: it resolves an external `bun` from `node_modules` and spawns it on `postgres-server.js` — neither exists inside a single compiled binary.

### Fix
New `bin/autopg-cli.js` as the compile entry (`build-binary.sh` default `ENTRY_POINT` `bin/postgres-server.js` → `bin/autopg-cli.js`; `knip.json` entry updated). It mirrors the wrapper's dispatch **minus** the bun-spawn:
- `--version`/`-v` → `autopg <version>` (BUILD_VERSION / package.json fallback)
- install/operator verbs → `src/cli-install.cjs` `dispatch()` **in-process**, with `scriptPath = process.execPath` so pm2 supervises `<self> postmaster …` (the binary handles `postmaster` natively)
- `postmaster`/`serve`/help/… → delegate to `bin/postgres-server.js` (single postmaster impl)

The npm path (`autopg-wrapper.cjs`) is **untouched**.

### Proven on the compiled binary (local)
| command | result |
|---|---|
| `autopg --version` | `autopg 3.0.6` (exit 0) |
| `autopg verify <real v3.0.5 .tgz>` | exit 0 — `verified … as automagik-pgserve-release (cosign_signed)` |
| `autopg doctor` | real diagnostics (`commands/doctor.js`) |
| `autopg install --help` | cli-install usage, in-process, **no daemon** |
| `autopg postmaster --help` | postgres-server.js help |

Regression: `tarball-smoke --real` **11/0**; fixture **11/0 ×3**; shellcheck + eslint + knip clean.

Known, documented, non-blocking: `update` uses a computed `__dirname` require (not bundle-static) — pre-existing, not smoke-critical, tracked follow-up.

### After merge (per §19, human-merge only)
Cut **v3.0.6** via `gh workflow run release.yml -f bump=patch`; I hand-drive build→sign→publish with a PAT (GITHUB_TOKEN-cascade follow-up still open), then run the **full** Phase-5 smoke — `autopg --version` **and** `autopg verify` — against the published v3.0.6, after which the clean from-scratch reinstall (your goal) can proceed with a genuinely working install.sh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--version` and `-v` flags to display autopg version information

* **Chores**
  * Unified CLI entry point for compiled binary distribution
  * Updated build configuration to reflect new CLI routing structure

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/automagik-dev/autopg/pull/137?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->