### PR TITLE
fix(postmaster): honor AUTOPG_PG_PASSWORD for initdb and the admin pool

### DIFF
--- a/bin/postgres-server.js
+++ b/bin/postgres-server.js
@@ -16,6 +16,7 @@
  */
 
 import { PostgresManager } from '../src/postgres.js';
+import { resolvePostmasterPassword } from '../src/lib/postmaster-password.js';
 import { resolveSocketDir, ensureSocketDir } from '../src/lib/socket-dir.js';
 import { writeRuntimeJson, clearRuntimeJson } from '../src/lib/runtime-json.js';
 import { createLogger } from '../src/logger.js';
@@ -93,12 +94,23 @@ async function runPostmasterSubcommand(postmasterArgs) {
     process.exit(1);
   }
 
+  // Managed superuser password (AUTOPG_PG_PASSWORD / PGSERVE_PG_PASSWORD,
+  // default 'postgres'). PostgresManager feeds it to initdb's --pwfile on
+  // fresh clusters AND to its TCP admin pool — without this wire a rotated
+  // password crash-loops every postmaster restart (admin pool refused).
+  // Log the SOURCE only, never the value.
+  const { password, source: passwordSource } = resolvePostmasterPassword();
+  if (passwordSource !== 'default') {
+    logger.info({ source: passwordSource }, 'pgserve postmaster: using managed superuser password');
+  }
+
   const manager = new PostgresManager({
     dataDir: opts.dataDir,
     port: opts.port,
     socketDir,
     useRam: opts.useRam,
     enablePgvector: opts.enablePgvector,
+    password,
     logger: logger.child({ component: 'postgres' }),
   });
 
@@ -223,6 +235,11 @@ OPTIONS:
   --ram                 Use /dev/shm (Linux only)
   --pgvector            Auto-enable pgvector on new databases
   --help                Show this help
+
+ENVIRONMENT:
+  AUTOPG_PG_PASSWORD    Managed superuser password (initdb --pwfile on fresh
+                        clusters + the admin pool). PGSERVE_PG_PASSWORD is
+                        the legacy alias. Default: postgres.
 
 The postmaster binds <socket-dir>/.s.PGSQL.<port> and TCP <port> on
 localhost. This entry point is invoked by pm2/systemd-user/launchd; it has

--- a/src/lib/postmaster-password.js
+++ b/src/lib/postmaster-password.js
@@ -1,0 +1,40 @@
+/**
+ * Managed superuser password resolution for the postmaster entry.
+ *
+ * PostgresManager has always accepted `options.password` — it flows into
+ * initdb's `--pwfile` (fresh clusters) and the TCP admin pool — but the
+ * `postmaster` subcommand never wired it, silently pinning the built-in
+ * 'postgres' default. Supervisors that rotate the superuser password (the
+ * k8s Helm chart's provision Job, for example) then crash-loop the
+ * postmaster on every restart: the admin pool re-authenticates fresh at
+ * each boot and is refused (observed in the omni k8s node-restart
+ * incident, 2026-07-03).
+ *
+ * Resolution order mirrors settings-schema.cjs `server.pgPassword`:
+ *   AUTOPG_PG_PASSWORD > PGSERVE_PG_PASSWORD (legacy) > 'postgres'.
+ *
+ * Env is the right channel for supervised deployments (k8s secretKeyRef,
+ * pm2 env files) — settings.json is non-secret and stays password-free.
+ * Empty strings are treated as unset so `AUTOPG_PG_PASSWORD=` in a unit
+ * file cannot lock the pool out with a blank password.
+ */
+
+export const POSTMASTER_PASSWORD_ENV_VARS = ['AUTOPG_PG_PASSWORD', 'PGSERVE_PG_PASSWORD'];
+
+export const DEFAULT_POSTMASTER_PASSWORD = 'postgres';
+
+/**
+ * Resolve the superuser password the postmaster should hand to
+ * PostgresManager. Returns `{ password, source }` where `source` is the
+ * env var name that supplied it, or `'default'` — callers may log the
+ * SOURCE for operability, never the value.
+ */
+export function resolvePostmasterPassword(env = process.env) {
+  for (const name of POSTMASTER_PASSWORD_ENV_VARS) {
+    const value = env[name];
+    if (value !== undefined && value !== '') {
+      return { password: value, source: name };
+    }
+  }
+  return { password: DEFAULT_POSTMASTER_PASSWORD, source: 'default' };
+}

--- a/tests/lib/postmaster-password.test.js
+++ b/tests/lib/postmaster-password.test.js
@@ -1,0 +1,74 @@
+/**
+ * Managed superuser password resolution for the postmaster
+ * (src/lib/postmaster-password.js).
+ *
+ * Locks the contract that fixed the omni k8s node-restart incident
+ * (2026-07-03): PostgresManager always supported `options.password`
+ * (initdb --pwfile + the TCP admin pool), but the postmaster entry never
+ * wired it — so a supervisor-rotated superuser password crash-looped the
+ * postmaster on every restart. The resolver reads the documented env
+ * chain from settings-schema.cjs `server.pgPassword`.
+ */
+
+import { test, expect, describe } from 'bun:test';
+import { spawnSync } from 'node:child_process';
+import path from 'node:path';
+import {
+  resolvePostmasterPassword,
+  POSTMASTER_PASSWORD_ENV_VARS,
+  DEFAULT_POSTMASTER_PASSWORD,
+} from '../../src/lib/postmaster-password.js';
+
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+const POSTGRES_SERVER = path.join(REPO_ROOT, 'bin', 'postgres-server.js');
+
+describe('resolvePostmasterPassword', () => {
+  test('defaults to the built-in password with an empty environment', () => {
+    expect(resolvePostmasterPassword({})).toEqual({
+      password: DEFAULT_POSTMASTER_PASSWORD,
+      source: 'default',
+    });
+  });
+
+  test('AUTOPG_PG_PASSWORD supplies the managed password', () => {
+    expect(resolvePostmasterPassword({ AUTOPG_PG_PASSWORD: 's3cret' })).toEqual({
+      password: 's3cret',
+      source: 'AUTOPG_PG_PASSWORD',
+    });
+  });
+
+  test('PGSERVE_PG_PASSWORD is honored as the legacy alias', () => {
+    expect(resolvePostmasterPassword({ PGSERVE_PG_PASSWORD: 'legacy' })).toEqual({
+      password: 'legacy',
+      source: 'PGSERVE_PG_PASSWORD',
+    });
+  });
+
+  test('AUTOPG_PG_PASSWORD wins over the legacy alias (schema env order)', () => {
+    const env = { AUTOPG_PG_PASSWORD: 'new', PGSERVE_PG_PASSWORD: 'old' };
+    expect(resolvePostmasterPassword(env).password).toBe('new');
+  });
+
+  test('empty-string env vars are treated as unset (cannot blank the pool password)', () => {
+    const env = { AUTOPG_PG_PASSWORD: '', PGSERVE_PG_PASSWORD: '' };
+    expect(resolvePostmasterPassword(env)).toEqual({
+      password: DEFAULT_POSTMASTER_PASSWORD,
+      source: 'default',
+    });
+  });
+
+  test('env chain matches the settings-schema documented names', () => {
+    expect(POSTMASTER_PASSWORD_ENV_VARS).toEqual(['AUTOPG_PG_PASSWORD', 'PGSERVE_PG_PASSWORD']);
+  });
+});
+
+describe('postmaster --help documents the managed password env', () => {
+  test('help text advertises AUTOPG_PG_PASSWORD and the legacy alias', () => {
+    const result = spawnSync(process.execPath, [POSTGRES_SERVER, 'postmaster', '--help'], {
+      encoding: 'utf8',
+      timeout: 5000,
+    });
+    expect(result.stdout).toContain('AUTOPG_PG_PASSWORD');
+    expect(result.stdout).toContain('PGSERVE_PG_PASSWORD');
+  });
+});


### PR DESCRIPTION
## Postmaster ignores the managed superuser password

**The bug** (found debugging a k8s node-restart incident, 2026-07-03): `PostgresManager` has always accepted `options.password` — it flows into **initdb's `--pwfile`** on fresh clusters (`src/postgres.js:717-730`) and into the **TCP admin pool** (`:787`). But the `postmaster` subcommand never wires it: `parsePostmasterArgs` has no password surface and the constructor call passes none, so `this.password` silently pins to the built-in `'postgres'` (`src/postgres.js:542`).

**Impact:** any supervisor that rotates the superuser password (e.g. a k8s Helm provision job doing `ALTER USER postgres PASSWORD ...`) crash-loops the postmaster on every **restart** — the admin pool re-authenticates fresh at each boot and is refused:
```
Failed to initialize admin pool after 5 attempts: password authentication failed for user "postgres"
```
It works until the first restart, which makes it a latent production landmine. Note `cli-ui.cjs:366` already honors `server.pgPassword` — the postmaster was the odd one out.

**The fix:** a small resolver (`src/lib/postmaster-password.js`) wired into the postmaster entry, mirroring the `settings-schema.cjs server.pgPassword` env chain:

`AUTOPG_PG_PASSWORD` > `PGSERVE_PG_PASSWORD` (legacy) > `'postgres'`

- Empty strings treated as unset (an `AUTOPG_PG_PASSWORD=` in a unit file can't blank the pool password).
- The **source** (env var name) is logged for operability — never the value.
- `postmaster --help` documents the env.
- Env-only by design: settings.json is non-secret and stays password-free; k8s feeds it via `secretKeyRef`, pm2 via env files.

**Tests:** `tests/lib/postmaster-password.test.js` — 7 cases (default, both env vars, precedence, empty-string, schema-name lock, `--help` advertisement). Full suite: 701 pass / 1 pre-existing failure (`tests/console/smoke.test.js` — bundled console asset absent on a clean clone; fails identically on `dev` without this change). `eslint src/ bin/` clean.

**Downstream:** with this shipped, the k8s chart (#141) can restore superuser-password rotation by setting `AUTOPG_PG_PASSWORD` from its Secret — rotation was removed there as a workaround for this exact bug.
