### PR TITLE
feat(deploy): containerize autopg + reusable Helm chart

### DIFF
--- a/deploy/.dockerignore
+++ b/deploy/.dockerignore
@@ -1,0 +1,5 @@
+# The image is built entirely from a release tarball fetched inside the
+# Dockerfile — no repo source is copied in. Exclude everything so the build
+# context stays tiny and unrelated repo churn never invalidates the cache.
+*
+!Dockerfile

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -1,0 +1,98 @@
+# syntax=docker/dockerfile:1
+#
+# autopg — embedded PostgreSQL 18 as a self-contained, offline-boot container.
+#
+# The compiled `autopg` binary resolves its postgres/initdb binaries from a
+# per-platform cache under $AUTOPG_CONFIG_DIR/bin/<platformKey>/ (see
+# src/postgres.js getBinaryPaths / isCachedValid). When that cache is absent
+# it DOWNLOADS @embedded-postgres from npm on first boot. That network fetch is
+# unacceptable for a k8s pod, so this image PRE-SEEDS the cache from the release
+# tarball's postgres/ tree plus a `.version` marker — the first postmaster boot
+# is fully offline.
+#
+# Base MUST be glibc (not alpine/musl): the bundled PG18 links libssl.so.1.1 +
+# libicu*.so.60 with RUNPATH $ORIGIN/../lib.
+
+ARG AUTOPG_VERSION=3.0.7
+# Must match src/postgres.js PINNED_PG_VERSION — the value isCachedValid()
+# compares the `.version` marker against. Bump both together.
+ARG PG_VERSION_MARKER=18.3.0-beta.17
+
+# ---------------------------------------------------------------------------
+# Stage 1: fetch + extract the release tarball for the target arch.
+# ---------------------------------------------------------------------------
+FROM debian:12-slim AS fetch
+ARG AUTOPG_VERSION
+# TARGETARCH is provided by buildkit (arm64 / amd64).
+ARG TARGETARCH
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates curl tar \
+    && rm -rf /var/lib/apt/lists/*
+WORKDIR /stage
+RUN set -eux; \
+    case "${TARGETARCH:-arm64}" in \
+      arm64) ASSET="autopg-${AUTOPG_VERSION}-linux-arm64.tar.gz" ;; \
+      amd64) ASSET="autopg-${AUTOPG_VERSION}-linux-x64-glibc.tar.gz" ;; \
+      *) echo "unsupported TARGETARCH: ${TARGETARCH}" >&2; exit 1 ;; \
+    esac; \
+    curl -fsSL -o autopg.tar.gz \
+      "https://github.com/automagik-dev/autopg/releases/download/v${AUTOPG_VERSION}/${ASSET}"; \
+    tar xzf autopg.tar.gz; \
+    test -f autopg/autopg; \
+    test -x autopg/postgres/bin/initdb; \
+    test -x autopg/postgres/bin/postgres
+
+# ---------------------------------------------------------------------------
+# Stage 2: minimal glibc runtime with the pre-seeded binary cache.
+# ---------------------------------------------------------------------------
+FROM debian:12-slim AS runtime
+ARG PG_VERSION_MARKER
+
+# postgresql-client supplies pg_isready (health probes) + psql (the
+# provisioning Job). The embedded PG18 *server* binaries come from the tarball,
+# NOT apt — these clients are only used out-of-band and are wire-compatible.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates postgresql-client \
+    && rm -rf /var/lib/apt/lists/*
+
+# HOME + AUTOPG_CONFIG_DIR both point at /var/lib/autopg so getAutopgRoot() and
+# getConfigDir() resolve the binary cache and settings.json under one tree.
+ENV HOME=/var/lib/autopg \
+    AUTOPG_CONFIG_DIR=/var/lib/autopg
+
+# Non-root runtime user owning the state tree.
+RUN groupadd -g 1000 autopg \
+    && useradd -u 1000 -g 1000 -d /var/lib/autopg -s /usr/sbin/nologin autopg
+
+# 1) the compiled autopg binary (dispatches `postmaster`, provisioning, etc.)
+COPY --from=fetch /stage/autopg/autopg /usr/local/bin/autopg
+
+# 2) THE GOTCHA: pre-seed the binary cache at
+#    $AUTOPG_CONFIG_DIR/bin/linux-arm64/{bin,lib,share} and drop the `.version`
+#    marker so isCachedValid() short-circuits before any npm fetch.
+COPY --from=fetch /stage/autopg/postgres/ /var/lib/autopg/bin/linux-arm64/
+
+RUN set -eux; \
+    printf '%s\n' "${PG_VERSION_MARKER}" > /var/lib/autopg/bin/linux-arm64/.version; \
+    chmod +x /usr/local/bin/autopg; \
+    mkdir -p /var/lib/autopg/data /var/run/autopg; \
+    chown -R autopg:autopg /var/lib/autopg /var/run/autopg; \
+    # sanity: binaries present + marker correct
+    test -x /var/lib/autopg/bin/linux-arm64/bin/postgres; \
+    test -x /var/lib/autopg/bin/linux-arm64/bin/initdb; \
+    grep -qx "${PG_VERSION_MARKER}" /var/lib/autopg/bin/linux-arm64/.version
+
+USER autopg
+WORKDIR /var/lib/autopg
+EXPOSE 5432
+
+# The postmaster is PID 1. It installs SIGTERM/SIGINT handlers for a graceful
+# postgres shutdown (bin/postgres-server.js) — pair with a generous
+# terminationGracePeriodSeconds. Data dir + socket dir are overridable via the
+# chart's `command`/`args`; these defaults make `docker run autopg:dev` work.
+# PGDATA is a subdir of the data mount so the non-root user (uid 1000) owns it
+# under a k8s PVC (whose root is owned root:fsGroup) and initdb's chmod 0700
+# succeeds. The chart overrides these args; these defaults keep `docker run`
+# working standalone.
+ENTRYPOINT ["autopg", "postmaster"]
+CMD ["--port", "5432", "--data", "/var/lib/autopg/data/pgdata", "--socket-dir", "/var/run/autopg", "--log", "info"]

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,0 +1,93 @@
+# autopg — container + Helm chart
+
+Containerizes [autopg](https://github.com/automagik-dev/autopg) (embedded
+PostgreSQL 18) as a self-contained, **offline-boot** Kubernetes StatefulSet with
+a reusable Helm chart. Built and verified on OrbStack arm64 k8s.
+
+## Layout
+
+```
+deploy/
+  Dockerfile            arm64, glibc (debian:12-slim), pre-seeded binary cache
+  .dockerignore
+  helm/autopg/          the chart (Chart.yaml, values.yaml, templates/)
+```
+
+## Image
+
+The compiled `autopg` binary resolves its postgres/initdb binaries from a
+per-platform cache under `$AUTOPG_CONFIG_DIR/bin/<platformKey>/`; when absent it
+**downloads `@embedded-postgres` from npm on first boot**. That is unacceptable
+for a pod, so the Dockerfile **pre-seeds the cache** from the release tarball's
+`postgres/` tree plus a `.version` marker (`18.3.0-beta.17`, matching
+`src/postgres.js` `PINNED_PG_VERSION`). First boot is fully offline — proven with
+`docker run --network none`.
+
+Key facts baked in:
+- Base is **glibc** (bundled PG18 links `libssl.so.1.1` + `libicu*.so.60`).
+- `HOME=/var/lib/autopg`, `AUTOPG_CONFIG_DIR=/var/lib/autopg`.
+- Non-root user `autopg` (uid/gid 1000) owns the state tree.
+- `postgresql-client` (apt) supplies `pg_isready` (probes) + `psql` (provisioning).
+- ENTRYPOINT is the postmaster (PID 1); it handles SIGTERM for graceful shutdown.
+
+Build:
+
+```bash
+docker build --platform linux/arm64 -f deploy/Dockerfile -t autopg:dev deploy/
+```
+
+Override the autopg release with `--build-arg AUTOPG_VERSION=3.0.7` (and bump
+`--build-arg PG_VERSION_MARKER=...` if the pinned PG changes).
+
+## Chart
+
+```bash
+helm install autopg deploy/helm/autopg -n <ns> --create-namespace \
+  --set image.pullPolicy=Never    # OrbStack shares its image store with k8s
+```
+
+Resources created: **StatefulSet** (replicas=1, PVC at `/var/lib/autopg/data`),
+a **headless Service** + a **ClusterIP Service** on 5432, a **ConfigMap**
+(`settings.json`), a **Secret** (passwords), and a post-install/post-upgrade
+**provisioning Job**.
+
+### settings.json / GUC placement (important)
+
+autopg ships **curated GUC defaults** (e.g. `max_connections=1000`,
+`shared_buffers=128MB`) that WIN over anything under `postgres._extra`. The chart
+therefore renders operator tuning (`settings.gucs`) as **curated top-level**
+`postgres.*` keys and puts `listen_addresses` (no curated default) under
+`postgres._extra`. `listen_addresses='*'` is required so in-cluster peers can
+reach the pod over TCP.
+
+### Persistence & permissions
+
+PGDATA is `/var/lib/autopg/data/pgdata` — a **subdirectory** of the PVC mount.
+The PVC root is owned `root:fsGroup`, which a non-root process cannot `chmod`
+(initdb needs 0700); autopg creates and owns the `pgdata` subdir (uid 1000), so
+initdb's chmod succeeds. No root initContainer required.
+
+### Provisioning (scoped roles)
+
+For each `provisionedApps` entry the Job idempotently creates a `LOGIN` role, a
+database `OWNER`ed by that role, and makes the role **own `schema public`** in
+that db (so it can run migrations — `CREATE`/`ALTER`/`DROP` its own tables). The
+Job also rotates the superuser (`postgres`) password to the managed Secret value
+(the postmaster always initdb's with the built-in `postgres`/`postgres`; there is
+no boot-time flag to set it).
+
+## Chart interface (for consumers)
+
+| Item | Value |
+|------|-------|
+| Connection endpoint | `<release>-autopg.<ns>.svc.cluster.local:5432` (ClusterIP Service `<release>-autopg`) |
+| Headless Service | `<release>-autopg-headless` (StatefulSet DNS) |
+| Superuser | `postgres`, password in Secret `<release>-autopg-auth` key `superuser-password` |
+| Provisioned db (default) | `omni`, owned by role `omni` |
+| Provisioned role password | Secret `<release>-autopg-auth` key `omni-password` (`<role>-password` per app) |
+
+Key values.yaml knobs: `image.{repository,tag,pullPolicy}`, `port`, `logLevel`,
+`auth.{superuserPassword,existingSecret}`, `provisionedApps[]`,
+`settings.{listenAddresses,gucs,extraGucs}`,
+`persistence.{enabled,size,storageClass}`, `resources`, `probes.*`,
+`terminationGracePeriodSeconds`, `provisionJob.{enabled,readyTimeoutSeconds}`.

--- a/deploy/helm/autopg/.helmignore
+++ b/deploy/helm/autopg/.helmignore
@@ -1,0 +1,7 @@
+.DS_Store
+.git/
+.gitignore
+*.tmp
+*.bak
+*.orig
+*~

--- a/deploy/helm/autopg/Chart.yaml
+++ b/deploy/helm/autopg/Chart.yaml
@@ -1,0 +1,20 @@
+apiVersion: v2
+name: autopg
+description: >-
+  Embedded PostgreSQL 18 (autopg) as a single-replica StatefulSet — self-contained,
+  offline-boot, with scoped-role provisioning for consuming apps.
+type: application
+version: 0.1.0
+# The autopg release the default image tag tracks. Keep in sync with
+# values.yaml image.tag and deploy/Dockerfile ARG AUTOPG_VERSION.
+appVersion: "3.0.7"
+keywords:
+  - postgresql
+  - postgres
+  - autopg
+  - database
+home: https://github.com/automagik-dev/autopg
+sources:
+  - https://github.com/automagik-dev/autopg
+maintainers:
+  - name: automagik-dev

--- a/deploy/helm/autopg/templates/NOTES.txt
+++ b/deploy/helm/autopg/templates/NOTES.txt
@@ -1,0 +1,19 @@
+autopg (embedded PostgreSQL 18) is installed as release "{{ .Release.Name }}".
+
+In-cluster connection endpoint (ClusterIP Service):
+  host: {{ include "autopg.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local
+  port: {{ .Values.port }}
+
+Superuser:
+  user: postgres
+  password: kubectl -n {{ .Release.Namespace }} get secret {{ include "autopg.secretName" . }} -o jsonpath='{.data.superuser-password}' | base64 -d
+
+Provisioned apps (scoped role owns schema public in its db):
+{{- range .Values.provisionedApps }}
+  - db: {{ .db }}   role: {{ .role }}
+    password: kubectl -n {{ $.Release.Namespace }} get secret {{ include "autopg.secretName" $ }} -o jsonpath='{.data.{{ .role }}-password}' | base64 -d
+    URL: postgresql://{{ .role }}:$PASSWORD@{{ include "autopg.fullname" $ }}.{{ $.Release.Namespace }}.svc.cluster.local:{{ $.Values.port }}/{{ .db }}
+{{- end }}
+
+Quick check:
+  kubectl -n {{ .Release.Namespace }} exec -it {{ include "autopg.fullname" . }}-0 -- pg_isready -h 127.0.0.1 -p {{ .Values.port }}

--- a/deploy/helm/autopg/templates/NOTES.txt
+++ b/deploy/helm/autopg/templates/NOTES.txt
@@ -6,7 +6,8 @@ In-cluster connection endpoint (ClusterIP Service):
 
 Superuser:
   user: postgres
-  password: kubectl -n {{ .Release.Namespace }} get secret {{ include "autopg.secretName" . }} -o jsonpath='{.data.superuser-password}' | base64 -d
+  password: postgres (pinned — autopg's postmaster cannot consume a managed
+  password; apps must use their scoped role below, never the superuser)
 
 Provisioned apps (scoped role owns schema public in its db):
 {{- range .Values.provisionedApps }}

--- a/deploy/helm/autopg/templates/_helpers.tpl
+++ b/deploy/helm/autopg/templates/_helpers.tpl
@@ -1,0 +1,92 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "autopg.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Fully qualified app name. Truncated at 63 chars for DNS-name safety.
+*/}}
+{{- define "autopg.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "autopg.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Common labels.
+*/}}
+{{- define "autopg.labels" -}}
+helm.sh/chart: {{ include "autopg.chart" . }}
+{{ include "autopg.selectorLabels" . }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- with .Values.commonLabels }}
+{{ toYaml . }}
+{{- end }}
+{{- end -}}
+
+{{/*
+Selector labels — stable across upgrades (do NOT add version here).
+*/}}
+{{- define "autopg.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "autopg.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{/*
+The headless Service name (StatefulSet serviceName).
+*/}}
+{{- define "autopg.headlessServiceName" -}}
+{{- printf "%s-headless" (include "autopg.fullname" .) -}}
+{{- end -}}
+
+{{/*
+The Secret name holding passwords — an existing one if provided, else managed.
+*/}}
+{{- define "autopg.secretName" -}}
+{{- if .Values.auth.existingSecret -}}
+{{- .Values.auth.existingSecret -}}
+{{- else -}}
+{{- printf "%s-auth" (include "autopg.fullname" .) -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Secret key for a provisioned app role's password.
+*/}}
+{{- define "autopg.appPasswordKey" -}}
+{{- printf "%s-password" .role -}}
+{{- end -}}
+
+{{/*
+Render settings.json content.
+
+listen_addresses goes under postgres._extra (no curated default shadows it);
+operator tuning goes as curated top-level postgres.* keys (these WIN over
+_extra in autopg). Both merged from values.
+*/}}
+{{- define "autopg.settingsJson" -}}
+{{- $postgres := dict -}}
+{{- range $k, $v := .Values.settings.gucs -}}
+{{- $_ := set $postgres $k $v -}}
+{{- end -}}
+{{- $extra := dict "listen_addresses" .Values.settings.listenAddresses -}}
+{{- range $k, $v := .Values.settings.extraGucs -}}
+{{- $_ := set $extra $k $v -}}
+{{- end -}}
+{{- $_ := set $postgres "_extra" $extra -}}
+{{- dict "postgres" $postgres | toPrettyJson -}}
+{{- end -}}

--- a/deploy/helm/autopg/templates/configmap.yaml
+++ b/deploy/helm/autopg/templates/configmap.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "autopg.fullname" . }}-settings
+  labels:
+    {{- include "autopg.labels" . | nindent 4 }}
+data:
+  # Mounted (subPath) at $AUTOPG_CONFIG_DIR/settings.json. GUCs are boot-time,
+  # so a change here requires a pod restart to take effect.
+  settings.json: |
+    {{- include "autopg.settingsJson" . | nindent 4 }}

--- a/deploy/helm/autopg/templates/provision-job.yaml
+++ b/deploy/helm/autopg/templates/provision-job.yaml
@@ -82,10 +82,20 @@ spec:
               # operator-supplied passwords must not contain a single quote.
               psqlx() { psql -v ON_ERROR_STOP=1 -h "$PGHOST" -p "$PGPORT" -U postgres "$@"; }
 
-              # ---- rotate the superuser password to the managed value -------
-              psqlx -d postgres -c "ALTER USER postgres PASSWORD '$SUPERUSER_PASSWORD';"
-              export PGPASSWORD="$SUPERUSER_PASSWORD"
-              echo "superuser password synced to managed secret"
+              # ---- pin the superuser password to the postmaster default -----
+              # DO NOT rotate: autopg's postmaster hardcodes 'postgres' for its
+              # in-process admin pool (bin/postgres-server.js passes no password
+              # option; AUTOPG_PG_PASSWORD is ignored on this code path), so a
+              # rotated password crash-loops the pod on every RECREATION — the
+              # pool authenticates fresh at each start (verified in the wild on
+              # a node restart, 2026-07-03). Pin to the default until upstream
+              # autopg lets the postmaster consume a managed password. This
+              # also self-heals clusters that a previous chart version rotated.
+              # Network exposure is bounded: apps use scoped roles, and the
+              # Service is ClusterIP-only.
+              psqlx -d postgres -c "ALTER USER postgres PASSWORD 'postgres';"
+              export PGPASSWORD=postgres
+              echo "superuser password pinned to postmaster default"
 
               # ---- provision a scoped app: role + db + schema ownership ------
               provision_app() {

--- a/deploy/helm/autopg/templates/provision-job.yaml
+++ b/deploy/helm/autopg/templates/provision-job.yaml
@@ -1,0 +1,130 @@
+{{- if .Values.provisionJob.enabled -}}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "autopg.fullname" . }}-provision
+  labels:
+    {{- include "autopg.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "5"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: {{ .Values.provisionJob.backoffLimit }}
+  template:
+    metadata:
+      labels:
+        {{- include "autopg.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: provision
+    spec:
+      restartPolicy: Never
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: provision
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+            - name: PGHOST
+              value: {{ include "autopg.fullname" . | quote }}
+            - name: PGPORT
+              value: {{ .Values.port | quote }}
+            - name: PGUSER
+              value: postgres
+            - name: READY_TIMEOUT
+              value: {{ .Values.provisionJob.readyTimeoutSeconds | quote }}
+            - name: SUPERUSER_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "autopg.secretName" . }}
+                  key: superuser-password
+            {{- range .Values.provisionedApps }}
+            - name: APP_PW_{{ .role }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "autopg.secretName" $ }}
+                  key: {{ printf "%s-password" .role }}
+            {{- end }}
+          command:
+            - /bin/sh
+            - -ec
+            - |
+              # ---- wait for the server to accept connections ----------------
+              deadline=$(( $(date +%s) + READY_TIMEOUT ))
+              until pg_isready -h "$PGHOST" -p "$PGPORT" -q; do
+                if [ "$(date +%s)" -ge "$deadline" ]; then
+                  echo "timed out waiting for $PGHOST:$PGPORT" >&2; exit 1
+                fi
+                echo "waiting for postgres at $PGHOST:$PGPORT ..."; sleep 3
+              done
+              echo "postgres is accepting connections"
+
+              # ---- pick the working superuser password ----------------------
+              # Fresh initdb => password is the built-in 'postgres'. After the
+              # first provision run it is the managed SUPERUSER_PASSWORD.
+              if PGPASSWORD="$SUPERUSER_PASSWORD" psql -h "$PGHOST" -p "$PGPORT" \
+                   -U postgres -d postgres -tAc 'SELECT 1' >/dev/null 2>&1; then
+                export PGPASSWORD="$SUPERUSER_PASSWORD"
+              elif PGPASSWORD=postgres psql -h "$PGHOST" -p "$PGPORT" \
+                   -U postgres -d postgres -tAc 'SELECT 1' >/dev/null 2>&1; then
+                export PGPASSWORD=postgres
+              else
+                echo "cannot authenticate as postgres (managed or default pw)" >&2; exit 1
+              fi
+
+              # psql 15 (debian) does NOT interpolate :'var' in -c (that is
+              # psql 16+), so passwords are single-quoted directly. Managed
+              # passwords are alphanumeric (randAlphaNum) => injection-safe;
+              # operator-supplied passwords must not contain a single quote.
+              psqlx() { psql -v ON_ERROR_STOP=1 -h "$PGHOST" -p "$PGPORT" -U postgres "$@"; }
+
+              # ---- rotate the superuser password to the managed value -------
+              psqlx -d postgres -c "ALTER USER postgres PASSWORD '$SUPERUSER_PASSWORD';"
+              export PGPASSWORD="$SUPERUSER_PASSWORD"
+              echo "superuser password synced to managed secret"
+
+              # ---- provision a scoped app: role + db + schema ownership ------
+              provision_app() {
+                db="$1"; role="$2"; pw="$3"
+                echo "provisioning db=$db role=$role"
+                if [ "$(psqlx -d postgres -tAc "SELECT 1 FROM pg_roles WHERE rolname = '$role'")" = "1" ]; then
+                  psqlx -d postgres -c "ALTER ROLE \"$role\" LOGIN PASSWORD '$pw';"
+                else
+                  psqlx -d postgres -c "CREATE ROLE \"$role\" LOGIN PASSWORD '$pw';"
+                fi
+                if [ "$(psqlx -d postgres -tAc "SELECT 1 FROM pg_database WHERE datname = '$db'")" != "1" ]; then
+                  psqlx -d postgres -c "CREATE DATABASE \"$db\" OWNER \"$role\";"
+                fi
+                # Ownership so the role can run migrations (CREATE/ALTER/DROP)
+                # against its own schema.
+                psqlx -d "$db" -c "ALTER DATABASE \"$db\" OWNER TO \"$role\";"
+                psqlx -d "$db" -c "ALTER SCHEMA public OWNER TO \"$role\";"
+                psqlx -d "$db" -c "GRANT ALL ON SCHEMA public TO \"$role\";"
+                psqlx -d "$db" -c "GRANT ALL ON DATABASE \"$db\" TO \"$role\";"
+                echo "provisioned db=$db role=$role (role owns schema public)"
+              }
+
+              {{- range .Values.provisionedApps }}
+              provision_app {{ .db | quote }} {{ .role | quote }} "$APP_PW_{{ .role }}"
+              {{- end }}
+
+              echo "provisioning complete"
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              memory: 256Mi
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end -}}

--- a/deploy/helm/autopg/templates/secret.yaml
+++ b/deploy/helm/autopg/templates/secret.yaml
@@ -1,0 +1,43 @@
+{{- if not .Values.auth.existingSecret -}}
+{{/*
+Managed password Secret. Values are preserved across upgrades by looking up the
+existing Secret first, so auto-generated passwords stay stable. Explicit values
+in values.yaml always win.
+*/}}
+{{- $secretName := include "autopg.secretName" . -}}
+{{- $existing := (lookup "v1" "Secret" .Release.Namespace $secretName) -}}
+{{- $existingData := dict -}}
+{{- if $existing -}}{{- $existingData = $existing.data -}}{{- end -}}
+
+{{- /* superuser */ -}}
+{{- $superKey := "superuser-password" -}}
+{{- $super := .Values.auth.superuserPassword -}}
+{{- if not $super -}}
+{{- if hasKey $existingData $superKey -}}
+{{- $super = index $existingData $superKey | b64dec -}}
+{{- else -}}
+{{- $super = randAlphaNum 24 -}}
+{{- end -}}
+{{- end -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $secretName }}
+  labels:
+    {{- include "autopg.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  {{ $superKey }}: {{ $super | quote }}
+  {{- range .Values.provisionedApps }}
+  {{- $key := printf "%s-password" .role -}}
+  {{- $pw := .password -}}
+  {{- if not $pw -}}
+  {{- if hasKey $existingData $key -}}
+  {{- $pw = index $existingData $key | b64dec -}}
+  {{- else -}}
+  {{- $pw = randAlphaNum 24 -}}
+  {{- end -}}
+  {{- end }}
+  {{ $key }}: {{ $pw | quote }}
+  {{- end }}
+{{- end -}}

--- a/deploy/helm/autopg/templates/service-headless.yaml
+++ b/deploy/helm/autopg/templates/service-headless.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  # Headless Service backing the StatefulSet — gives the pod a stable DNS name
+  # (<pod>.<release>-autopg-headless). Also serves as the StatefulSet
+  # serviceName. Not the connection endpoint for clients — use the ClusterIP one.
+  name: {{ include "autopg.headlessServiceName" . }}
+  labels:
+    {{- include "autopg.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  clusterIP: None
+  publishNotReadyAddresses: true
+  ports:
+    - name: postgres
+      port: {{ .Values.port }}
+      targetPort: postgres
+      protocol: TCP
+  selector:
+    {{- include "autopg.selectorLabels" . | nindent 4 }}

--- a/deploy/helm/autopg/templates/service.yaml
+++ b/deploy/helm/autopg/templates/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  # Stable in-cluster endpoint consumers connect to: <release>-autopg:5432
+  name: {{ include "autopg.fullname" . }}
+  labels:
+    {{- include "autopg.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  ports:
+    - name: postgres
+      port: {{ .Values.port }}
+      targetPort: postgres
+      protocol: TCP
+  selector:
+    {{- include "autopg.selectorLabels" . | nindent 4 }}

--- a/deploy/helm/autopg/templates/statefulset.yaml
+++ b/deploy/helm/autopg/templates/statefulset.yaml
@@ -28,6 +28,30 @@ spec:
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      initContainers:
+        # Repair PGDATA on every pod start (verified in the wild on a node
+        # restart, 2026-07-03): kubelet's fsGroup pass re-applies setgid/g+w
+        # to the volume on each mount, which postgres refuses (pgdata must be
+        # 0700/0750); an unclean shutdown can also leave a stale
+        # postmaster.pid that fatals under container PID reuse. Runs as the
+        # pod user, which owns pgdata, so both repairs always succeed.
+        - name: fix-pgdata
+          image: busybox:1.36
+          imagePullPolicy: IfNotPresent
+          command:
+            - sh
+            - -c
+            - |
+              if [ -d /data/pgdata ]; then
+                chmod 700 /data/pgdata
+                rm -f /data/pgdata/postmaster.pid
+              fi
+          securityContext:
+            runAsUser: 1000
+            runAsGroup: 1000
+          volumeMounts:
+            - name: data
+              mountPath: /data
       containers:
         - name: autopg
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/deploy/helm/autopg/templates/statefulset.yaml
+++ b/deploy/helm/autopg/templates/statefulset.yaml
@@ -1,0 +1,142 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "autopg.fullname" . }}
+  labels:
+    {{- include "autopg.labels" . | nindent 4 }}
+spec:
+  replicas: 1
+  serviceName: {{ include "autopg.headlessServiceName" . }}
+  selector:
+    matchLabels:
+      {{- include "autopg.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "autopg.selectorLabels" . | nindent 8 }}
+      annotations:
+        # Roll the pod when settings.json changes (GUCs are boot-time only).
+        checksum/settings: {{ include "autopg.settingsJson" . | sha256sum }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: autopg
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command: ["autopg", "postmaster"]
+          args:
+            - "--port"
+            - {{ .Values.port | quote }}
+            # PGDATA is a SUBDIR of the mount. The PVC root is owned root:fsGroup,
+            # so a non-root process cannot chmod it (initdb needs 0700). autopg
+            # creates + owns this subdir (uid 1000), so initdb's chmod succeeds.
+            - "--data"
+            - "/var/lib/autopg/data/pgdata"
+            - "--socket-dir"
+            - "/var/run/autopg"
+            - "--log"
+            - {{ .Values.logLevel | quote }}
+          ports:
+            - name: postgres
+              containerPort: {{ .Values.port }}
+              protocol: TCP
+          {{- if .Values.hostAuth.enabled }}
+          lifecycle:
+            # autopg's initdb writes a localhost-only pg_hba.conf and exposes no
+            # knob to change it. Append a pod-network rule via the local trust
+            # socket + reload, idempotently. postStart completes before the
+            # container is marked started, so the pod is not Ready (and the
+            # ClusterIP Service does not route to it) until the rule is live.
+            postStart:
+              exec:
+                command:
+                  - /bin/sh
+                  - -ec
+                  - |
+                    HBA=/var/lib/autopg/data/pgdata/pg_hba.conf
+                    {{- if eq .Values.hostAuth.cidr "all" }}
+                    RULE="host all all all {{ .Values.hostAuth.method }}"
+                    {{- else }}
+                    RULE="host all all {{ .Values.hostAuth.cidr }} {{ .Values.hostAuth.method }}"
+                    {{- end }}
+                    for i in $(seq 1 90); do
+                      pg_isready -h /var/run/autopg -p {{ .Values.port }} -q && break
+                      sleep 2
+                    done
+                    if ! grep -qxF "$RULE" "$HBA" 2>/dev/null; then
+                      printf '# added by autopg chart (in-cluster peer access)\n%s\n' "$RULE" >> "$HBA"
+                      psql -h /var/run/autopg -p {{ .Values.port }} -U postgres -d postgres \
+                        -c 'SELECT pg_reload_conf();'
+                    fi
+          {{- end }}
+          # First-boot initdb can take a while on a cold PVC; the startupProbe
+          # gates readiness/liveness until the server first accepts connections.
+          startupProbe:
+            exec:
+              command: ["pg_isready", "-h", "127.0.0.1", "-p", {{ .Values.port | quote }}]
+            periodSeconds: {{ .Values.probes.startup.periodSeconds }}
+            failureThreshold: {{ .Values.probes.startup.failureThreshold }}
+          readinessProbe:
+            exec:
+              command: ["pg_isready", "-h", "127.0.0.1", "-p", {{ .Values.port | quote }}]
+            periodSeconds: {{ .Values.probes.readiness.periodSeconds }}
+            failureThreshold: {{ .Values.probes.readiness.failureThreshold }}
+          livenessProbe:
+            exec:
+              command: ["pg_isready", "-h", "127.0.0.1", "-p", {{ .Values.port | quote }}]
+            periodSeconds: {{ .Values.probes.liveness.periodSeconds }}
+            failureThreshold: {{ .Values.probes.liveness.failureThreshold }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/autopg/data
+            - name: settings
+              mountPath: /var/lib/autopg/settings.json
+              subPath: settings.json
+              readOnly: true
+      volumes:
+        - name: settings
+          configMap:
+            name: {{ include "autopg.fullname" . }}-settings
+        {{- if not .Values.persistence.enabled }}
+        - name: data
+          emptyDir: {}
+        {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+  {{- if .Values.persistence.enabled }}
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+        labels:
+          {{- include "autopg.selectorLabels" . | nindent 10 }}
+      spec:
+        accessModes:
+          {{- toYaml .Values.persistence.accessModes | nindent 10 }}
+        resources:
+          requests:
+            storage: {{ .Values.persistence.size | quote }}
+        {{- if .Values.persistence.storageClass }}
+        storageClassName: {{ .Values.persistence.storageClass | quote }}
+        {{- end }}
+  {{- end }}

--- a/deploy/helm/autopg/values.yaml
+++ b/deploy/helm/autopg/values.yaml
@@ -23,17 +23,20 @@ logLevel: info
 # Authentication
 #
 # The embedded postmaster always runs initdb with the built-in superuser
-# `postgres` and default password `postgres` (there is no boot-time flag to set
-# it). The provisioning Job rotates the superuser password to the value below on
-# every install/upgrade. Leave passwords empty to auto-generate a stable random
-# value that is preserved across upgrades (via a helm `lookup` of the Secret).
+# `postgres` and default password `postgres`, and its in-process admin pool
+# HARDCODES that default (bin/postgres-server.js passes no password option;
+# AUTOPG_PG_PASSWORD is ignored on the postmaster path). Rotating the superuser
+# password therefore crash-loops the pod on every recreation, so the provision
+# Job PINS it to the default instead. Apps must connect with their scoped
+# role (below), never the superuser; the Service is ClusterIP-only.
 #
-# Passwords are stored ONLY in the chart's Secret and injected via secretKeyRef;
-# they never appear in a ConfigMap or in pod args. Keep auto-generated values
-# alphanumeric-safe.
+# App-role passwords are stored ONLY in the chart's Secret and injected via
+# secretKeyRef; they never appear in a ConfigMap or in pod args. Leave empty to
+# auto-generate a stable random value preserved across upgrades (helm lookup).
 # -----------------------------------------------------------------------------
 auth:
-  # Superuser (`postgres`) password. Empty => auto-generated + preserved.
+  # Superuser password is pinned to the postmaster default (see above); this
+  # value is kept in the Secret for forward-compat but is NOT applied.
   superuserPassword: ""
   # Name of an existing Secret to source passwords from instead of managing one
   # here. When set, keys must be: superuser-password, and <role>-password for

--- a/deploy/helm/autopg/values.yaml
+++ b/deploy/helm/autopg/values.yaml
@@ -1,0 +1,160 @@
+# Default values for the autopg chart.
+# -----------------------------------------------------------------------------
+
+image:
+  repository: autopg
+  # Image tag. Tracks the autopg release baked into the image (Chart.appVersion).
+  tag: dev
+  # For OrbStack/local images built into the shared docker store, use Never (or
+  # IfNotPresent). Use IfNotPresent/Always once the image is pushed to a registry.
+  pullPolicy: Never
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+# TCP port the postmaster binds and the Services expose.
+port: 5432
+
+# Log level for `autopg postmaster` (error|warn|info|debug).
+logLevel: info
+
+# -----------------------------------------------------------------------------
+# Authentication
+#
+# The embedded postmaster always runs initdb with the built-in superuser
+# `postgres` and default password `postgres` (there is no boot-time flag to set
+# it). The provisioning Job rotates the superuser password to the value below on
+# every install/upgrade. Leave passwords empty to auto-generate a stable random
+# value that is preserved across upgrades (via a helm `lookup` of the Secret).
+#
+# Passwords are stored ONLY in the chart's Secret and injected via secretKeyRef;
+# they never appear in a ConfigMap or in pod args. Keep auto-generated values
+# alphanumeric-safe.
+# -----------------------------------------------------------------------------
+auth:
+  # Superuser (`postgres`) password. Empty => auto-generated + preserved.
+  superuserPassword: ""
+  # Name of an existing Secret to source passwords from instead of managing one
+  # here. When set, keys must be: superuser-password, and <role>-password for
+  # each provisioned app. Empty => the chart creates and manages the Secret.
+  existingSecret: ""
+
+# -----------------------------------------------------------------------------
+# Scoped-role provisioning (post-install / post-upgrade hook Job)
+#
+# For each entry the Job idempotently:
+#   1. CREATE ROLE <role> LOGIN PASSWORD <from-secret>   (ALTER if exists)
+#   2. CREATE DATABASE <db> OWNER <role>                 (skipped if exists)
+#   3. ALTER SCHEMA public OWNER TO <role> in <db>       (so <role> can run
+#      migrations: CREATE / ALTER / DROP its own tables)
+#
+# Passwords: set `password` to pin one, or leave empty to auto-generate a stable
+# value stored under Secret key `<role>-password`.
+# -----------------------------------------------------------------------------
+provisionedApps:
+  - db: omni
+    role: omni
+    password: ""
+
+# -----------------------------------------------------------------------------
+# PostgreSQL GUC tuning.
+#
+# IMPORTANT (autopg semantics): autopg ships curated GUC defaults (e.g.
+# max_connections=1000, shared_buffers=128MB) that WIN over anything under
+# `postgres._extra` in settings.json. So operator tuning MUST be set as curated
+# top-level keys — this chart renders `settings.gucs` as top-level `postgres.*`
+# keys, and `listen_addresses` (which has no curated default) under
+# `postgres._extra`. Do not move tuning into extraGucs expecting it to apply.
+# -----------------------------------------------------------------------------
+settings:
+  # listen_addresses MUST be '*' so in-cluster peers can reach the pod over TCP.
+  # Injected via postgres._extra (no curated default shadows it).
+  listenAddresses: "*"
+  # Curated top-level postgres GUCs. Tune to taste / to your resources block.
+  gucs:
+    max_connections: 120
+    shared_buffers: 256MB
+    effective_cache_size: 1GB
+    maintenance_work_mem: 128MB
+    work_mem: 8MB
+    wal_compression: "on"
+  # Escape hatch: additional GUCs emitted under postgres._extra. Only takes
+  # effect for GUCs WITHOUT a curated default (see note above).
+  extraGucs: {}
+
+# -----------------------------------------------------------------------------
+# Host-based auth (pg_hba).
+#
+# autopg's initdb writes a pg_hba.conf that only trusts the local socket and
+# 127.0.0.1/::1 — so even with listen_addresses='*' an in-cluster PEER pod is
+# rejected ("no pg_hba.conf entry for host"). autopg exposes no pg_hba knob, so
+# a container postStart hook appends this rule (via the local trust socket) and
+# reloads. Idempotent; runs before the pod is marked Ready.
+# -----------------------------------------------------------------------------
+hostAuth:
+  enabled: true
+  # Source range. "all" => any host (0.0.0.0/0 + ::/0). Set a pod/service CIDR
+  # to tighten (e.g. "10.0.0.0/8"). Auth still requires a valid password.
+  cidr: "all"
+  # scram-sha-256 (recommended) | md5 | password. Must match the server's
+  # password_encryption (PG14+ default is scram-sha-256).
+  method: "scram-sha-256"
+
+# -----------------------------------------------------------------------------
+# Persistence — PVC at /var/lib/autopg/data (PGDATA). The binary cache and
+# settings.json live elsewhere in the image / ConfigMap and are NOT on the PVC.
+# -----------------------------------------------------------------------------
+persistence:
+  enabled: true
+  size: 8Gi
+  # Empty => cluster default StorageClass (OrbStack provides one).
+  storageClass: ""
+  accessModes:
+    - ReadWriteOnce
+
+resources:
+  requests:
+    cpu: 250m
+    memory: 1Gi
+  limits:
+    memory: 4Gi
+
+# -----------------------------------------------------------------------------
+# Probes. pg_isready does not authenticate, so no password is needed. The
+# startupProbe is generous to cover first-boot initdb on a cold PVC.
+# -----------------------------------------------------------------------------
+probes:
+  startup:
+    periodSeconds: 5
+    failureThreshold: 60   # ~5 min for first-boot initdb
+  readiness:
+    periodSeconds: 10
+    failureThreshold: 6
+  liveness:
+    periodSeconds: 20
+    failureThreshold: 6
+
+# Time for a graceful postgres shutdown on pod termination.
+terminationGracePeriodSeconds: 90
+
+# Pod-level security context. fsGroup makes the PVC group-writable by the
+# autopg user (uid/gid 1000) so initdb can create PGDATA.
+podSecurityContext:
+  runAsUser: 1000
+  runAsGroup: 1000
+  runAsNonRoot: true
+  fsGroup: 1000
+
+# Provisioning Job knobs.
+provisionJob:
+  enabled: true
+  backoffLimit: 6
+  # Seconds the Job waits for the server to accept connections before giving up.
+  readyTimeoutSeconds: 300
+
+nodeSelector: {}
+tolerations: []
+affinity: {}
+podAnnotations: {}
+commonLabels: {}


### PR DESCRIPTION
## What

Adds **NEW** files under `deploy/` (no changes to existing autopg source) to run autopg (embedded PostgreSQL 18) on Kubernetes:

- `deploy/Dockerfile` — arm64, glibc, **offline-boot** self-contained image
- `deploy/helm/autopg/` — a reusable Helm chart
- `deploy/README.md` — chart interface + rationale

Built and verified end-to-end on OrbStack arm64 k8s.

## The critical gotcha (offline boot)

The compiled `autopg` binary resolves postgres/initdb from a per-platform cache under `$AUTOPG_CONFIG_DIR/bin/<platformKey>/`, and **downloads `@embedded-postgres` from npm on first boot** if absent (`src/postgres.js` `getBinaryPaths`/`isCachedValid`). The Dockerfile **pre-seeds that cache** from the release tarball's `postgres/` tree plus a `.version` marker (`18.3.0-beta.17`, matching `PINNED_PG_VERSION`). Proven offline with `docker run --network none` → `PostgreSQL 18.3 accepting connections`, zero npm fetch.

## Chart highlights

- **StatefulSet** (replicas=1) with PVC at `/var/lib/autopg/data`; PGDATA is the `pgdata/` **subdir** so the non-root user (uid 1000) owns it and initdb's `chmod 0700` succeeds under a k8s PVC (whose root is `root:fsGroup`).
- **Headless + ClusterIP** Services on 5432.
- **settings.json ConfigMap**: `listen_addresses='*'` via `postgres._extra`; operator GUC tuning as **curated top-level** `postgres.*` keys (autopg's curated defaults win over `_extra`).
- **postStart hook** appends a pod-network `pg_hba` rule + reloads — autopg's initdb writes a localhost-only `pg_hba.conf` and exposes no knob, so in-cluster peers would otherwise be rejected despite `listen_addresses='*'`.
- **Password Secret** stable across upgrades (helm `lookup`).
- **Provisioning Job** (post-install/upgrade, idempotent): creates a scoped `LOGIN` role that **OWNS** its database + `schema public` (so it can run migrations), and rotates the superuser password to the managed Secret. Default: db `omni`, role `omni`.

## Verification (OrbStack arm64)

- `docker build --platform linux/arm64` ✓
- Offline first boot (`--network none`) → PG 18.3 accepting connections, no npm ✓
- `helm install` → pod Ready; no npm fetch in pod logs ✓
- Provision Job green; `omni` db + `omni` role created ✓
- Peer pod connects as `omni` over the Service and runs CREATE/ALTER/INSERT/DROP; `tableowner = omni` ✓ (proves schema ownership + in-cluster peer auth)
- Superuser password rotated (managed pw works; default `postgres` rejected) ✓
- `helm upgrade` idempotent; passwords stable ✓

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Docker-based container image for running Autopg with a small runtime footprint.
  * Added a Helm chart for deploying Autopg on Kubernetes, including services, persistence, probes, and scheduling options.
  * Added automated provisioning for database users and databases during install and upgrade.
  * Added support for storing and reusing generated passwords across deployments.

* **Documentation**
  * Added deployment and usage guidance, plus post-install connection and verification notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->