### PR TITLE
fix: route autopg auth through wrapper

### DIFF
--- a/bin/autopg-wrapper.cjs
+++ b/bin/autopg-wrapper.cjs
@@ -52,6 +52,8 @@ const __installSubcommands = new Set([
   'update',
   'restart',
   'ui',
+  // Admin Basic Auth password rotation / admin path; pure node, same dispatcher.
+  'auth',
   // pgserve singleton (v2.4) — `pgserve-singleton-no-proxy` wish, Group 4.
   // `verify` shells out to cosign + writes an HMAC cache token. Pure node
   // (no bun) so it must skip the bun probe like the install surface above.

--- a/src/cli-ui.cjs
+++ b/src/cli-ui.cjs
@@ -431,6 +431,13 @@ function handleStatic(req, res, root) {
   }
   fs.stat(target, (statErr, stat) => {
     if (statErr || !stat.isFile()) {
+      // Do not SPA-fallback concrete asset requests. If /app.js or a CSS
+      // file is missing, returning index.html as text/html creates strict
+      // module MIME failures in the browser and hides the real packaging bug.
+      if (path.extname(url)) {
+        sendError(res, 404, 'NOT_FOUND', `no file at ${url}`);
+        return;
+      }
       // SPA fallback: serve index.html on a miss so client routing works.
       const fallback = path.join(root, 'index.html');
       if (fs.existsSync(fallback)) {

--- a/tests/cli-install.test.js
+++ b/tests/cli-install.test.js
@@ -113,6 +113,13 @@ afterEach(() => {
 });
 
 describe('pgserve install', () => {
+  test('autopg auth is routed by the wrapper before the bun probe', () => {
+    const result = runCli(['auth', 'show-admin-path']);
+    expect(result.status).toBe(0);
+    expect(result.stdout.trim()).toBe(path.join(tmpHome, 'admin.json'));
+    expect(result.stderr).not.toContain('unknown verb "auth"');
+  });
+
   test('first install registers under pm2 and writes config', () => {
     const result = runCli(['install']);
     expect(result.status).toBe(0);

--- a/tests/console/no-cdn.test.js
+++ b/tests/console/no-cdn.test.js
@@ -81,12 +81,14 @@ test('app.js bundle is reachable as static asset', async () => {
   // Both are valid — the test's job is to confirm if a bundle IS served, it's
   // local + valid JS.
   if (res.status === 200) {
+    expect(res.headers.get('content-type')).toMatch(/javascript/);
     const body = await res.text();
     expect(body.length).toBeGreaterThan(1000); // bundle should be > 1KB
     expect(body).not.toMatch(/unpkg\.com/);
     expect(body).not.toMatch(/jsdelivr/);
   } else {
     // src/ fallback path — accept 404 as long as src/main.jsx exists for dev mode
+    expect(res.status).toBe(404);
     const distPresent = fs.existsSync(path.join(REPO_ROOT, 'console', 'dist', 'app.js'));
     if (distPresent) {
       throw new Error(`dist/app.js exists on disk but server returned ${res.status}`);


### PR DESCRIPTION
## Summary
- Route `autopg auth` through the v3 wrapper's pure-node dispatcher.
- Prevent missing concrete static assets such as `/app.js` from falling back to `index.html` as `text/html`.
- Add regression coverage for auth routing and module-asset MIME behavior.

## Test Plan
- `bun test tests/console/no-cdn.test.js`
- `bun test tests/cli-install.test.js --test-name-pattern 'autopg auth is routed'`
- `bun test tests/console/auth.test.js`
- `AUTOPG_CONFIG_DIR=$(mktemp -d) node bin/autopg-wrapper.cjs auth show-admin-path`
- added-line secret scan: clean

## Notes
This targets autopg v3 (`package.json` version `3.0.7`) on `main`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Corrected static file serving to return proper 404 responses for missing assets with file extensions, preventing incorrect SPA fallback behavior
  * Improved admin authentication command routing through the CLI dispatcher

* **Tests**
  * Added verification for admin authentication command routing
  * Strengthened static asset reachability validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->