### PR TITLE
fix(install): honor runtime.enablePgvector from settings.json

### DIFF
--- a/src/cli-install.cjs
+++ b/src/cli-install.cjs
@@ -499,12 +499,56 @@ function getEffectiveSupervision() {
   }
 }
 
+/**
+ * Read the effective `runtime.enablePgvector` setting from settings.json.
+ * Defaults to `false` (matches HARDENED_DEFAULTS behavior). Returns boolean.
+ *
+ * Precedence: defaults < settings.json < env (env wins via loadEffectiveConfig).
+ *
+ * This is what propagates `autopg config set runtime.enablePgvector true` into
+ * the pm2-supervised postmaster's CLI args. Without this read, settings.json's
+ * `enablePgvector` would be silently ignored and `--pgvector` would never reach
+ * the postmaster's `parsePostmasterArgs`, so `_doEnsurePgvectorFiles` (which
+ * downloads + stages vector.so on PG start when `enablePgvector` is true) would
+ * never run — leaving fresh installs without the extension files. See
+ * https://github.com/namastexlabs/pgserve/issues/<TBD> for the regression
+ * surfaced by `@khal-os/brain` v1.61.x dogfood.
+ */
+function getEffectiveEnablePgvector() {
+  try {
+    const { loadEffectiveConfig } = require('./settings-loader.cjs');
+    const { settings } = loadEffectiveConfig();
+    return settings?.runtime?.enablePgvector === true;
+  } catch {
+    return false;
+  }
+}
+
 function buildPm2StartArgs({ scriptPath, port, dataDir, socketDir }) {
   const logs = {
     out: path.join(getLogsDir(), `${PM2_PROCESS_NAME}-out.log`),
     error: path.join(getLogsDir(), `${PM2_PROCESS_NAME}-error.log`),
   };
   const supervision = getEffectiveSupervision();
+  const enablePgvector = getEffectiveEnablePgvector();
+  const postmasterArgs = [
+    // pgserve singleton (v2.4): pm2 supervises the postmaster directly via
+    // the `pgserve postmaster` subcommand — no router, no bun proxy, no
+    // daemon control socket. Postgres binds the canonical Unix socket
+    // under <socketDir> AND TCP <port> natively. Operators connect via
+    //   psql -h $XDG_RUNTIME_DIR/pgserve     (Unix socket, no -p)
+    //   psql -h 127.0.0.1 -p 5432            (canonical TCP)
+    'postmaster',
+    '--port',
+    String(port),
+    '--data',
+    dataDir,
+    '--socket-dir',
+    socketDir,
+    '--log',
+    'warn',
+  ];
+  if (enablePgvector) postmasterArgs.push('--pgvector');
   return [
     'start',
     scriptPath,
@@ -532,21 +576,7 @@ function buildPm2StartArgs({ scriptPath, port, dataDir, socketDir }) {
     '--error',
     logs.error,
     '--',
-    // pgserve singleton (v2.4): pm2 supervises the postmaster directly via
-    // the `pgserve postmaster` subcommand — no router, no bun proxy, no
-    // daemon control socket. Postgres binds the canonical Unix socket
-    // under <socketDir> AND TCP <port> natively. Operators connect via
-    //   psql -h $XDG_RUNTIME_DIR/pgserve     (Unix socket, no -p)
-    //   psql -h 127.0.0.1 -p 5432            (canonical TCP)
-    'postmaster',
-    '--port',
-    String(port),
-    '--data',
-    dataDir,
-    '--socket-dir',
-    socketDir,
-    '--log',
-    'warn',
+    ...postmasterArgs,
   ];
 }
 

--- a/tests/cli-install.test.js
+++ b/tests/cli-install.test.js
@@ -619,6 +619,35 @@ describe('pgserve singleton (v2.4) — socket dir + admin.json supervisor record
     expect(scriptArgs[sdIdx + 1]).toBe(path.join(tmpXdg, 'pgserve'));
   });
 
+  test('install does NOT pass --pgvector to the postmaster when settings.json omits it (default off)', () => {
+    runWithXdg(['install', '--no-ui']);
+    const calls = readCallLog(stubBin.calls);
+    const startCall = calls.find((c) => c[0] === 'start' && c.includes('autopg-server'));
+    const dashIdx = startCall.indexOf('--');
+    const scriptArgs = startCall.slice(dashIdx + 1);
+    expect(scriptArgs).not.toContain('--pgvector');
+  });
+
+  test('install passes --pgvector to the postmaster when settings.json has runtime.enablePgvector=true', () => {
+    // Pre-seed settings.json before install so loadEffectiveConfig sees it.
+    fs.mkdirSync(tmpHome, { recursive: true });
+    fs.writeFileSync(
+      path.join(tmpHome, 'settings.json'),
+      JSON.stringify({ _schemaVersion: 1, runtime: { enablePgvector: true } }),
+    );
+    runWithXdg(['install', '--no-ui']);
+    const calls = readCallLog(stubBin.calls);
+    const startCall = calls.find((c) => c[0] === 'start' && c.includes('autopg-server'));
+    const dashIdx = startCall.indexOf('--');
+    const scriptArgs = startCall.slice(dashIdx + 1);
+    // --pgvector must reach the postmaster so PostgresManager.enablePgvector
+    // is true and _doEnsurePgvectorFiles runs on PG start. Without this,
+    // `autopg config set runtime.enablePgvector true` is silently dropped
+    // and consumers (e.g. @khal-os/brain) hit "type \"vector\" does not exist"
+    // at CREATE EXTENSION time.
+    expect(scriptArgs).toContain('--pgvector');
+  });
+
   test('install writes admin.json with supervisor=pm2 + canonical socketDir + port', () => {
     runWithXdg(['install', '--no-ui']);
     const adminFile = path.join(tmpHome, 'admin.json');


### PR DESCRIPTION
## Summary

`pgserve install` / `autopg install` hardcoded the postmaster CLI args and never read `runtime.enablePgvector` from settings.json. So:

```
autopg config set runtime.enablePgvector true
```

was silently dropped — the postmaster's `parsePostmasterArgs()` never saw `--pgvector`, `PostgresManager.enablePgvector` stayed `false`, and `_doEnsurePgvectorFiles()` never ran. Fresh installs therefore have no `vector.so` / `vector.control` on disk, and any consumer doing `CREATE EXTENSION vector` hits:

```
ERROR:  extension "vector" is not available
HINT:   The extension must first be installed on the system where PostgreSQL is running.
```

## How it was found

`@khal-os/brain` v1.61.x dogfood. Brain talks to autopg over the discovery socket and assumes pgvector is available. With this regression, a fresh khal-hermes install couldn't embed a single document despite the manifest declaring 768-dim vectors and the Gemini API responding cleanly.

Repro on any clean machine:

```bash
autopg install --port 8432 --data ~/.autopg/data --socket-dir $XDG_RUNTIME_DIR/pgserve
autopg config set runtime.enablePgvector true   # silently dropped today
psql -h $XDG_RUNTIME_DIR/pgserve -U postgres -d postgres -c 'CREATE EXTENSION vector;'
# ERROR: extension "vector" is not available
```

## Fix

`buildPm2StartArgs()` now reads `runtime.enablePgvector` via the same `loadEffectiveConfig()` pipeline already used for supervision settings, and appends `--pgvector` to the postmaster args when true. Default behavior unchanged: settings.json absent or `enablePgvector: false` → no flag, same as before.

## Tests

Two new tests under `pgserve singleton (v2.4) — socket dir + admin.json supervisor record`:

- **Negative:** install without `enablePgvector` setting → `--pgvector` NOT in pm2 postmaster args.
- **Positive:** install with `settings.json { runtime: { enablePgvector: true } }` → `--pgvector` IS in pm2 postmaster args.

Both pass on this branch. The 6 pre-existing failures in `pgserve url/port/status` are unrelated host-`XDG_RUNTIME_DIR` leakage and reproduce on `main` without this change.

## Workaround for users on existing installs

Until they upgrade to a release with this fix:

```bash
autopg config set runtime.enablePgvector true
pm2 delete autopg-server
autopg install --port <PORT> --data <DATA> --socket-dir <SOCK>
```

Or manually run the pgvector `.deb` install (which is what `_doEnsurePgvectorFiles` does on its own): download `postgresql-$PG_MAJOR-pgvector_0.8.1-2.pgdg+1_amd64.deb` from `apt.postgresql.org`, extract, copy `vector.so` into `~/.autopg/bin/linux-x64/lib/`, copy `vector*.{sql,control}` into `~/.autopg/bin/linux-x64/share/postgresql/extension/`, patch the absolute `module_pathname` in `vector.control`, restart PG.